### PR TITLE
Limit Macro Tests to macOS to Fix Build Errors on Other Platforms

### DIFF
--- a/Tests/MacrosTests/MacrosTests.swift
+++ b/Tests/MacrosTests/MacrosTests.swift
@@ -5,53 +5,55 @@
 //  Created by Noriaki Watanabe on 2024/12/23.
 //
 
-import SwiftSyntax
-import SwiftSyntaxBuilder
-import SwiftSyntaxMacros
-import SwiftSyntaxMacrosTestSupport
-import XCTest
-@testable import Macros
+#if os(macOS)
+    import SwiftSyntax
+    import SwiftSyntaxBuilder
+    import SwiftSyntaxMacros
+    import SwiftSyntaxMacrosTestSupport
+    import XCTest
+    @testable import Macros
 
-final class MacroExampleTests: XCTestCase {
-    func testXRPCClientMacro() throws {
-        let testMacros: [String: Macro.Type] = [
-            "XRPCClientMacro": XRPCClientMacro.self,
-        ]
+    final class MacroExampleTests: XCTestCase {
+        func testXRPCClientMacro() throws {
+            let testMacros: [String: Macro.Type] = [
+                "XRPCClientMacro": XRPCClientMacro.self,
+            ]
 
-        assertMacroExpansion(
-            """
-            @XRPCClientMacro
-            public struct TestClient {
-              let host: URL
-              public var auth: AuthInfo
-              public var serviceEndpoint: URL {
-                auth.serviceEndPoint ?? host
-              }
-              public let decoder: JSONDecoder
-            }
-            """,
-            expandedSource: """
-            public struct TestClient {
-              let host: URL
-              public var auth: AuthInfo
-              public var serviceEndpoint: URL {
-                auth.serviceEndPoint ?? host
-              }
-              public let decoder: JSONDecoder
+            assertMacroExpansion(
+                """
+                @XRPCClientMacro
+                public struct TestClient {
+                  let host: URL
+                  public var auth: AuthInfo
+                  public var serviceEndpoint: URL {
+                    auth.serviceEndPoint ?? host
+                  }
+                  public let decoder: JSONDecoder
+                }
+                """,
+                expandedSource: """
+                public struct TestClient {
+                  let host: URL
+                  public var auth: AuthInfo
+                  public var serviceEndpoint: URL {
+                    auth.serviceEndPoint ?? host
+                  }
+                  public let decoder: JSONDecoder
 
-              private init(host: URL, auth: AuthInfo) {
-                self.host = host
-                self.auth = auth
-                decoder = JSONDecoder()
-                Self.setModuleName()
-              }
-            }
+                  private init(host: URL, auth: AuthInfo) {
+                    self.host = host
+                    self.auth = auth
+                    decoder = JSONDecoder()
+                    Self.setModuleName()
+                  }
+                }
 
-            extension TestClient: XRPCClientProtocol {
-            }
-            """,
-            macros: testMacros,
-            indentationWidth: .spaces(2)
-        )
+                extension TestClient: XRPCClientProtocol {
+                }
+                """,
+                macros: testMacros,
+                indentationWidth: .spaces(2)
+            )
+        }
     }
-}
+#endif


### PR DESCRIPTION
This project’s Swift Macro unit tests depend on APIs from SwiftSyntax, SwiftSyntaxBuilder, and SwiftSyntaxMacros, which currently require a macOS host environment to build and link successfully. On non-macOS platforms (for example, Linux), these dependencies cause build errors when running the test suite.

This PR wraps the affected test code in a conditional compilation block so that the macro tests are only compiled and run on macOS.