### PR TITLE
Enable Swift Macro sources and tests on Linux

### DIFF
--- a/Sources/Macros/Macros.swift
+++ b/Sources/Macros/Macros.swift
@@ -5,7 +5,7 @@
 //  Created by Noriaki Watanabe on 2024/12/23.
 //
 
-#if os(macOS)
+#if os(macOS) || os(Linux)
   import SwiftCompilerPlugin
   import SwiftDiagnostics
   import SwiftSyntax

--- a/Tests/MacrosTests/MacrosTests.swift
+++ b/Tests/MacrosTests/MacrosTests.swift
@@ -5,7 +5,7 @@
 //  Created by Noriaki Watanabe on 2024/12/23.
 //
 
-#if os(macOS)
+#if os(macOS) || os(Linux)
   import SwiftSyntax
   import SwiftSyntaxBuilder
   import SwiftSyntaxMacros


### PR DESCRIPTION
This change updates the platform guards for Swift Macro sources and their unit tests to include Linux in addition to macOS.