### PR TITLE
Fix Codable retroactive conformance and resolve test concurrency warning

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,6 +76,7 @@ let package = Package(
             dependencies: [
                 "Macros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
+                .product(name: "SwiftSyntax", package: "swift-syntax"),
             ]
         ),
         .plugin(name: "Generate Source Code",

--- a/Sources/SwiftAtproto/SwiftAtproto.swift
+++ b/Sources/SwiftAtproto/SwiftAtproto.swift
@@ -138,7 +138,7 @@ extension String {
 public typealias LexLink = CID
 extension CID: @unchecked @retroactive Sendable {}
 
-extension LexLink: Codable {
+extension LexLink: @retroactive Codable {
     static func dataEncodingStrategy(data: Data, encoder: any Encoder) throws {
         let cid = try CID(data[1...])
         var container = encoder.container(keyedBy: LexLink.CodingKeys.self)

--- a/Tests/MacrosTests/MacrosTests.swift
+++ b/Tests/MacrosTests/MacrosTests.swift
@@ -12,12 +12,12 @@ import SwiftSyntaxMacrosTestSupport
 import XCTest
 @testable import Macros
 
-let testMacros: [String: Macro.Type] = [
-    "XRPCClientMacro": XRPCClientMacro.self,
-]
-
 final class MacroExampleTests: XCTestCase {
     func testXRPCClientMacro() throws {
+        let testMacros: [String: Macro.Type] = [
+            "XRPCClientMacro": XRPCClientMacro.self,
+        ]
+
         assertMacroExpansion(
             """
             @XRPCClientMacro


### PR DESCRIPTION
This PR addresses two issues:

- **Codable conformance**
  - Marks `LexLink`'s `Codable` conformance as `@retroactive` to properly indicate its retroactive nature.

- **Test warning**
  - Adds `SwiftSyntax` as a test dependency.
  - Moves the `testMacros` definition inside the test method to resolve the warning:
    ```
    Let 'testMacros' is not concurrency-safe because non-'Sendable' type '[String : any Macro.Type]' may have shared mutable state
    ```