### PR TITLE
Fix object type handling in typeNameForField

### DIFF
--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -681,7 +681,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
         return "\(name)_\(k.titleCased())"
       }
     default:
-      fatalError()
+      fatalError("field \(k) in \(name) has unsupported type name (\(v.type))")
     }
   }
 

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -674,7 +674,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
       let ts = TypeSchema(id: v.id, prefix: v.prefix, defName: "Elem", type: def.items)
       let subt = Self.typeNameForField(name: "\(name)_\(k.titleCased())", k: "Elem", v: ts, defMap: defMap, dropPrefix: dropPrefix)
       return "[\(subt)]"
-    case .union:
+    case .union, .object:
       if !dropPrefix {
         return "\(Lex.structNameFor(prefix: v.prefix)).\(name)_\(k.titleCased())"
       } else {


### PR DESCRIPTION
This PR fixes an issue in the `typeNameForField` function where the `object` schema type was not being handled.