### PR TITLE
Limit Macro Tests to macOS to Fix Build Errors on Other Platforms

### DIFF
--- a/Tests/MacrosTests/MacrosTests.swift
+++ b/Tests/MacrosTests/MacrosTests.swift
@@ -5,6 +5,7 @@
 //  Created by Noriaki Watanabe on 2024/12/23.
 //
 
+#if os(macOS)
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
@@ -55,3 +56,4 @@ final class MacroExampleTests: XCTestCase {
         )
     }
 }
+#endif


### PR DESCRIPTION
This project’s Swift Macro unit tests depend on APIs from SwiftSyntax, SwiftSyntaxBuilder, and SwiftSyntaxMacros, which currently require a macOS host environment to build and link successfully. On non-macOS platforms (for example, Linux), these dependencies cause build errors when running the test suite.

This PR wraps the affected test code in a conditional compilation block so that the macro tests are only compiled and run on macOS.