### PR TITLE
Chore: Bump swift-syntax version to 602.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "395ea43c764a0163fa0a80beef178baab4aa403b61f509d1cc871b1c96eeb631",
+  "originHash" : "cccef21e9838dd640dd298604a495093f93ad4df9fcf3d61d0b5c74a14a820fd",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -186,8 +186,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
-        "version" : "601.0.1"
+        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
+        "version" : "602.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/swift-libp2p/swift-cid", exact: "0.0.1"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "601.0.1"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "602.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.3.1"),
         .package(url: "https://github.com/nicklockwood/SwiftFormat", exact: "0.55.5"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),


### PR DESCRIPTION
This PR updates the `swift-syntax` dependency from version **601.0.1** to **602.0.0**. 
