### PR TITLE
Allow Lexgen executable to compile on iOS by guarding platform-specific code

### DIFF
--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -1,36 +1,39 @@
+import ArgumentParser
+import Foundation
+
 #if os(macOS) || os(Linux)
-  import ArgumentParser
-  import Foundation
   import SourceControl
   import SwiftAtprotoLex
+#endif
 
-  @main
-  struct Lexgen: AsyncParsableCommand {
+@main
+struct Lexgen: AsyncParsableCommand {
+  #if os(macOS) || os(Linux)
     static var configuration: CommandConfiguration {
       CommandConfiguration(commandName: "swift-atproto", version: SourceControl.version)
     }
+  #endif
+  #if os(macOS)
+    private static let defaultModulePath = "Sources/Lexicon"
+
+    @Option(name: .customLong("atproto-configuration"))
+    var configuration: String
+    @Option(name: .long)
+    var outdir: String?
+  #endif
+
+  mutating func run() async throws {
     #if os(macOS)
-      private static let defaultModulePath = "Sources/Lexicon"
-
-      @Option(name: .customLong("atproto-configuration"))
-      var configuration: String
-      @Option(name: .long)
-      var outdir: String?
+      let configurationtURL = URL(filePath: configuration)
+      let data = try Data(contentsOf: configurationtURL)
+      let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
+      let module = outdir ?? config.module ?? Self.defaultModulePath
+      let rootURL = configurationtURL.deletingLastPathComponent()
+      try SourceControl.main(rootURL: rootURL, config: config, module: module)
+      try await SwiftAtprotoLex.main(outdir: module, path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path())
+    #elseif os(Linux)
+      print("swift-atproto lexgen is not supported on Linux yet.\n")
+      print(Self.helpMessage())
     #endif
-
-    mutating func run() async throws {
-      #if os(macOS)
-        let configurationtURL = URL(filePath: configuration)
-        let data = try Data(contentsOf: configurationtURL)
-        let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
-        let module = outdir ?? config.module ?? Self.defaultModulePath
-        let rootURL = configurationtURL.deletingLastPathComponent()
-        try SourceControl.main(rootURL: rootURL, config: config, module: module)
-        try await SwiftAtprotoLex.main(outdir: module, path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path())
-      #else
-        print("swift-atproto lexgen is not supported on Linux yet.\n")
-        print(Self.helpMessage())
-      #endif
-    }
   }
-#endif
+}

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 
 let package = Package(
   name: "SwiftAtproto",
-  platforms: [.macOS(.v14), .iOS(.v16)],
+  platforms: [.macOS(.v14), .iOS(.v17)],
   products: [
     .library(
       name: "SwiftAtproto",


### PR DESCRIPTION
This change makes it possible to run unit tests for the Lexgen executable in Xcode on iOS.
Since Xcode always attempts to build executableTargets for iOS and they can’t be disabled per platform, platform-specific code has been isolated with conditional compilation.
The iOS deployment target is also updated to meet toolchain requirements.