### PR TITLE
Improve JSON file decoding by using Data(contentsOf:) directly

### DIFF
--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -13,8 +13,8 @@ public func main(outdir: String, path: String) throws {
                 let fileAttributes = try fileUrl.resourceValues(forKeys: [.isRegularFileKey])
                 if fileAttributes.isRegularFile!, fileUrl.pathExtension == "json" {
                     prefixes.insert(fileUrl.prefix(baseURL: url))
-                    let json = try String(contentsOf: fileUrl, encoding: .utf8)
-                    try schemas.append(decoder.decode(Schema.self, from: Data(json.utf8)))
+                    let data = try Data(contentsOf: fileUrl)
+                    try schemas.append(decoder.decode(Schema.self, from: data))
                 }
             } catch {
                 print(error, fileUrl)


### PR DESCRIPTION
This change simplifies how JSON schema files are loaded and decoded within `SwiftAtprotoLex`. Previously, JSON files were read as UTF-8 Strings, then converted back to Data for decoding. 