### PR TITLE
Fix: Generate correct RawRepresentable initializer

### DIFF
--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -2395,7 +2395,7 @@ struct StringFormat: Codable, RawRepresentable {
     typealias RawValue = String
     let rawValue: String
 
-    init?(rawValue: String) {
+    init(rawValue: String) {
         self.rawValue = rawValue
     }
 

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -1202,7 +1202,6 @@ class TypeSchema: Codable {
                     DeclModifierSyntax(name: .keyword(.public)),
                 ]),
                 initKeyword: .keyword(.`init`),
-                optionalMark: .postfixQuestionMarkToken(),
                 signature: FunctionSignatureSyntax(parameterClause: FunctionParameterClauseSyntax(
                     leftParen: .leftParenToken(),
                     parameters: FunctionParameterListSyntax([
@@ -1313,20 +1312,17 @@ class TypeSchema: Codable {
                         CodeBlockItemSyntax(item: CodeBlockItemSyntax.Item(SequenceExprSyntax(elements: ExprListSyntax([
                             ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self))),
                             ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
-                            ExprSyntax(ForceUnwrapExprSyntax(
-                                expression: FunctionCallExprSyntax(
-                                    calledExpression: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.Self))),
-                                    leftParen: .leftParenToken(),
-                                    arguments: LabeledExprListSyntax([
-                                        LabeledExprSyntax(
-                                            label: .identifier("rawValue"),
-                                            colon: .colonToken(),
-                                            expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("rawValue")))
-                                        ),
-                                    ]),
-                                    rightParen: .rightParenToken()
-                                ),
-                                exclamationMark: .exclamationMarkToken()
+                            ExprSyntax(FunctionCallExprSyntax(
+                                calledExpression: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.Self))),
+                                leftParen: .leftParenToken(),
+                                arguments: LabeledExprListSyntax([
+                                    LabeledExprSyntax(
+                                        label: .identifier("rawValue"),
+                                        colon: .colonToken(),
+                                        expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("rawValue")))
+                                    ),
+                                ]),
+                                rightParen: .rightParenToken()
                             )),
                         ])))),
                     ]),


### PR DESCRIPTION
This pull request addresses an issue with the generated code for `RawRepresentable` conformance. Previously, the code generated a failable `init?(rawValue:)` and then force-unwrapped the result.

This PR makes two key changes:
1.  **Code Generation:** The `init?(rawValue:)` is no longer generated with a question mark, correctly producing a non-failable `init(rawValue:)`.
2.  **Explicit Implementation:** The generated code now includes an explicit, non-failable `init(rawValue:)` implementation, as required by the `RawRepresentable` protocol.