### PR TITLE
Allow custom moduleName prefix for record type resolution in XRPCClientProtocol

### DIFF
--- a/Sources/SwiftAtproto/XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/XRPCClientProtocol.swift
@@ -32,6 +32,7 @@ public protocol XRPCClientProtocol: ATPClientProtocol, Sendable {
 
     mutating func signout()
 
+    static var moduleName: String { get }
     static func setModuleName()
 }
 
@@ -93,9 +94,10 @@ public protocol XRPCClientProtocol: ATPClientProtocol, Sendable {
 
 public extension XRPCClientProtocol {
     static var errorDomain: String { "XRPCErrorDomain" }
+    static var moduleName: String { _typeName(type(of: self)).split(separator: ".").first.flatMap { String($0) } ?? "" }
 
     static func setModuleName() {
-        LexiconTypesMap.shared.moduleName = _typeName(type(of: self)).split(separator: ".").first.flatMap { String($0) } ?? ""
+        LexiconTypesMap.shared.moduleName = moduleName
     }
 }
 


### PR DESCRIPTION
This PR introduces a `static var moduleName: String { get }` requirement on `XRPCClientProtocol`, and changes `setModuleName()` to use that property. With this change, library users can adjust the module name prefix used when resolving record types (instead of being forced to use the inferred module name).