### PR TITLE
Fix identifier handling: camelCase fallback and Swift keyword escaping

### DIFF
--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -277,6 +277,10 @@ extension String {
     let rest = words.dropFirst().map(\.capitalized)
     return ([first] + rest).joined()
   }
+
+  var escapedSwiftKeyword: String {
+    isNeedEscapingKeyword(self) ? "`\(self)`" : self
+  }
 }
 
 extension Substring {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -272,6 +272,7 @@ extension String {
   func camelCased() -> String {
     guard !isEmpty else { return "" }
     let words = components(separatedBy: CharacterSet.alphanumerics.inverted).filter { !$0.isEmpty }
+    if words.isEmpty { return self }
     let first = words.first!.lowercased()
     let rest = words.dropFirst().map(\.capitalized)
     return ([first] + rest).joined()

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -1725,7 +1725,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
                   declName: DeclReferenceExprSyntax(baseName: .identifier(key))
                 )),
               ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
-              ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(key))),
+              ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(key.escapedSwiftKeyword))),
             ]))
         }
         SequenceExprSyntax(
@@ -1765,7 +1765,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
             ]))
         }
         for key in def.properties.keys.sorted() {
-          EnumCaseDeclSyntax(elements: EnumCaseElementListSyntax([EnumCaseElementSyntax(name: .init(stringLiteral: key))]))
+          EnumCaseDeclSyntax(elements: EnumCaseElementListSyntax([EnumCaseElementSyntax(name: .init(stringLiteral: key.escapedSwiftKeyword))]))
         }
       }
 
@@ -2893,7 +2893,7 @@ enum FieldTypeDefinition: Encodable, DecodableWithConfiguration, Sendable {
       bindingSpecifier: .keyword(isMutable ? .var : .let)
     ) {
       PatternBindingSyntax(
-        pattern: PatternSyntax(stringLiteral: name),
+        pattern: PatternSyntax(stringLiteral: name.escapedSwiftKeyword),
         typeAnnotation: TypeAnnotationSyntax(
           type: type
         )


### PR DESCRIPTION
This PR improves identifier handling in code generation.

- Return original string when camelCased() has no words
- Escape Swift keywords for valid identifiers