### PR TITLE
Support specifying revision in Lexicon dependencies

### DIFF
--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -92,6 +92,16 @@ public final class GitRepository {
         }
     }
 
+    public func checkout(revision: String) throws {
+        try lock.withLock {
+            _ = try callGit([
+                "checkout",
+                "-f",
+                revision,
+            ])
+        }
+    }
+
     func isBare() throws -> Bool {
         try lock.withLock {
             let output = try callGit([
@@ -107,8 +117,15 @@ public final class GitRepository {
     }
 
     public func resolveRevision(tag: String) throws -> String {
-        let specifier = "\(tag)^{commit}"
-        return try lock.withLock {
+        try resolveHash(specifier: "\(tag)^{commit}")
+    }
+
+    public func resolveRevision(identifier: String) throws -> String {
+        try resolveHash(specifier: "\(identifier)^{commit}")
+    }
+
+    func resolveHash(specifier: String) throws -> String {
+        try lock.withLock {
             let output = try callGit([
                 "rev-parse",
                 "--verify",

--- a/Sources/SourceControl/LexiconConfig.swift
+++ b/Sources/SourceControl/LexiconConfig.swift
@@ -11,8 +11,46 @@ public struct LexiconDependency: Codable, Sendable {
         public let path: String
     }
 
-    public struct SourceState: Codable, Sendable {
-        public let tag: String
+    public enum SourceState: Codable, Sendable {
+        case tag(String)
+        case revision(String)
+
+        enum CodingKeys: String, CodingKey {
+            case tag
+            case revision
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            guard container.allKeys.count == 1 else {
+                throw DecodingError.dataCorrupted(DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Exactly one of 'tag' or 'revision' must be specified"))
+            }
+            switch container.allKeys[0] {
+            case .tag:
+                self = try .tag(container.decode(String.self, forKey: .tag))
+            case .revision:
+                self = try .revision(container.decode(String.self, forKey: .revision))
+            }
+        }
+
+        public func encode(to encoder: any Encoder) throws {
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case let .tag(value):
+                try container.encode(value, forKey: .tag)
+            case let .revision(value):
+                try container.encode(value, forKey: .revision)
+            }
+        }
+
+        public var tag: String? {
+            switch self {
+            case let .tag(tag):
+                tag
+            case .revision:
+                nil
+            }
+        }
     }
 
     public let location: URL

--- a/Sources/SourceControl/LexiconsStore.swift
+++ b/Sources/SourceControl/LexiconsStore.swift
@@ -21,7 +21,7 @@ public struct ResolvedLexiconDependency: Codable {
 
     public struct SourceState: Codable {
         public let tag: String
-        public let revison: String
+        public let revision: String
     }
 
     public let location: URL
@@ -31,6 +31,6 @@ public struct ResolvedLexiconDependency: Codable {
     public init(config: LexiconDependency, revision: String) {
         location = config.location
         lexicons = config.lexicons
-        state = SourceState(tag: config.state.tag, revison: revision)
+        state = SourceState(tag: config.state.tag, revision: revision)
     }
 }

--- a/Sources/SourceControl/LexiconsStore.swift
+++ b/Sources/SourceControl/LexiconsStore.swift
@@ -20,7 +20,7 @@ public struct ResolvedLexiconDependency: Codable {
     }
 
     public struct SourceState: Codable {
-        public let tag: String
+        public let tag: String?
         public let revision: String
     }
 

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -45,9 +45,15 @@ public func main(rootURL: URL, config: LexiconConfig, module: String) throws {
         if !GitRepositoryProvider.workingCopyExists(at: destURL.path()) {
             let clone = try GitRepositoryProvider.createWorkingCopy(sourcePath: dependency.location.absoluteString,
                                                                     at: destURL.path())
-            let tag = dependency.state.tag
-            try clone.checkout(tag: tag)
-            let revision = try clone.resolveRevision(tag: tag)
+            let revision: String
+            switch dependency.state {
+            case let .tag(tag):
+                try clone.checkout(tag: tag)
+                revision = try clone.resolveRevision(tag: tag)
+            case let .revision(identifier):
+                revision = try clone.resolveRevision(identifier: identifier)
+                try clone.checkout(revision: revision)
+            }
             resolvedDendencies.append(.init(config: dependency, revision: revision))
         }
         for lexicon in dependency.lexicons {


### PR DESCRIPTION
This PR allows Lexicon dependencies to be specified by revision (commit hash) in addition to tags. 

Previously, only Git tags could be used to reference Lexicons, but with this change, users can specify exact revisions, providing more flexibility in dependency management.

Changes include:
- Added `checkout(revision:)` and `resolveRevision(identifier:)` in GitRepository.
- Updated `LexiconConfig.SourceState` to support both tag and revision.
- Updated `ResolvedLexiconDependency.SourceState` to store optional tags and required revisions.
- Fixed a typo in `ResolvedLexiconDependency.SourceState` (`revison` → `revision`).