### PR TITLE
Show usage with a clear message on Linux for lexgen

### DIFF
--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -27,6 +27,9 @@
         let rootURL = configurationtURL.deletingLastPathComponent()
         try SourceControl.main(rootURL: rootURL, config: config, module: module)
         try SwiftAtprotoLex.main(outdir: module, path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path())
+      #else
+        print("swift-atproto lexgen is not supported on Linux yet.\n")
+        print(Self.helpMessage())
       #endif
     }
   }


### PR DESCRIPTION
Print a not-supported message followed by the help output when running lexgen on Linux, where the implementation is not available yet.