### PR TITLE
Restrict command-line tool to macOS platforms

### DIFF
--- a/CommandLineTool/main.swift
+++ b/CommandLineTool/main.swift
@@ -1,28 +1,30 @@
-import ArgumentParser
-import Foundation
-import SourceControl
-import SwiftAtprotoLex
+#if os(macOS)
+    import ArgumentParser
+    import Foundation
+    import SourceControl
+    import SwiftAtprotoLex
 
-struct Lexgen: ParsableCommand {
-    private static let defaultModulePath = "Sources/Lexicon"
-    static var configuration: CommandConfiguration {
-        CommandConfiguration(commandName: "swift-atproto", version: SourceControl.version)
+    struct Lexgen: ParsableCommand {
+        private static let defaultModulePath = "Sources/Lexicon"
+        static var configuration: CommandConfiguration {
+            CommandConfiguration(commandName: "swift-atproto", version: SourceControl.version)
+        }
+
+        @Option(name: .customLong("atproto-configuration"))
+        var configuration: String
+        @Option(name: .long)
+        var outdir: String?
+
+        mutating func run() throws {
+            let configurationtURL = URL(filePath: configuration)
+            let data = try Data(contentsOf: configurationtURL)
+            let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
+            let module = outdir ?? config.module ?? Self.defaultModulePath
+            let rootURL = configurationtURL.deletingLastPathComponent()
+            try SourceControl.main(rootURL: rootURL, config: config, module: module)
+            try SwiftAtprotoLex.main(outdir: module, path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path())
+        }
     }
 
-    @Option(name: .customLong("atproto-configuration"))
-    var configuration: String
-    @Option(name: .long)
-    var outdir: String?
-
-    mutating func run() throws {
-        let configurationtURL = URL(filePath: configuration)
-        let data = try Data(contentsOf: configurationtURL)
-        let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
-        let module = outdir ?? config.module ?? Self.defaultModulePath
-        let rootURL = configurationtURL.deletingLastPathComponent()
-        try SourceControl.main(rootURL: rootURL, config: config, module: module)
-        try SwiftAtprotoLex.main(outdir: module, path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path())
-    }
-}
-
-Lexgen.main()
+    Lexgen.main()
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
             name: "swift-atproto",
             dependencies: [
                 "SwiftAtprotoLex",
-                "SourceControl",
+                .target(name: "SourceControl", condition: .when(platforms: [.macOS])),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
             ],
             path: "CommandLineTool"


### PR DESCRIPTION
### Summary

This PR refactors the command-line tool to be exclusively compiled on macOS.

The command-line tool relies on dependencies like `ArgumentParser` and `SourceControl`, which are intended for use on macOS. This change prevents compilation failures on other platforms (e.g., Linux) where these dependencies are not supported or relevant for the main library's functionality.

### Changes Made

-   Wrapped the `CommandLineTool/main.swift` file with an `#if os(macOS)` conditional compilation block.
-   Added a `condition` to the `SourceControl` dependency in `Package.swift` to only link it on macOS.