### PR TITLE
feat: implement server-side code generation for XRPC

### DIFF
--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -30,7 +30,11 @@ struct Lexgen: AsyncParsableCommand {
       let module = outdir ?? config.module ?? Self.defaultModulePath
       let rootURL = configurationtURL.deletingLastPathComponent()
       try SourceControl.main(rootURL: rootURL, config: config, module: module)
-      try await SwiftAtprotoLex.main(outdir: module, path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path())
+      try await SwiftAtprotoLex.main(
+        outdir: module,
+        path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path(),
+        generate: config.generate
+      )
     #elseif os(Linux)
       print("swift-atproto lexgen is not supported on Linux yet.\n")
       print(Self.helpMessage())

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
       dependencies: [
         .product(name: "SwiftSyntax", package: "swift-syntax"),
         .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .target(name: "SourceControl", condition: .when(platforms: [.macOS, .linux])),
       ]
     ),
     .target(

--- a/Sources/SourceControl/LexiconConfig.swift
+++ b/Sources/SourceControl/LexiconConfig.swift
@@ -1,8 +1,65 @@
 import Foundation
 
+public struct GenerateOption: OptionSet, Codable, Sendable {
+  public let rawValue: UInt8
+
+  public init(rawValue: UInt8) {
+    self.rawValue = rawValue
+  }
+
+  public init(from decoder: any Decoder) throws {
+    var options: GenerateOption = []
+    let names: [String]
+    do {
+      names = try [String](from: decoder)
+    } catch DecodingError.typeMismatch {
+      names = try [String(from: decoder)]
+    }
+    for name in names {
+      switch name {
+      case "client":
+        options.insert(.client)
+      case "server":
+        options.insert(.server)
+      default:
+        throw DecodingError.dataCorrupted(.init(codingPath: [], debugDescription: "Unknown generate option: \(name)"))
+      }
+    }
+    self = options
+  }
+
+  public func encode(to encoder: any Encoder) throws {
+    switch self {
+    case .client:
+      try "client".encode(to: encoder)
+    case .server:
+      try "server".encode(to: encoder)
+    default:
+      throw EncodingError.invalidValue("\(self)", EncodingError.Context(codingPath: [], debugDescription: "Unhandled generate option"))
+    }
+  }
+
+  public static let client = Self(rawValue: 1 << 0)
+  public static let server = Self(rawValue: 1 << 1)
+}
+
 public struct LexiconConfig: Codable, Sendable {
   public let dependencies: [LexiconDependency]
   public let module: String?
+  public let generate: GenerateOption
+
+  enum CodingKeys: String, CodingKey {
+    case dependencies
+    case module
+    case generate
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    dependencies = try container.decode([LexiconDependency].self, forKey: .dependencies)
+    module = try container.decodeIfPresent(String.self, forKey: .module)
+    generate = try container.decodeIfPresent(GenerateOption.self, forKey: .generate) ?? .client
+  }
 }
 
 public struct LexiconDependency: Codable, Sendable {

--- a/Sources/SwiftAtprotoLex/Definitions/ArrayTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ArrayTypeDefinition.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftSyntax
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 final class ArrayTypeDefinition: Encodable, DecodableWithConfiguration, Sendable, SwiftCodeGeneratable {
   var type: FieldType { .array }
 
@@ -34,7 +38,10 @@ final class ArrayTypeDefinition: Encodable, DecodableWithConfiguration, Sendable
     try container.encodeIfPresent(minLength, forKey: .minLength)
   }
 
-  func generateDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name: String, type typeName: String, defMap: ExtDefMap) -> any DeclSyntaxProtocol {
+  func generateDeclaration(
+    leadingTrivia: Trivia?, ts: TypeSchema, name: String, type typeName: String,
+    defMap: ExtDefMap, generate: GenerateOption
+  ) -> any DeclSyntaxProtocol {
     let key = "elem"
     let ts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: key, type: items)
     let tname = TypeSchema.typeNameForField(name: name, k: key, v: ts, defMap: defMap)

--- a/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftSyntax
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 protocol HTTPAPITypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGeneratable {
   associatedtype DecodingConfiguration = TypeSchema.DecodingConfiguration
   var type: FieldType { get }
@@ -163,7 +167,7 @@ extension HTTPAPITypeDefinition {
     }
   }
 
-  func generateDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name typeName: String, type: String, defMap _: ExtDefMap) -> any DeclSyntaxProtocol {
+  func generateDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name typeName: String, type: String, defMap _: ExtDefMap, generate: GenerateOption) -> any DeclSyntaxProtocol {
     return EnumDeclSyntax(
       modifiers: [
         DeclModifierSyntax(name: .keyword(.public))

--- a/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
@@ -1,181 +1,23 @@
 import Foundation
 import SwiftSyntax
 
-#if os(macOS) || os(Linux)
-  import SourceControl
-#endif
-
 protocol HTTPAPITypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGeneratable {
   associatedtype DecodingConfiguration = TypeSchema.DecodingConfiguration
   var type: FieldType { get }
-  var parameters: Parameters? { get }
   var output: OutputType? { get }
-  var input: InputType? { get }
   var description: String? { get }
   var errors: [ErrorResponse]? { get }
-
   var contentType: String { get }
   var inputRPCValue: ExprSyntax { get }
   func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax]
-  func rpcOutput(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> ReturnClauseSyntax
+  func rpcOutput(fname: String, defMap: ExtDefMap, prefix: String) -> ReturnClauseSyntax
   func rpcParams(id: String, prefix: String) -> ExprSyntaxProtocol
-}
-
-private enum HTTPAPITypedCodingKeys: String, CodingKey {
-  case type
-  case parameters
-  case output
-  case input
-  case description
+  func makeErrorDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name typeName: String, type: String) -> any DeclSyntaxProtocol
 }
 
 extension HTTPAPITypeDefinition {
-  func encode(to encoder: Encoder) throws {
-    var container = encoder.container(keyedBy: HTTPAPITypedCodingKeys.self)
-    try container.encode(type, forKey: .type)
-    try container.encodeIfPresent(parameters, forKey: .parameters)
-    try container.encodeIfPresent(output, forKey: .output)
-    try container.encodeIfPresent(input, forKey: .input)
-    try container.encodeIfPresent(description, forKey: .description)
-  }
-
-  var contentType: String {
-    if let input {
-      switch input.encoding {
-      case .json, .jsonl, .text, .mp4:
-        return input.encoding.rawValue
-      case .cbor, .any, .car:
-        return "*/*"
-      }
-    }
-    return "*/*"
-  }
-
-  var inputRPCValue: ExprSyntax {
-    ExprSyntax(stringLiteral: input != nil ? "input" : "Bool?.none")
-  }
-
-  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax] {
-    var arguments = [FunctionParameterSyntax]()
-    if let input {
-      switch input.encoding {
-      case .cbor, .any, .car, .mp4:
-        let tname = "Data"
-        let comma: TokenSyntax? = (parameters == nil || (parameters?.properties.isEmpty ?? false)) ? nil : .commaToken()
-        arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname), trailingComma: comma))
-      case .text:
-        let tname = "String"
-        let comma: TokenSyntax? = (parameters == nil || (parameters?.properties.isEmpty ?? false)) ? nil : .commaToken()
-        arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname), trailingComma: comma))
-      case .json, .jsonl:
-        let tname: String
-        if case .ref(let ref) = input.schema?.type {
-          (_, tname) = ts.namesFromRef(ref: ref.ref, defMap: defMap)
-        } else {
-          tname = "\(fname)_Input"
-        }
-        let comma: TokenSyntax? = (parameters == nil || (parameters?.properties.isEmpty ?? false)) ? nil : .commaToken()
-        arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: "\(prefix).\(tname)"), trailingComma: comma))
-      }
-    }
-
-    if let parameters {
-      var required = [String: Bool]()
-      for req in parameters.required ?? [] {
-        required[req] = true
-      }
-      let count = parameters.properties.count
-      var i = 0
-      for (name, t) in parameters.sortedProperties {
-        i += 1
-        let isRequired = required[name] ?? false
-        let tn: String
-        if case .string(let def) = t, def.enum != nil || def.knownValues != nil {
-          tn = "\(prefix).\(fname)_\(name.titleCased())"
-        } else {
-          let ts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: name, type: t)
-          tn = TypeSchema.typeNameForField(name: name, k: "", v: ts, defMap: defMap, dropPrefix: false)
-        }
-        let type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(tn)))
-        let comma: TokenSyntax? = i == count ? nil : .commaToken()
-        let defaultValue: InitializerClauseSyntax? =
-          isRequired
-          ? nil
-          : InitializerClauseSyntax(
-            equal: .equalToken(),
-            value: NilLiteralExprSyntax()
-          )
-        arguments.append(
-          .init(
-            firstName: .identifier(name),
-            type: isRequired
-              ? type
-              : TypeSyntax(OptionalTypeSyntax(wrappedType: type)), defaultValue: defaultValue, trailingComma: comma))
-      }
-    }
-    return arguments
-  }
-
-  func rpcOutput(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> ReturnClauseSyntax {
-    if let output {
-      switch output.encoding {
-      case .json, .jsonl:
-        guard let schema = output.schema else {
-          return ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "EmptyResponse"))
-        }
-        let outname: String
-        if case .ref(let def) = schema.type {
-          (_, outname) = ts.namesFromRef(ref: def.ref, defMap: defMap)
-        } else {
-          outname = "\(fname)_Output"
-        }
-        return ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "\(prefix).\(outname)"))
-      case .text:
-        return ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "String"))
-      case .cbor, .car, .any, .mp4:
-        return ReturnClauseSyntax(type: TypeSyntax(stringLiteral: "Data"))
-      }
-    }
-    return ReturnClauseSyntax(type: TypeSyntax("Bool"))
-  }
-
-  func rpcParams(id: String, prefix: String) -> ExprSyntaxProtocol {
-    if let parameters, !parameters.properties.isEmpty {
-      var required = [String: Bool]()
-      for req in parameters.required ?? [] {
-        required[req] = true
-      }
-      return DictionaryExprSyntax {
-        for (name, t) in parameters.sortedProperties {
-          let ts = TypeSchema(id: id, prefix: prefix, defName: name, type: t)
-          let tn = TypeSchema.paramNameForField(typeSchema: ts)
-          let isRequired = required[name] ?? false
-          let stringLiteral =
-            if case .string(let def) = t, def.enum != nil || def.knownValues != nil {
-              isRequired ? ".\(tn)(\(name).rawValue)" : ".\(tn)(\(name)?.rawValue)"
-            } else {
-              ".\(tn)(\(name))"
-            }
-          DictionaryElementSyntax(
-            key: StringLiteralExprSyntax(content: name),
-            value: ExprSyntax(stringLiteral: stringLiteral)
-          )
-        }
-      }
-    } else {
-      return NilLiteralExprSyntax()
-    }
-  }
-
-  func generateDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name typeName: String, type: String, defMap _: ExtDefMap, generate: GenerateOption) -> any DeclSyntaxProtocol {
-    return EnumDeclSyntax(
-      modifiers: [
-        DeclModifierSyntax(name: .keyword(.public))
-      ],
-      name: .identifier(ts.typeName)
-    ) {
-      makeErrorDeclaration(leadingTrivia: .spaces(4), ts: ts, name: typeName, type: type)
-    }
+  func rpcOutput(fname: String, defMap: ExtDefMap, prefix: String) -> ReturnClauseSyntax {
+    ReturnClauseSyntax(type: IdentifierTypeSyntax(name: output?.typeName(fname: fname, prefix: prefix, defMap: defMap, isOutput: true) ?? .identifier("Bool")))
   }
 
   func makeErrorDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name typeName: String, type: String) -> any DeclSyntaxProtocol {

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftSyntax
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGeneratable {
   typealias DecodingConfiguration = TypeSchema.DecodingConfiguration
 
@@ -38,7 +42,10 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     }
   }
 
-  func generateDeclaration(leadingTrivia: Trivia? = nil, ts: TypeSchema, name: String, type typeName: String, defMap: ExtDefMap) -> any DeclSyntaxProtocol {
+  func generateDeclaration(
+    leadingTrivia: Trivia? = nil, ts: TypeSchema, name: String, type typeName: String,
+    defMap: ExtDefMap, generate: GenerateOption
+  ) -> any DeclSyntaxProtocol {
     var required = [String: Bool]()
     for req in self.required ?? [] {
       required[req] = true

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -1,16 +1,18 @@
 import SwiftSyntax
 
-struct ProcedureTypeDefinition: HTTPAPITypeDefinition {
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
+struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
   var type: FieldType { .procedure }
-  var parameters: Parameters? { nil }
   let output: OutputType?
-  let input: InputType?
+  var input: InputType?
   let description: String?
   let errors: [ErrorResponse]?
 
   private enum CodingKeys: String, CodingKey {
     case type
-    case parameters
     case output
     case input
     case description
@@ -23,5 +25,1095 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition {
     input = try container.decodeIfPresent(InputType.self, forKey: .input, configuration: configuration)
     description = try container.decodeIfPresent(String.self, forKey: .description)
     errors = try container.decodeIfPresent([ErrorResponse].self, forKey: .errors)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .type)
+    try container.encodeIfPresent(output, forKey: .output)
+    try container.encodeIfPresent(input, forKey: .input)
+    try container.encodeIfPresent(description, forKey: .description)
+    try container.encodeIfPresent(errors, forKey: .errors)
+  }
+
+  var contentType: String {
+    if let input {
+      switch input.encoding {
+      case .json, .jsonl, .text, .mp4:
+        return input.encoding.rawValue
+      case .cbor, .any, .car:
+        return "*/*"
+      }
+    }
+    return "*/*"
+  }
+
+  var inputRPCValue: ExprSyntax {
+    if input != nil {
+      ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("input")))
+    } else {
+      ExprSyntax(
+        MemberAccessExprSyntax(
+          base: OptionalChainingExprSyntax(
+            expression: DeclReferenceExprSyntax(baseName: .identifier("Bool")),
+            questionMark: .postfixQuestionMarkToken()
+          ),
+          period: .periodToken(),
+          declName: DeclReferenceExprSyntax(baseName: .identifier("none"))
+        ))
+    }
+  }
+
+  func inputBody(fname: String, defMap: ExtDefMap, prefix: String) -> EnumCaseElementSyntax {
+    if let input {
+      switch input.encoding {
+      case .json, .jsonl:
+        let token: String = {
+          guard let schema = input.schema else {
+            return "EmptyResponse"
+          }
+          let outname: String
+          if case .ref(let def) = schema.type {
+            (_, outname) = schema.namesFromRef(ref: def.ref, defMap: defMap)
+          } else {
+            outname = "\(fname)_Input"
+          }
+          return outname
+        }()
+        return EnumCaseElementSyntax(
+          name: .identifier("json"),
+          parameterClause: EnumCaseParameterClauseSyntax(
+            leftParen: .leftParenToken(),
+            parameters: EnumCaseParameterListSyntax([
+              EnumCaseParameterSyntax(
+                type: IdentifierTypeSyntax(name: .identifier(token))
+              )
+            ]),
+            rightParen: .rightParenToken()
+          )
+        )
+      case .text:
+        return EnumCaseElementSyntax(
+          name: .identifier("json"),
+          parameterClause: EnumCaseParameterClauseSyntax(
+            leftParen: .leftParenToken(),
+            parameters: EnumCaseParameterListSyntax([
+              EnumCaseParameterSyntax(
+                type: IdentifierTypeSyntax(name: .identifier("String"))
+              )
+            ]),
+            rightParen: .rightParenToken()
+          )
+        )
+      case .cbor, .car, .any, .mp4:
+        return EnumCaseElementSyntax(
+          name: .identifier("binary"),
+          parameterClause: EnumCaseParameterClauseSyntax(
+            leftParen: .leftParenToken(),
+            parameters: EnumCaseParameterListSyntax([
+              EnumCaseParameterSyntax(
+                type: IdentifierTypeSyntax(name: .identifier("HTTPBody"))
+              )
+            ]),
+            rightParen: .rightParenToken()
+          )
+        )
+      }
+    }
+    return EnumCaseElementSyntax(
+      name: .identifier("json"),
+      parameterClause: EnumCaseParameterClauseSyntax(
+        leftParen: .leftParenToken(),
+        parameters: EnumCaseParameterListSyntax([
+          EnumCaseParameterSyntax(
+            type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("Bool")))
+          )
+        ]),
+        rightParen: .rightParenToken()
+      )
+    )
+  }
+
+  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax] {
+    var arguments = [FunctionParameterSyntax]()
+    guard let input else { return arguments }
+    switch input.encoding {
+    case .cbor, .any, .car, .mp4:
+      let tname = "Data"
+      arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
+    case .text:
+      let tname = "String"
+      arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
+    case .json, .jsonl:
+      let tname: String
+      if case .ref(let ref) = input.schema?.type {
+        (_, tname) = ts.namesFromRef(ref: ref.ref, defMap: defMap)
+      } else {
+        tname = "\(fname)_Input"
+      }
+      arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: "\(prefix).\(tname)")))
+    }
+    return arguments
+  }
+
+  func rpcParams(id: String, prefix: String) -> ExprSyntaxProtocol {
+    NilLiteralExprSyntax()
+  }
+
+  func inputType(fname: String, defMap: ExtDefMap, prefix: String, binaryTypeName: String = "Data") -> ExprSyntax {
+    guard let token = input?.typeName(fname: fname, prefix: prefix, defMap: defMap, binaryTypeName: binaryTypeName, isOutput: false) else {
+      return ExprSyntax(
+        OptionalChainingExprSyntax(
+          expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("Bool"))),
+          questionMark: .postfixQuestionMarkToken()
+        ))
+    }
+    return ExprSyntax(DeclReferenceExprSyntax(baseName: token))
+  }
+
+  var isBinary: Bool {
+    input?.isBinary ?? false
+  }
+
+  func generateDeclaration(leadingTrivia: SwiftSyntax.Trivia?, ts: TypeSchema, name: String, type: String, defMap: ExtDefMap, generate: GenerateOption) -> any DeclSyntaxProtocol {
+    let prefix = Lex.structNameFor(prefix: ts.prefix)
+    return EnumDeclSyntax(
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public))
+      ],
+      name: .identifier(ts.typeName)
+    ) {
+      if generate.contains(.server) {
+        staticLetDecl(leadingTrivia: [.newlines(1), .spaces(2)], ident: "id", value: StringLiteralExprSyntax(content: type))
+        MemberBlockItemSyntax(
+          decl: DeclSyntax(
+            StructDeclSyntax(
+              leadingTrivia: [.newlines(1), .spaces(2)],
+              modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+              name: .identifier("Input"),
+              inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+            ) {
+              StructDeclSyntax(
+                leadingTrivia: [.newlines(1), .spaces(4)],
+                modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+                name: .identifier("Headers"),
+                inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+              ) {
+                VariableDeclSyntax(
+                  leadingTrivia: [.newlines(1), .spaces(6)],
+                  modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+                  bindingSpecifier: .keyword(.var),
+                  bindings: PatternBindingListSyntax([
+                    PatternBindingSyntax(
+                      pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("accept"))),
+                      typeAnnotation: TypeAnnotationSyntax(
+                        colon: .colonToken(),
+                        type: TypeSyntax(
+                          ArrayTypeSyntax(
+                            leftSquare: .leftSquareToken(),
+                            element: TypeSyntax(
+                              MemberTypeSyntax(
+                                baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime"))),
+                                period: .periodToken(),
+                                name: .identifier("AcceptHeaderContentType"),
+                                genericArgumentClause: GenericArgumentClauseSyntax(
+                                  leftAngle: .leftAngleToken(),
+                                  arguments: GenericArgumentListSyntax([
+                                    GenericArgumentSyntax(
+                                      argument: GenericArgumentSyntax.Argument(
+                                        MemberTypeSyntax(
+                                          baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                          period: .periodToken(),
+                                          name: .identifier("AcceptableContentType")
+                                        )))
+                                  ]),
+                                  rightAngle: .rightAngleToken()
+                                )
+                              )),
+                            rightSquare: .rightSquareToken()
+                          ))
+                      )
+                    )
+                  ])
+                )
+                InitializerDeclSyntax(
+                  leadingTrivia: [.newlines(1), .spaces(6)],
+                  modifiers: DeclModifierListSyntax([
+                    DeclModifierSyntax(name: .keyword(.public))
+                  ]),
+                  signature: FunctionSignatureSyntax(
+                    parameterClause: FunctionParameterClauseSyntax(
+                      leftParen: .leftParenToken(),
+                      parameters: FunctionParameterListSyntax([
+                        FunctionParameterSyntax(
+                          firstName: .identifier("accept"),
+                          colon: .colonToken(),
+                          type: ArrayTypeSyntax(
+                            leftSquare: .leftSquareToken(),
+                            element: MemberTypeSyntax(
+                              baseType: IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime")),
+                              period: .periodToken(),
+                              name: .identifier("AcceptHeaderContentType"),
+                              genericArgumentClause: GenericArgumentClauseSyntax {
+                                GenericArgumentSyntax(
+                                  argument: GenericArgumentSyntax.Argument(
+                                    MemberTypeSyntax(
+                                      baseType: IdentifierTypeSyntax(name: .identifier(ts.typeName)),
+                                      period: .periodToken(),
+                                      name: .identifier("AcceptableContentType")
+                                    ))
+                                )
+                              }
+                            ),
+                            rightSquare: .rightSquareToken()
+                          ),
+                          defaultValue: InitializerClauseSyntax(
+                            equal: .equalToken(),
+                            value: FunctionCallExprSyntax(
+                              callee: MemberAccessExprSyntax(
+                                period: .periodToken(),
+                                declName: DeclReferenceExprSyntax(baseName: .identifier("defaultValues"))
+                              ))
+                          )
+                        )
+                      ]),
+                      rightParen: .rightParenToken()
+                    ))
+                ) {
+                  SequenceExprSyntax(leadingTrivia: [.newlines(1), .spaces(8)]) {
+                    MemberAccessExprSyntax(
+                      base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+                      period: .periodToken(),
+                      declName: DeclReferenceExprSyntax(baseName: .identifier("accept"))
+                    )
+                    AssignmentExprSyntax(equal: .equalToken())
+                    DeclReferenceExprSyntax(baseName: .identifier("accept"))
+                  }
+                }
+              }
+              VariableDeclSyntax(
+                leadingTrivia: [.newlines(1), .spaces(4)],
+                modifiers: [
+                  DeclModifierSyntax(name: .keyword(.public))
+                ],
+                bindingSpecifier: .keyword(.var),
+                bindings: PatternBindingListSyntax([
+                  PatternBindingSyntax(
+                    pattern: IdentifierPatternSyntax(identifier: .identifier("headers")),
+                    typeAnnotation: TypeAnnotationSyntax(
+                      colon: .colonToken(),
+                      type: TypeSyntax(
+                        MemberTypeSyntax(
+                          baseType: TypeSyntax(
+                            MemberTypeSyntax(
+                              baseType: IdentifierTypeSyntax(name: .identifier(ts.typeName)),
+                              period: .periodToken(),
+                              name: .identifier("Input")
+                            )),
+                          period: .periodToken(),
+                          name: .identifier("Headers")
+                        ))
+                    )
+                  )
+                ])
+              )
+              EnumDeclSyntax(
+                leadingTrivia: [.newlines(2), .spaces(4)],
+                attributes: AttributeListSyntax {
+                  AttributeSyntax(
+                    atSign: .atSignToken(),
+                    attributeName: IdentifierTypeSyntax(name: .identifier("frozen"))
+                  )
+                },
+                modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+                name: .identifier("Body"),
+                inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+              ) {
+                EnumCaseDeclSyntax(leadingTrivia: [.newlines(1), .spaces(6)]) {
+                  inputBody(fname: name, defMap: defMap, prefix: prefix)
+                }
+              }
+              varDecl(
+                ident: "body",
+                type: MemberTypeSyntax(
+                  baseType: MemberTypeSyntax(
+                    baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                    name: .identifier("Input")
+                  ),
+                  name: .identifier("Body")
+                ))
+              procedureInputInitializer(leadingTrivia: [.newlines(2), .spaces(4)], typeName: ts.typeName)
+            }
+          ))
+        MemberBlockItemSyntax(
+          decl: DeclSyntax(
+            EnumDeclSyntax(
+              attributes: AttributeListSyntax {
+                AttributeSyntax(
+                  atSign: .atSignToken(leadingTrivia: [.newlines(1), .spaces(2)]),
+                  attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("frozen")))
+                )
+              },
+              modifiers: DeclModifierListSyntax([
+                DeclModifierSyntax(name: .keyword(.public))
+              ]),
+              enumKeyword: .keyword(.enum),
+              name: .identifier("Output"),
+              inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"]),
+              memberBlock: MemberBlockSyntax(
+                leftBrace: .leftBraceToken(),
+                members: MemberBlockItemListSyntax([
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      StructDeclSyntax(
+                        leadingTrivia: [.newlines(1), .spaces(4)],
+                        modifiers: [
+                          DeclModifierSyntax(name: .keyword(.public))
+                        ],
+                        name: .identifier("Ok"),
+                        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+                      ) {
+                        MemberBlockItemSyntax(
+                          decl: DeclSyntax(
+                            EnumDeclSyntax(
+                              attributes: AttributeListSyntax {
+                                AttributeSyntax(
+                                  atSign: .atSignToken(leadingTrivia: [.newlines(1), .spaces(6)]),
+                                  attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("frozen")))
+                                )
+                              },
+                              modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+                              name: .identifier("Body"),
+                              inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"]),
+                              memberBlock: MemberBlockSyntax(
+                                leftBrace: .leftBraceToken(),
+                                members: MemberBlockItemListSyntax([
+                                  MemberBlockItemSyntax(
+                                    decl: DeclSyntax(
+                                      EnumCaseDeclSyntax(
+                                        leadingTrivia: [.newlines(1), .spaces(8)],
+                                        elements: EnumCaseElementListSyntax([
+                                          EnumCaseElementSyntax(
+                                            name: .identifier("json"),
+                                            parameterClause: EnumCaseParameterClauseSyntax(
+                                              leftParen: .leftParenToken(),
+                                              parameters: EnumCaseParameterListSyntax([
+                                                EnumCaseParameterSyntax(
+                                                  type: TypeSyntax(
+                                                    MemberTypeSyntax(
+                                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
+                                                      period: .periodToken(),
+                                                      name: .identifier("Bool")
+                                                    ))
+                                                )
+                                              ]),
+                                              rightParen: .rightParenToken()
+                                            )
+                                          )
+                                        ])
+                                      ))),
+                                  MemberBlockItemSyntax(
+                                    decl: DeclSyntax(
+                                      VariableDeclSyntax(
+                                        modifiers: DeclModifierListSyntax([
+                                          DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(8)]))
+                                        ]),
+                                        bindingSpecifier: .keyword(.var),
+                                        bindings: PatternBindingListSyntax([
+                                          PatternBindingSyntax(
+                                            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("json"))),
+                                            typeAnnotation: TypeAnnotationSyntax(
+                                              colon: .colonToken(),
+                                              type: TypeSyntax(
+                                                MemberTypeSyntax(
+                                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
+                                                  period: .periodToken(),
+                                                  name: .identifier("Bool")
+                                                ))
+                                            ),
+                                            accessorBlock: AccessorBlockSyntax(
+                                              leftBrace: .leftBraceToken(),
+                                              accessors: .accessors(
+                                                AccessorDeclListSyntax([
+                                                  AccessorDeclSyntax(
+                                                    accessorSpecifier: .keyword(.get, leadingTrivia: [.newlines(1), .spaces(10)]),
+                                                    effectSpecifiers: AccessorEffectSpecifiersSyntax(throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))),
+                                                    body: CodeBlockSyntax(
+                                                      leftBrace: .leftBraceToken(),
+                                                      statements: CodeBlockItemListSyntax([
+                                                        CodeBlockItemSyntax(
+                                                          item: CodeBlockItemSyntax.Item(
+                                                            ExpressionStmtSyntax(
+                                                              expression: ExprSyntax(
+                                                                SwitchExprSyntax(
+                                                                  leadingTrivia: [.newlines(1), .spaces(12)],
+                                                                  subject: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self)))
+                                                                ) {
+                                                                  SwitchCaseSyntax(
+                                                                    label: SwitchCaseSyntax.Label(
+                                                                      SwitchCaseLabelSyntax(
+                                                                        leadingTrivia: [.newlines(1), .spaces(12)],
+                                                                        caseItems: SwitchCaseItemListSyntax([
+                                                                          SwitchCaseItemSyntax(
+                                                                            pattern: PatternSyntax(
+                                                                              ExpressionPatternSyntax(
+                                                                                expression: ExprSyntax(
+                                                                                  FunctionCallExprSyntax(
+                                                                                    callee: MemberAccessExprSyntax(
+                                                                                      period: .periodToken(),
+                                                                                      declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                                                                    )
+                                                                                  ) {
+                                                                                    LabeledExprSyntax(
+                                                                                      expression: PatternExprSyntax(
+                                                                                        pattern: ValueBindingPatternSyntax(
+                                                                                          bindingSpecifier: .keyword(.let),
+                                                                                          pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("body")))
+                                                                                        )))
+                                                                                  }
+                                                                                ))))
+                                                                        ]),
+                                                                        colon: .colonToken()
+                                                                      )),
+                                                                    statements: CodeBlockItemListSyntax([
+                                                                      CodeBlockItemSyntax(
+                                                                        item: CodeBlockItemSyntax.Item(
+                                                                          ReturnStmtSyntax(
+                                                                            leadingTrivia: [.newlines(1), .spaces(14)],
+                                                                            expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("body")))
+                                                                          )))
+                                                                    ])
+                                                                  )
+                                                                }
+                                                                .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(12)]))
+                                                              ))))
+                                                      ]),
+                                                      rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(10)])
+                                                    )
+                                                  )
+                                                ])),
+                                              rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(8)])
+                                            )
+                                          )
+                                        ])
+                                      ))),
+                                ]),
+                                rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(6)])
+                              )
+                            )))
+                        MemberBlockItemSyntax(
+                          decl: DeclSyntax(
+                            VariableDeclSyntax(
+                              modifiers: DeclModifierListSyntax([
+                                DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(2), .spaces(6)]))
+                              ]),
+                              bindingSpecifier: .keyword(.var),
+                              bindings: PatternBindingListSyntax([
+                                PatternBindingSyntax(
+                                  pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("body"))),
+                                  typeAnnotation: TypeAnnotationSyntax(
+                                    colon: .colonToken(),
+                                    type: TypeSyntax(
+                                      MemberTypeSyntax(
+                                        baseType:
+                                          MemberTypeSyntax(
+                                            baseType: TypeSyntax(
+                                              MemberTypeSyntax(
+                                                baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                                period: .periodToken(),
+                                                name: .identifier("Output")
+                                              )),
+                                            period: .periodToken(),
+                                            name: .identifier("Ok")
+                                          ),
+                                        period: .periodToken(),
+                                        name: .identifier("Body")
+                                      ))
+                                  )
+                                )
+                              ])
+                            )))
+                        MemberBlockItemSyntax(
+                          decl: DeclSyntax(
+                            InitializerDeclSyntax(
+                              modifiers: DeclModifierListSyntax([
+                                DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(2), .spaces(6)]))
+                              ]),
+                              initKeyword: .keyword(.`init`),
+                              signature: FunctionSignatureSyntax(
+                                parameterClause: FunctionParameterClauseSyntax(
+                                  leftParen: .leftParenToken(),
+                                  parameters: FunctionParameterListSyntax([
+                                    FunctionParameterSyntax(
+                                      firstName: .identifier("body"),
+                                      colon: .colonToken(),
+                                      type: TypeSyntax(
+                                        MemberTypeSyntax(
+                                          baseType: TypeSyntax(
+                                            MemberTypeSyntax(
+                                              baseType: TypeSyntax(
+                                                MemberTypeSyntax(
+                                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                                  period: .periodToken(),
+                                                  name: .identifier("Output")
+                                                )),
+                                              period: .periodToken(),
+                                              name: .identifier("Ok")
+                                            )),
+                                          period: .periodToken(),
+                                          name: .identifier("Body")
+                                        ))
+                                    )
+                                  ]),
+                                  rightParen: .rightParenToken()
+                                )),
+                              body: CodeBlockSyntax(
+                                leftBrace: .leftBraceToken(),
+                                statements: CodeBlockItemListSyntax([
+                                  CodeBlockItemSyntax(
+                                    item: CodeBlockItemSyntax.Item(
+                                      SequenceExprSyntax(
+                                        elements: ExprListSyntax([
+                                          ExprSyntax(
+                                            MemberAccessExprSyntax(
+                                              base: DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(8)])),
+                                              period: .periodToken(),
+                                              declName: DeclReferenceExprSyntax(baseName: .identifier("body"))
+                                            )),
+                                          ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
+                                          ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("body"))),
+                                        ]))))
+                                ]),
+                                rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(6)])
+                              )
+                            )))
+                      }
+                    )),
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      EnumCaseDeclSyntax(
+                        leadingTrivia: [.newlines(2), .spaces(4)],
+                        elements: EnumCaseElementListSyntax([
+                          EnumCaseElementSyntax(
+                            name: .identifier("ok"),
+                            parameterClause: EnumCaseParameterClauseSyntax(
+                              leftParen: .leftParenToken(),
+                              parameters: EnumCaseParameterListSyntax([
+                                EnumCaseParameterSyntax(
+                                  type: TypeSyntax(
+                                    MemberTypeSyntax(
+                                      baseType: TypeSyntax(
+                                        MemberTypeSyntax(
+                                          baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                          period: .periodToken(),
+                                          name: .identifier("Output")
+                                        )),
+                                      period: .periodToken(),
+                                      name: .identifier("Ok")
+                                    ))
+                                )
+                              ]),
+                              rightParen: .rightParenToken()
+                            )
+                          )
+                        ])
+                      ))),
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      VariableDeclSyntax(
+                        modifiers: DeclModifierListSyntax([
+                          DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(2), .spaces(4)]))
+                        ]),
+                        bindingSpecifier: .keyword(.var),
+                        bindings: PatternBindingListSyntax([
+                          PatternBindingSyntax(
+                            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("ok"))),
+                            typeAnnotation: TypeAnnotationSyntax(
+                              colon: .colonToken(),
+                              type: TypeSyntax(
+                                MemberTypeSyntax(
+                                  baseType: TypeSyntax(
+                                    MemberTypeSyntax(
+                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                      period: .periodToken(),
+                                      name: .identifier("Output")
+                                    )),
+                                  period: .periodToken(),
+                                  name: .identifier("Ok")
+                                ))
+                            ),
+                            accessorBlock: AccessorBlockSyntax(
+                              leftBrace: .leftBraceToken(),
+                              accessors: AccessorBlockSyntax.Accessors(
+                                AccessorDeclListSyntax([
+                                  AccessorDeclSyntax(
+                                    accessorSpecifier: .keyword(.get, leadingTrivia: [.newlines(1), .spaces(6)]),
+                                    effectSpecifiers: AccessorEffectSpecifiersSyntax(throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))),
+                                    body: CodeBlockSyntax(
+                                      leftBrace: .leftBraceToken(),
+                                      statements: CodeBlockItemListSyntax([
+                                        CodeBlockItemSyntax(
+                                          item: CodeBlockItemSyntax.Item(
+                                            ExpressionStmtSyntax(
+                                              expression: ExprSyntax(
+                                                SwitchExprSyntax(
+                                                  leadingTrivia: [.newlines(1), .spaces(8)],
+                                                  subject: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self))),
+                                                ) {
+                                                  SwitchCaseSyntax(
+                                                    label: SwitchCaseSyntax.Label(
+                                                      SwitchCaseLabelSyntax(
+                                                        leadingTrivia: [.newlines(1), .spaces(8)]) {
+                                                          SwitchCaseItemSyntax(
+                                                            pattern: PatternSyntax(
+                                                              ExpressionPatternSyntax(
+                                                                expression: ExprSyntax(
+                                                                  FunctionCallExprSyntax(
+                                                                    callee: ExprSyntax(
+                                                                      MemberAccessExprSyntax(
+                                                                        period: .periodToken(),
+                                                                        declName: DeclReferenceExprSyntax(baseName: .identifier("ok"))
+                                                                      ))
+                                                                  ) {
+                                                                    LabeledExprSyntax(
+                                                                      expression: ExprSyntax(
+                                                                        PatternExprSyntax(
+                                                                          pattern: PatternSyntax(
+                                                                            ValueBindingPatternSyntax(
+                                                                              bindingSpecifier: .keyword(.let),
+                                                                              pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("response")))
+                                                                            )))))
+                                                                  }
+                                                                ))))
+                                                        }
+                                                    )
+                                                  ) {
+                                                    ReturnStmtSyntax(
+                                                      leadingTrivia: [.newlines(1), .spaces(10)],
+                                                      expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("response")))
+                                                    )
+                                                  }
+                                                  SwitchCaseSyntax(
+                                                    label: SwitchCaseSyntax.Label(
+                                                      SwitchDefaultLabelSyntax(
+                                                        leadingTrivia: [.newlines(1), .spaces(8)],
+                                                        colon: .colonToken()
+                                                      ))
+                                                  ) {
+                                                    TryExprSyntax(
+                                                      leadingTrivia: [.newlines(1), .spaces(10)],
+                                                      expression: FunctionCallExprSyntax(
+                                                        callee: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("throwUnexpectedResponseStatus")))
+                                                      ) {
+                                                        LabeledExprSyntax(
+                                                          label: .identifier("expectedStatus", leadingTrivia: [.newlines(1), .spaces(12)]),
+                                                          colon: .colonToken(),
+                                                          expression: ExprSyntax(
+                                                            StringLiteralExprSyntax(
+                                                              openingQuote: .stringQuoteToken(),
+                                                              segments: StringLiteralSegmentListSyntax([
+                                                                StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment("ok")))
+                                                              ]),
+                                                              closingQuote: .stringQuoteToken()
+                                                            )),
+                                                          trailingComma: .commaToken()
+                                                        )
+                                                        LabeledExprSyntax(
+                                                          label: .identifier("response", leadingTrivia: [.newlines(1), .spaces(12)]),
+                                                          colon: .colonToken(),
+                                                          expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self)))
+                                                        )
+                                                      }
+                                                      .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(10)]))
+                                                    )
+                                                  }
+                                                }
+                                                .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(8)]))
+                                              ))))
+                                      ]),
+                                      rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(6)])
+                                    )
+                                  )
+                                ])),
+                              rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+                            )
+                          )
+                        ])
+                      ))),
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      EnumCaseDeclSyntax(
+                        leadingTrivia: [.newlines(1), .spaces(4)],
+                        elements: EnumCaseElementListSyntax([
+                          EnumCaseElementSyntax(
+                            name: .identifier("undocumented"),
+                            parameterClause: EnumCaseParameterClauseSyntax(
+                              leftParen: .leftParenToken(),
+                              parameters: EnumCaseParameterListSyntax([
+                                EnumCaseParameterSyntax(
+                                  firstName: .identifier("statusCode"),
+                                  colon: .colonToken(),
+                                  type: TypeSyntax(
+                                    MemberTypeSyntax(
+                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
+                                      period: .periodToken(),
+                                      name: .identifier("Int")
+                                    )),
+                                  trailingComma: .commaToken()
+                                ),
+                                EnumCaseParameterSyntax(
+                                  type: TypeSyntax(
+                                    MemberTypeSyntax(
+                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime"))),
+                                      period: .periodToken(),
+                                      name: .identifier("UndocumentedPayload")
+                                    ))
+                                ),
+                              ]),
+                              rightParen: .rightParenToken()
+                            )
+                          )
+                        ])
+                      ))),
+                ]),
+                rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(2)])
+              )
+            )))
+        MemberBlockItemSyntax(
+          decl: DeclSyntax(
+            EnumDeclSyntax(
+              attributes: AttributeListSyntax {
+                AttributeSyntax(
+                  atSign: .atSignToken(leadingTrivia: [.newlines(1), .spaces(2)]),
+                  attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("frozen")))
+                )
+              },
+              modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+              name: .identifier("AcceptableContentType"),
+              inheritanceClause: InheritanceClauseSyntax(typeNames: ["AcceptableProtocol"]),
+              memberBlock: MemberBlockSyntax(
+                leftBrace: .leftBraceToken(),
+                members: MemberBlockItemListSyntax([
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      EnumCaseDeclSyntax(
+                        leadingTrivia: [.newlines(1), .spaces(4)],
+                        elements: EnumCaseElementListSyntax([
+                          EnumCaseElementSyntax(name: .identifier("json"))
+                        ])
+                      ))),
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      EnumCaseDeclSyntax(
+                        leadingTrivia: [.newlines(1), .spaces(4)],
+                        elements: EnumCaseElementListSyntax([
+                          EnumCaseElementSyntax(
+                            name: .identifier("other"),
+                            parameterClause: EnumCaseParameterClauseSyntax(
+                              leftParen: .leftParenToken(),
+                              parameters: EnumCaseParameterListSyntax([
+                                EnumCaseParameterSyntax(
+                                  type: TypeSyntax(
+                                    MemberTypeSyntax(
+                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
+                                      period: .periodToken(),
+                                      name: .identifier("String")
+                                    ))
+                                )
+                              ]),
+                              rightParen: .rightParenToken()
+                            )
+                          )
+                        ])
+                      ))),
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      InitializerDeclSyntax(
+                        modifiers: DeclModifierListSyntax([
+                          DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(4)]))
+                        ]),
+                        initKeyword: .keyword(.`init`),
+                        optionalMark: .postfixQuestionMarkToken(),
+                        signature: FunctionSignatureSyntax(
+                          parameterClause: FunctionParameterClauseSyntax(
+                            leftParen: .leftParenToken(),
+                            parameters: FunctionParameterListSyntax([
+                              FunctionParameterSyntax(
+                                firstName: .identifier("rawValue"),
+                                colon: .colonToken(),
+                                type: MemberTypeSyntax(
+                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
+                                  period: .periodToken(),
+                                  name: .identifier("String")
+                                )
+                              )
+                            ]),
+                            rightParen: .rightParenToken()
+                          )),
+                        body: CodeBlockSyntax(
+                          leftBrace: .leftBraceToken(),
+                          statements: CodeBlockItemListSyntax([
+                            CodeBlockItemSyntax(
+                              item: CodeBlockItemSyntax.Item(
+                                ExpressionStmtSyntax(
+                                  expression: ExprSyntax(
+                                    SwitchExprSyntax(
+                                      leadingTrivia: [.newlines(1), .spaces(6)],
+                                      subject: FunctionCallExprSyntax(
+                                        callee: ExprSyntax(
+                                          MemberAccessExprSyntax(
+                                            base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("rawValue"))),
+                                            period: .periodToken(),
+                                            declName: DeclReferenceExprSyntax(baseName: .identifier("lowercased"))
+                                          )
+                                        )
+                                      )
+                                    ) {
+                                      SwitchCaseSyntax(
+                                        label: SwitchCaseSyntax.Label(
+                                          SwitchCaseLabelSyntax(
+                                            leadingTrivia: [.newlines(1), .spaces(6)]) {
+                                              SwitchCaseItemSyntax(
+                                                pattern: PatternSyntax(
+                                                  ExpressionPatternSyntax(
+                                                    expression: ExprSyntax(
+                                                      StringLiteralExprSyntax(content: "application/json")
+                                                    ))
+                                                ))
+                                            })
+                                      ) {
+                                        SequenceExprSyntax {
+                                          ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(8)])))
+                                          ExprSyntax(AssignmentExprSyntax(equal: .equalToken()))
+                                          ExprSyntax(
+                                            MemberAccessExprSyntax(
+                                              period: .periodToken(),
+                                              declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                            ))
+                                        }
+                                      }
+                                      SwitchCaseSyntax(
+                                        label: SwitchCaseSyntax.Label(
+                                          SwitchDefaultLabelSyntax(
+                                            leadingTrivia: [.newlines(1), .spaces(6)],
+                                            colon: .colonToken()
+                                          )),
+                                        statements: CodeBlockItemListSyntax([
+                                          CodeBlockItemSyntax(
+                                            item: CodeBlockItemSyntax.Item(
+                                              SequenceExprSyntax(
+                                                elements: ExprListSyntax([
+                                                  ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(8)]))),
+                                                  ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
+                                                  ExprSyntax(
+                                                    FunctionCallExprSyntax(
+                                                      callee: ExprSyntax(
+                                                        MemberAccessExprSyntax(
+                                                          period: .periodToken(),
+                                                          declName: DeclReferenceExprSyntax(baseName: .identifier("other"))
+                                                        ))
+                                                    ) {
+                                                      LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("rawValue"))))
+                                                    }
+                                                  ),
+                                                ]))))
+                                        ])
+                                      )
+                                    }
+                                    .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(6)]))
+                                  ))))
+                          ]),
+                          rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+                        )
+                      ))),
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      VariableDeclSyntax(
+                        modifiers: DeclModifierListSyntax([
+                          DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(4)]))
+                        ]),
+                        bindingSpecifier: .keyword(.var),
+                        bindings: PatternBindingListSyntax([
+                          PatternBindingSyntax(
+                            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("rawValue"))),
+                            typeAnnotation: TypeAnnotationSyntax(
+                              colon: .colonToken(),
+                              type: TypeSyntax(
+                                MemberTypeSyntax(
+                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
+                                  period: .periodToken(),
+                                  name: .identifier("String")
+                                ))
+                            ),
+                            accessorBlock: AccessorBlockSyntax(
+                              leftBrace: .leftBraceToken(),
+                              accessors: AccessorBlockSyntax.Accessors(
+                                CodeBlockItemListSyntax([
+                                  CodeBlockItemSyntax(
+                                    item: CodeBlockItemSyntax.Item(
+                                      ExpressionStmtSyntax(
+                                        expression: ExprSyntax(
+                                          SwitchExprSyntax(
+                                            leadingTrivia: [.newlines(1), .spaces(6)],
+                                            subject: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self)))
+                                          ) {
+                                            SwitchCaseSyntax(
+                                              label: SwitchCaseSyntax.Label(
+                                                SwitchCaseLabelSyntax(
+                                                  leadingTrivia: [.newlines(1), .spaces(6)],
+                                                  caseItems: SwitchCaseItemListSyntax([
+                                                    SwitchCaseItemSyntax(
+                                                      pattern: PatternSyntax(
+                                                        ExpressionPatternSyntax(
+                                                          expression: ExprSyntax(
+                                                            FunctionCallExprSyntax(
+                                                              callee: ExprSyntax(
+                                                                MemberAccessExprSyntax(
+                                                                  period: .periodToken(),
+                                                                  declName: DeclReferenceExprSyntax(baseName: .identifier("other"))
+                                                                ))
+                                                            ) {
+                                                              LabeledExprSyntax(
+                                                                expression: ExprSyntax(
+                                                                  PatternExprSyntax(
+                                                                    pattern: PatternSyntax(
+                                                                      ValueBindingPatternSyntax(
+                                                                        bindingSpecifier: .keyword(.let),
+                                                                        pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("string")))
+                                                                      )))))
+                                                            }
+                                                          ))))
+                                                  ]),
+                                                  colon: .colonToken()
+                                                ))
+                                            ) {
+                                              ReturnStmtSyntax(
+                                                leadingTrivia: [.newlines(1), .spaces(8)],
+                                                expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("string")))
+                                              )
+                                            }
+                                            SwitchCaseSyntax(
+                                              label: SwitchCaseSyntax.Label(
+                                                SwitchCaseLabelSyntax(
+                                                  leadingTrivia: [.newlines(1), .spaces(6)],
+                                                  caseItems: SwitchCaseItemListSyntax([
+                                                    SwitchCaseItemSyntax(
+                                                      pattern: PatternSyntax(
+                                                        ExpressionPatternSyntax(
+                                                          expression: ExprSyntax(
+                                                            MemberAccessExprSyntax(
+                                                              period: .periodToken(),
+                                                              declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                                            )))))
+                                                  ]),
+                                                  colon: .colonToken()
+                                                )),
+                                              statements: CodeBlockItemListSyntax([
+                                                CodeBlockItemSyntax(
+                                                  item: CodeBlockItemSyntax.Item(
+                                                    ReturnStmtSyntax(
+                                                      leadingTrivia: [.newlines(1), .spaces(8)],
+                                                      expression: ExprSyntax(
+                                                        StringLiteralExprSyntax(
+                                                          openingQuote: .stringQuoteToken(),
+                                                          segments: StringLiteralSegmentListSyntax([
+                                                            StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment("application/json")))
+                                                          ]),
+                                                          closingQuote: .stringQuoteToken()
+                                                        ))
+                                                    )))
+                                              ])
+                                            )
+                                          }
+                                          .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(6)]))
+                                        ))))
+                                ])),
+                              rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+                            )
+                          )
+                        ])
+                      ))),
+                  MemberBlockItemSyntax(
+                    decl: DeclSyntax(
+                      VariableDeclSyntax(
+                        modifiers: DeclModifierListSyntax([
+                          DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(4)])),
+                          DeclModifierSyntax(name: .keyword(.static)),
+                        ]),
+                        bindingSpecifier: .keyword(.var),
+                        bindings: PatternBindingListSyntax([
+                          PatternBindingSyntax(
+                            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("allCases"))),
+                            typeAnnotation: TypeAnnotationSyntax(
+                              colon: .colonToken(),
+                              type: TypeSyntax(
+                                ArrayTypeSyntax(
+                                  leftSquare: .leftSquareToken(),
+                                  element: TypeSyntax(IdentifierTypeSyntax(name: .keyword(.Self))),
+                                  rightSquare: .rightSquareToken()
+                                ))
+                            ),
+                            accessorBlock: AccessorBlockSyntax(
+                              leftBrace: .leftBraceToken(),
+                              accessors: AccessorBlockSyntax.Accessors(
+                                CodeBlockItemListSyntax([
+                                  CodeBlockItemSyntax(
+                                    item: CodeBlockItemSyntax.Item(
+                                      ArrayExprSyntax(
+                                        leadingTrivia: [.newlines(1), .spaces(6)],
+                                        rightSquare: .rightSquareToken(leadingTrivia: [.newlines(1), .spaces(6)])
+                                      ) {
+                                        ArrayElementSyntax(
+                                          expression: ExprSyntax(
+                                            MemberAccessExprSyntax(
+                                              period: .periodToken(leadingTrivia: [.newlines(1), .spaces(8)]),
+                                              declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                            )))
+                                      }
+                                    ))
+                                ])),
+                              rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+                            )
+                          )
+                        ])
+                      ))),
+                ]),
+                rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(2)])
+              )
+            )))
+      }
+      makeErrorDeclaration(leadingTrivia: [.newlines(1)], ts: ts, name: name, type: type)
+    }
+  }
+
+  private func procedureInputInitializer(leadingTrivia: Trivia? = nil, typeName: String) -> InitializerDeclSyntax {
+    memberInitializer(
+      leadingTrivia: leadingTrivia,
+      members: [
+        (
+          "headers",
+          MemberTypeSyntax(
+            baseType: MemberTypeSyntax(
+              baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(typeName))),
+              period: .periodToken(),
+              name: .identifier("Input")
+            ),
+            period: .periodToken(),
+            name: .identifier("Headers")
+          )
+        ),
+        (
+          "body",
+          MemberTypeSyntax(
+            baseType: MemberTypeSyntax(
+              baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(typeName))),
+              period: .periodToken(),
+              name: .identifier("Input")
+            ),
+            period: .periodToken(),
+            name: .identifier("Body")
+          )
+        ),
+      ])
   }
 }

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -1,10 +1,13 @@
 import SwiftSyntax
 
-struct QueryTypeDefinition: HTTPAPITypeDefinition {
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
+struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
   var type: FieldType { .query }
   let parameters: Parameters?
   let output: OutputType?
-  var input: InputType? { nil }
   let description: String?
   let errors: [ErrorResponse]?
 
@@ -23,5 +26,1068 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition {
     output = try container.decodeIfPresent(OutputType.self, forKey: .output, configuration: configuration)
     description = try container.decodeIfPresent(String.self, forKey: .description)
     errors = try container.decodeIfPresent([ErrorResponse].self, forKey: .errors)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(type, forKey: .type)
+    try container.encodeIfPresent(output, forKey: .output)
+    try container.encodeIfPresent(description, forKey: .description)
+    try container.encodeIfPresent(errors, forKey: .errors)
+  }
+
+  private func queries(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [PatternBindingSyntax] {
+    var queries = [PatternBindingSyntax]()
+    guard let parameters else { return queries }
+    var required = [String: Bool]()
+    for req in parameters.required ?? [] {
+      required[req] = true
+    }
+    for (name, t) in parameters.sortedProperties {
+      let isRequired = required[name] ?? false
+      let tn: String
+      if case .string(let def) = t, def.enum != nil || def.knownValues != nil {
+        tn = "\(prefix).\(fname)_\(name.titleCased())"
+      } else {
+        let ts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: name, type: t)
+        tn = TypeSchema.typeNameForField(name: name, k: "", v: ts, defMap: defMap, dropPrefix: false)
+      }
+      let type: TypeSyntax
+      if isRequired {
+        type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(tn)))
+      } else {
+        type = TypeSyntax(
+          OptionalTypeSyntax(
+            wrappedType: IdentifierTypeSyntax(name: .identifier(tn)),
+            questionMark: .postfixQuestionMarkToken()
+          ))
+      }
+      queries.append(
+        PatternBindingSyntax(
+          pattern: IdentifierPatternSyntax(identifier: .identifier(name)),
+          typeAnnotation: TypeAnnotationSyntax(
+            colon: .colonToken(),
+            type: type
+          )))
+    }
+    return queries
+  }
+
+  var contentType: String {
+    "*/*"
+  }
+
+  var inputRPCValue: ExprSyntax {
+    ExprSyntax(
+      MemberAccessExprSyntax(
+        base: OptionalChainingExprSyntax(
+          expression: DeclReferenceExprSyntax(baseName: .identifier("Bool")),
+          questionMark: .postfixQuestionMarkToken()
+        ),
+        period: .periodToken(),
+        declName: DeclReferenceExprSyntax(baseName: .identifier("none"))
+      ))
+  }
+
+  func output(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> TokenSyntax {
+    if let output {
+      switch output.encoding {
+      case .json, .jsonl:
+        guard let schema = output.schema else {
+          return .identifier("EmptyResponse")
+        }
+        let outname: String
+        if case .ref(let def) = schema.type {
+          (_, outname) = ts.namesFromRef(ref: def.ref, defMap: defMap)
+        } else {
+          outname = "\(fname)_Output"
+        }
+        return .identifier("\(prefix).\(outname)")
+      case .text:
+        return .identifier("String")
+      case .cbor, .car, .any, .mp4:
+        return .identifier("Data")
+      }
+    }
+    return .identifier("Bool")
+  }
+
+  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax] {
+    var arguments = [FunctionParameterSyntax]()
+    guard let parameters else { return arguments }
+    var required = [String: Bool]()
+    for req in parameters.required ?? [] {
+      required[req] = true
+    }
+    for (name, t) in parameters.sortedProperties {
+      let isRequired = required[name] ?? false
+      let tn: String
+      if case .string(let def) = t, def.enum != nil || def.knownValues != nil {
+        tn = "\(prefix).\(fname)_\(name.titleCased())"
+      } else {
+        let ts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: name, type: t)
+        tn = TypeSchema.typeNameForField(name: name, k: "", v: ts, defMap: defMap, dropPrefix: false)
+      }
+      let type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(tn)))
+      let defaultValue: InitializerClauseSyntax? =
+        isRequired
+        ? nil
+        : InitializerClauseSyntax(
+          equal: .equalToken(),
+          value: NilLiteralExprSyntax()
+        )
+      arguments.append(
+        .init(
+          firstName: .identifier(name),
+          type: isRequired
+            ? type
+            : TypeSyntax(OptionalTypeSyntax(wrappedType: type)), defaultValue: defaultValue))
+    }
+    return arguments
+  }
+
+  func rpcParams(id: String, prefix: String) -> ExprSyntaxProtocol {
+    if let parameters, !parameters.properties.isEmpty {
+      var required = [String: Bool]()
+      for req in parameters.required ?? [] {
+        required[req] = true
+      }
+      return DictionaryExprSyntax {
+        for (name, t) in parameters.sortedProperties {
+          let ts = TypeSchema(id: id, prefix: prefix, defName: name, type: t)
+          let tn = TypeSchema.paramNameForField(typeSchema: ts)
+          let isRequired = required[name] ?? false
+          let stringLiteral =
+            if case .string(let def) = t, def.enum != nil || def.knownValues != nil {
+              isRequired ? ".\(tn)(\(name).rawValue)" : ".\(tn)(\(name)?.rawValue)"
+            } else {
+              ".\(tn)(\(name))"
+            }
+          DictionaryElementSyntax(
+            key: StringLiteralExprSyntax(content: name),
+            value: ExprSyntax(stringLiteral: stringLiteral)
+          )
+        }
+      }
+    } else {
+      return NilLiteralExprSyntax()
+    }
+  }
+
+  func generateDeclaration(leadingTrivia: SwiftSyntax.Trivia?, ts: TypeSchema, name: String, type: String, defMap: ExtDefMap, generate: GenerateOption) -> any DeclSyntaxProtocol {
+    return EnumDeclSyntax(
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public))
+      ],
+      name: .identifier(ts.typeName)
+    ) {
+      if generate.contains(.server) {
+        VariableDeclSyntax(
+          leadingTrivia: [.newlines(1), .spaces(2)],
+          modifiers: [
+            DeclModifierSyntax(name: .keyword(.public)),
+            DeclModifierSyntax(name: .keyword(.static)),
+          ],
+          bindingSpecifier: .keyword(.let)
+        ) {
+          PatternBindingSyntax(
+            pattern: IdentifierPatternSyntax(identifier: .identifier("id")),
+            initializer: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: StringLiteralExprSyntax(
+                openingQuote: .stringQuoteToken(),
+                segments: StringLiteralSegmentListSyntax([
+                  StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment(type)))
+                ]),
+                closingQuote: .stringQuoteToken()
+              )
+            )
+          )
+        }
+        genQueryInput(ts: ts, name: name, type: type, prefix: ts.prefix, defMap: defMap)
+        genQueryOutput(ts: ts, name: name, type: type, prefix: ts.prefix, defMap: defMap)
+        genAcceptableContentType()
+      }
+      makeErrorDeclaration(leadingTrivia: [.newlines(1)], ts: ts, name: name, type: type)
+    }
+  }
+
+  private func genQueryInput(ts: TypeSchema, name: String, type: String, prefix: String, defMap: ExtDefMap) -> StructDeclSyntax {
+    let prefix = Lex.structNameFor(prefix: prefix)
+    return StructDeclSyntax(
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public))
+      ],
+      name: .identifier("Input"),
+      inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+    ) {
+      StructDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(4)],
+        modifiers: [
+          DeclModifierSyntax(name: .keyword(.public))
+        ],
+        name: .identifier("Query"),
+        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+      ) {
+        for query in queries(ts: ts, fname: name, defMap: defMap, prefix: prefix) {
+          VariableDeclSyntax(
+            leadingTrivia: [.newlines(1), .spaces(8)],
+            modifiers: DeclModifierListSyntax([
+              DeclModifierSyntax(name: .keyword(.public))
+            ]),
+            bindingSpecifier: .keyword(.var),
+            bindings: [query]
+          )
+        }
+        InitializerDeclSyntax(
+          leadingTrivia: [.newlines(2), .spaces(8)],
+          modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+          signature: FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax {
+              rpcArguments(ts: ts, fname: name, defMap: defMap, prefix: prefix)
+            })
+        ) {
+          for (key, _) in parameters?.sortedProperties ?? [] {
+            SequenceExprSyntax(leadingTrivia: [.newlines(1), .spaces(10)]) {
+              MemberAccessExprSyntax(
+                base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+                period: .periodToken(),
+                declName: DeclReferenceExprSyntax(baseName: .identifier(key))
+              )
+              AssignmentExprSyntax(equal: .equalToken())
+              DeclReferenceExprSyntax(baseName: .identifier(key))
+            }
+          }
+        }
+      }
+      VariableDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(4)],
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+        bindingSpecifier: .keyword(.var),
+        bindings: PatternBindingListSyntax([
+          PatternBindingSyntax(
+            pattern: IdentifierPatternSyntax(identifier: .identifier("query")),
+            typeAnnotation: TypeAnnotationSyntax(
+              colon: .colonToken(),
+              type: TypeSyntax(
+                MemberTypeSyntax(
+                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Input"))),
+                  period: .periodToken(),
+                  name: .identifier("Query")
+                ))
+            )
+          )
+        ])
+      )
+      StructDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(4)],
+        modifiers: DeclModifierListSyntax([
+          DeclModifierSyntax(name: .keyword(.public))
+        ]),
+        name: .identifier("Headers"),
+        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"]),
+        memberBlock: MemberBlockSyntax(
+          leftBrace: .leftBraceToken(),
+          members: MemberBlockItemListSyntax([
+            MemberBlockItemSyntax(
+              decl: DeclSyntax(
+                VariableDeclSyntax(
+                  modifiers: DeclModifierListSyntax([
+                    DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(8)]))
+                  ]),
+                  bindingSpecifier: .keyword(.var),
+                  bindings: PatternBindingListSyntax([
+                    PatternBindingSyntax(
+                      pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("accept"))),
+                      typeAnnotation: TypeAnnotationSyntax(
+                        colon: .colonToken(),
+                        type: TypeSyntax(
+                          ArrayTypeSyntax(
+                            leftSquare: .leftSquareToken(),
+                            element: TypeSyntax(
+                              MemberTypeSyntax(
+                                baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime"))),
+                                period: .periodToken(),
+                                name: .identifier("AcceptHeaderContentType"),
+                                genericArgumentClause: GenericArgumentClauseSyntax(
+                                  leftAngle: .leftAngleToken(),
+                                  arguments: GenericArgumentListSyntax([
+                                    GenericArgumentSyntax(argument: GenericArgumentSyntax.Argument(IdentifierTypeSyntax(name: .identifier("AcceptableContentType"))))
+                                  ]),
+                                  rightAngle: .rightAngleToken()
+                                )
+                              )),
+                            rightSquare: .rightSquareToken()
+                          ))
+                      )
+                    )
+                  ])
+                ))),
+            MemberBlockItemSyntax(
+              decl: DeclSyntax(
+                InitializerDeclSyntax(
+                  modifiers: DeclModifierListSyntax([
+                    DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(8)]))
+                  ]),
+                  initKeyword: .keyword(.`init`),
+                  signature: FunctionSignatureSyntax(
+                    parameterClause: FunctionParameterClauseSyntax(
+                      leftParen: .leftParenToken(),
+                      parameters: FunctionParameterListSyntax([
+                        FunctionParameterSyntax(
+                          firstName: .identifier("accept"),
+                          colon: .colonToken(),
+                          type: TypeSyntax(
+                            ArrayTypeSyntax(
+                              leftSquare: .leftSquareToken(),
+                              element: TypeSyntax(
+                                MemberTypeSyntax(
+                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime"))),
+                                  period: .periodToken(),
+                                  name: .identifier("AcceptHeaderContentType"),
+                                  genericArgumentClause: GenericArgumentClauseSyntax(
+                                    leftAngle: .leftAngleToken(),
+                                    arguments: GenericArgumentListSyntax([
+                                      GenericArgumentSyntax(argument: GenericArgumentSyntax.Argument(IdentifierTypeSyntax(name: .identifier("AcceptableContentType"))))
+                                    ]),
+                                    rightAngle: .rightAngleToken()
+                                  )
+                                )),
+                              rightSquare: .rightSquareToken()
+                            )),
+                          defaultValue: InitializerClauseSyntax(
+                            equal: .equalToken(),
+                            value: FunctionCallExprSyntax(
+                              callee: MemberAccessExprSyntax(
+                                period: .periodToken(),
+                                declName: DeclReferenceExprSyntax(baseName: .identifier("defaultValues"))
+                              ))
+                          )
+                        )
+                      ]),
+                      rightParen: .rightParenToken()
+                    )),
+                  body: CodeBlockSyntax(
+                    leftBrace: .leftBraceToken(),
+                    statements: CodeBlockItemListSyntax([
+                      CodeBlockItemSyntax(
+                        item: CodeBlockItemSyntax.Item(
+                          SequenceExprSyntax(
+                            elements: ExprListSyntax([
+                              ExprSyntax(
+                                MemberAccessExprSyntax(
+                                  base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(12)]))),
+                                  period: .periodToken(),
+                                  declName: DeclReferenceExprSyntax(baseName: .identifier("accept"))
+                                )),
+                              ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
+                              ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("accept"))),
+                            ]))))
+                    ]),
+                    rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(8)])
+                  )
+                ))),
+          ]),
+          rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+        )
+      )
+      VariableDeclSyntax(
+        modifiers: DeclModifierListSyntax([
+          DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(4)]))
+        ]),
+        bindingSpecifier: .keyword(.var),
+        bindings: PatternBindingListSyntax([
+          PatternBindingSyntax(
+            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("headers"))),
+            typeAnnotation: TypeAnnotationSyntax(
+              colon: .colonToken(),
+              type: TypeSyntax(
+                MemberTypeSyntax(
+                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Input"))),
+                  period: .periodToken(),
+                  name: .identifier("Headers")
+                ))
+            )
+          )
+        ])
+      )
+      InitializerDeclSyntax(
+        modifiers: DeclModifierListSyntax([
+          DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(4)]))
+        ]),
+        initKeyword: .keyword(.`init`),
+        signature: FunctionSignatureSyntax(
+          parameterClause: FunctionParameterClauseSyntax(
+            leftParen: .leftParenToken(),
+            parameters: FunctionParameterListSyntax([
+              FunctionParameterSyntax(
+                leadingTrivia: [.newlines(1)],
+                firstName: .identifier("query"),
+                colon: .colonToken(),
+                type: TypeSyntax(
+                  MemberTypeSyntax(
+                    baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Input"))),
+                    period: .periodToken(),
+                    name: .identifier("Query")
+                  )),
+                trailingComma: .commaToken()
+              ),
+              FunctionParameterSyntax(
+                firstName: .identifier("headers", leadingTrivia: [.newlines(1), .spaces(8)]),
+                colon: .colonToken(),
+                type: TypeSyntax(
+                  MemberTypeSyntax(
+                    baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Input"))),
+                    period: .periodToken(),
+                    name: .identifier("Headers")
+                  )),
+                defaultValue: InitializerClauseSyntax(
+                  equal: .equalToken(),
+                  value: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(
+                      period: .periodToken(),
+                      declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+                    ))
+                )
+              ),
+            ]),
+            rightParen: .rightParenToken(leadingTrivia: [.newlines(1), .spaces(4)])
+          )),
+        body: CodeBlockSyntax(
+          leftBrace: .leftBraceToken(),
+          statements: CodeBlockItemListSyntax([
+            CodeBlockItemSyntax(
+              item: CodeBlockItemSyntax.Item(
+                SequenceExprSyntax(
+                  elements: ExprListSyntax([
+                    ExprSyntax(
+                      MemberAccessExprSyntax(
+                        base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(8)]))),
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .identifier("query"))
+                      )),
+                    ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
+                    ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("query"))),
+                  ])))),
+            CodeBlockItemSyntax(
+              item: CodeBlockItemSyntax.Item(
+                SequenceExprSyntax(
+                  elements: ExprListSyntax([
+                    ExprSyntax(
+                      MemberAccessExprSyntax(
+                        base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(8)]))),
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .identifier("headers"))
+                      )),
+                    ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
+                    ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("headers"))),
+                  ])))),
+          ]),
+          rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+        )
+      )
+    }
+  }
+
+  private func genQueryOutput(ts: TypeSchema, name: String, type: String, prefix: String, defMap: ExtDefMap) -> EnumDeclSyntax {
+    let prefix = Lex.structNameFor(prefix: ts.prefix)
+    let output = output(ts: ts, fname: name, defMap: defMap, prefix: prefix)
+    return EnumDeclSyntax(
+      attributes: [
+        AttributeListSyntax.Element(
+          AttributeSyntax(
+            atSign: .atSignToken(),
+            attributeName: IdentifierTypeSyntax(name: .identifier("frozen"))
+          ))
+      ],
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      name: .identifier("Output"),
+      inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"]),
+    ) {
+      StructDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+        name: .identifier("Ok"),
+        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+      ) {
+        EnumDeclSyntax(
+          leadingTrivia: [.newlines(1), .spaces(14)],
+          attributes: AttributeListSyntax {
+            AttributeSyntax(
+              atSign: .atSignToken(),
+              attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("frozen")))
+            )
+          },
+          modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+          name: .identifier("Body"),
+          inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+        ) {
+          genQueryOutputBody(ts: ts, name: name, type: type, prefix: prefix, defMap: defMap)
+          VariableDeclSyntax(
+            leadingTrivia: [.newlines(1), .spaces(18)],
+            modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+            bindingSpecifier: .keyword(.var),
+            bindings: PatternBindingListSyntax([
+              PatternBindingSyntax(
+                pattern: IdentifierPatternSyntax(identifier: .identifier("json")),
+                typeAnnotation: TypeAnnotationSyntax(
+                  colon: .colonToken(),
+                  type: IdentifierTypeSyntax(name: output)
+                ),
+                accessorBlock: AccessorBlockSyntax(
+                  leftBrace: .leftBraceToken(),
+                  accessors: AccessorBlockSyntax.Accessors(
+                    AccessorDeclListSyntax([
+                      AccessorDeclSyntax(
+                        accessorSpecifier: .keyword(.get, leadingTrivia: [.newlines(1), .spaces(22)]),
+                        effectSpecifiers: AccessorEffectSpecifiersSyntax(throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws)))
+                      ) {
+                        SwitchExprSyntax(
+                          leadingTrivia: [.newlines(1), .spaces(26)],
+                          subject: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                        ) {
+                          SwitchCaseSyntax(
+                            label: SwitchCaseSyntax.Label(
+                              SwitchCaseLabelSyntax(
+                                leadingTrivia: [.newlines(1), .spaces(26)],
+                                caseItems: SwitchCaseItemListSyntax([
+                                  SwitchCaseItemSyntax(
+                                    pattern: ValueBindingPatternSyntax(
+                                      bindingSpecifier: .keyword(.let),
+                                      pattern: ExpressionPatternSyntax(
+                                        expression: FunctionCallExprSyntax(
+                                          callee: MemberAccessExprSyntax(
+                                            period: .periodToken(),
+                                            declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                          )
+                                        ) {
+                                          LabeledExprSyntax(expression: PatternExprSyntax(pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("body")))))
+                                        }
+                                      )
+                                    ))
+                                ]),
+                                colon: .colonToken()
+                              ))
+                          ) {
+                            CodeBlockItemSyntax(
+                              item: CodeBlockItemSyntax.Item(
+                                ReturnStmtSyntax(
+                                  leadingTrivia: [.newlines(1), .spaces(30)],
+                                  expression: DeclReferenceExprSyntax(baseName: .identifier("body"))
+                                )))
+                          }
+                        }
+                        .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(26)]))
+                      }
+                    ])),
+                  rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(18)])
+                )
+              )
+            ])
+          )
+        }
+        VariableDeclSyntax(
+          modifiers: [
+            DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(14)]))
+          ],
+          bindingSpecifier: .keyword(.var),
+          bindings: PatternBindingListSyntax([
+            PatternBindingSyntax(
+              pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("body"))),
+              typeAnnotation: TypeAnnotationSyntax(
+                colon: .colonToken(),
+                type: TypeSyntax(
+                  MemberTypeSyntax(
+                    baseType: TypeSyntax(
+                      MemberTypeSyntax(
+                        baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Output"))),
+                        period: .periodToken(),
+                        name: .identifier("Ok")
+                      )),
+                    period: .periodToken(),
+                    name: .identifier("Body")
+                  ))
+              )
+            )
+          ])
+        )
+        InitializerDeclSyntax(
+          modifiers: DeclModifierListSyntax([
+            DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(14)]))
+          ]),
+          initKeyword: .keyword(.`init`),
+          signature: FunctionSignatureSyntax(
+            parameterClause: FunctionParameterClauseSyntax(
+              leftParen: .leftParenToken(),
+              parameters: FunctionParameterListSyntax([
+                FunctionParameterSyntax(
+                  firstName: .identifier("body"),
+                  colon: .colonToken(),
+                  type: TypeSyntax(
+                    MemberTypeSyntax(
+                      baseType: TypeSyntax(
+                        MemberTypeSyntax(
+                          baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Output"))),
+                          period: .periodToken(),
+                          name: .identifier("Ok")
+                        )),
+                      period: .periodToken(),
+                      name: .identifier("Body")
+                    ))
+                )
+              ]),
+              rightParen: .rightParenToken()
+            ))
+        ) {
+          SequenceExprSyntax(
+            elements: ExprListSyntax([
+              ExprSyntax(
+                MemberAccessExprSyntax(
+                  base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(18)]))),
+                  period: .periodToken(),
+                  declName: DeclReferenceExprSyntax(baseName: .identifier("body"))
+                )),
+              ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
+              ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("body"))),
+            ]))
+        }
+      }
+      EnumCaseDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        elements: EnumCaseElementListSyntax([
+          EnumCaseElementSyntax(
+            name: .identifier("ok"),
+            parameterClause: EnumCaseParameterClauseSyntax(
+              leftParen: .leftParenToken(),
+              parameters: EnumCaseParameterListSyntax([
+                EnumCaseParameterSyntax(
+                  type: TypeSyntax(
+                    MemberTypeSyntax(
+                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Output"))),
+                      period: .periodToken(),
+                      name: .identifier("Ok")
+                    ))
+                )
+              ]),
+              rightParen: .rightParenToken()
+            )
+          )
+        ])
+      )
+      VariableDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        modifiers: DeclModifierListSyntax([
+          DeclModifierSyntax(name: .keyword(.public))
+        ]),
+        bindingSpecifier: .keyword(.var),
+        bindings: PatternBindingListSyntax([
+          PatternBindingSyntax(
+            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("ok"))),
+            typeAnnotation: TypeAnnotationSyntax(
+              colon: .colonToken(),
+              type: TypeSyntax(
+                MemberTypeSyntax(
+                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Output"))),
+                  period: .periodToken(),
+                  name: .identifier("Ok")
+                ))
+            ),
+            accessorBlock: AccessorBlockSyntax(
+              leftBrace: .leftBraceToken(),
+              accessors: AccessorBlockSyntax.Accessors(
+                AccessorDeclListSyntax([
+                  AccessorDeclSyntax(
+                    accessorSpecifier: .keyword(.get, leadingTrivia: [.newlines(1), .spaces(14)]),
+                    effectSpecifiers: AccessorEffectSpecifiersSyntax(throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws)))
+                  ) {
+                    ExpressionStmtSyntax(
+                      expression: ExprSyntax(
+                        SwitchExprSyntax(
+                          leadingTrivia: [.newlines(1), .spaces(18)],
+                          subject: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self)))
+                        ) {
+                          SwitchCaseSyntax(
+                            label: SwitchCaseSyntax.Label(
+                              SwitchCaseLabelSyntax(
+                                leadingTrivia: [.newlines(1), .spaces(18)],
+                                caseItems: SwitchCaseItemListSyntax([
+                                  SwitchCaseItemSyntax(
+                                    pattern: ValueBindingPatternSyntax(
+                                      bindingSpecifier: .keyword(.let),
+                                      pattern: ExpressionPatternSyntax(
+                                        expression: FunctionCallExprSyntax(
+                                          callee: MemberAccessExprSyntax(
+                                            period: .periodToken(),
+                                            declName: DeclReferenceExprSyntax(baseName: .identifier("ok"))
+                                          )
+                                        ) {
+                                          LabeledExprSyntax(expression: PatternExprSyntax(pattern: IdentifierPatternSyntax(identifier: .identifier("response"))))
+                                        }
+                                      )
+                                    ))
+                                ]),
+                                colon: .colonToken()
+                              ))
+                          ) {
+                            ReturnStmtSyntax(
+                              leadingTrivia: [.newlines(1), .spaces(22)],
+                              expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("response")))
+                            )
+                          }
+                          SwitchCaseSyntax(
+                            label: SwitchCaseSyntax.Label(
+                              SwitchDefaultLabelSyntax(
+                                leadingTrivia: [.newlines(1), .spaces(18)],
+                                colon: .colonToken()
+                              ))
+                          ) {
+                            TryExprSyntax(
+                              leadingTrivia: [.newlines(1), .spaces(22)],
+                              expression: FunctionCallExprSyntax(
+                                callee: DeclReferenceExprSyntax(baseName: .identifier("throwUnexpectedResponseStatus"))
+                              ) {
+                                LabeledExprSyntax(
+                                  label: .identifier("expectedStatus", leadingTrivia: [.newlines(1), .spaces(26)]),
+                                  colon: .colonToken(),
+                                  expression: StringLiteralExprSyntax(content: "ok"),
+                                )
+                                LabeledExprSyntax(
+                                  label: .identifier("response", leadingTrivia: [.newlines(1), .spaces(26)]),
+                                  colon: .colonToken(),
+                                  expression: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                                )
+                              }
+                              .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(22)]))
+                            )
+                          }
+                        }
+                        .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(18)]))
+                      ))
+                  }
+                  .with(\.body!.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(14)]))
+                ])),
+              rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(10)])
+            )
+          )
+        ])
+      )
+      EnumCaseDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        elements: EnumCaseElementListSyntax([
+          EnumCaseElementSyntax(
+            name: .identifier("undocumented"),
+            parameterClause: EnumCaseParameterClauseSyntax(
+              leftParen: .leftParenToken(),
+              parameters: EnumCaseParameterListSyntax([
+                EnumCaseParameterSyntax(
+                  firstName: .identifier("statusCode"),
+                  colon: .colonToken(),
+                  type: TypeSyntax(
+                    MemberTypeSyntax(
+                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
+                      period: .periodToken(),
+                      name: .identifier("Int")
+                    )),
+                  trailingComma: .commaToken()
+                ),
+                EnumCaseParameterSyntax(
+                  type: TypeSyntax(
+                    MemberTypeSyntax(
+                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime"))),
+                      period: .periodToken(),
+                      name: .identifier("UndocumentedPayload")
+                    ))
+                ),
+              ]),
+              rightParen: .rightParenToken()
+            )
+          )
+        ])
+      )
+    }
+  }
+
+  private func genQueryOutputBody(ts: TypeSchema, name: String, type: String, prefix: String, defMap: ExtDefMap) -> EnumCaseDeclSyntax {
+    let output = output(ts: ts, fname: name, defMap: defMap, prefix: prefix)
+    return EnumCaseDeclSyntax(
+      leadingTrivia: [.newlines(1), .spaces(18)],
+      elements: EnumCaseElementListSyntax([
+        EnumCaseElementSyntax(
+          name: .identifier("json"),
+          parameterClause: EnumCaseParameterClauseSyntax(
+            leftParen: .leftParenToken(),
+            parameters: EnumCaseParameterListSyntax([
+              EnumCaseParameterSyntax(
+                type: IdentifierTypeSyntax(name: output)
+              )
+            ]),
+            rightParen: .rightParenToken()
+          )
+        )
+      ])
+    )
+  }
+
+  private func genAcceptableContentType() -> EnumDeclSyntax {
+    EnumDeclSyntax(
+      attributes: AttributeListSyntax {
+        AttributeSyntax(
+          atSign: .atSignToken(),
+          attributeName: IdentifierTypeSyntax(name: .identifier("frozen"))
+        )
+      },
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      name: .identifier("AcceptableContentType"),
+      inheritanceClause: InheritanceClauseSyntax(typeNames: ["AcceptableProtocol"])
+    ) {
+      EnumCaseDeclSyntax(
+        elements: EnumCaseElementListSyntax([
+          EnumCaseElementSyntax(name: .identifier("json"))
+        ])
+      )
+      EnumCaseDeclSyntax(
+        elements: [
+          EnumCaseElementSyntax(
+            name: .identifier("other"),
+            parameterClause: EnumCaseParameterClauseSyntax(
+              leftParen: .leftParenToken(),
+              parameters: EnumCaseParameterListSyntax([
+                EnumCaseParameterSyntax(
+                  type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String")))
+                )
+              ]),
+              rightParen: .rightParenToken()
+            )
+          )
+        ]
+      )
+      MemberBlockItemSyntax(
+        decl: DeclSyntax(
+          InitializerDeclSyntax(
+            leadingTrivia: [.newlines(1)],
+            modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+            optionalMark: .postfixQuestionMarkToken(),
+            signature: FunctionSignatureSyntax(
+              parameterClause: FunctionParameterClauseSyntax(
+                leftParen: .leftParenToken(),
+                parameters: [
+                  FunctionParameterSyntax(
+                    firstName: .identifier("rawValue"),
+                    colon: .colonToken(),
+                    type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String")))
+                  )
+                ],
+                rightParen: .rightParenToken()
+              )),
+          ) {
+            CodeBlockItemSyntax(
+              item: CodeBlockItemSyntax.Item(
+                ExpressionStmtSyntax(
+                  expression: ExprSyntax(
+                    SwitchExprSyntax(
+                      leadingTrivia: [.newlines(1), .spaces(8)],
+                      subject: FunctionCallExprSyntax(
+                        callee: MemberAccessExprSyntax(
+                          base: DeclReferenceExprSyntax(baseName: .identifier("rawValue")),
+                          period: .periodToken(),
+                          declName: DeclReferenceExprSyntax(baseName: .identifier("lowercased"))
+                        )
+                      )
+                    ) {
+                      SwitchCaseSyntax(
+                        label: SwitchCaseSyntax.Label(
+                          SwitchCaseLabelSyntax(
+                            leadingTrivia: [.newlines(1), .spaces(8)],
+                            caseItems: SwitchCaseItemListSyntax([
+                              SwitchCaseItemSyntax(
+                                pattern: PatternSyntax(
+                                  ExpressionPatternSyntax(
+                                    expression: ExprSyntax(
+                                      StringLiteralExprSyntax(
+                                        openingQuote: .stringQuoteToken(),
+                                        segments: StringLiteralSegmentListSyntax([
+                                          StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment("application/json")))
+                                        ]),
+                                        closingQuote: .stringQuoteToken()
+                                      )))))
+                            ]),
+                            colon: .colonToken()
+                          )),
+                        statements: CodeBlockItemListSyntax([
+                          CodeBlockItemSyntax(
+                            item: CodeBlockItemSyntax.Item(
+                              SequenceExprSyntax(
+                                elements: ExprListSyntax([
+                                  ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(12)]))),
+                                  ExprSyntax(AssignmentExprSyntax(equal: .equalToken())),
+                                  ExprSyntax(
+                                    MemberAccessExprSyntax(
+                                      period: .periodToken(),
+                                      declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                    )),
+                                ]))))
+                        ])
+                      )
+                      SwitchCaseSyntax(
+                        label: SwitchCaseSyntax.Label(
+                          SwitchDefaultLabelSyntax(
+                            leadingTrivia: [.newlines(1)],
+                            colon: .colonToken()
+                          ))
+                      ) {
+                        SequenceExprSyntax {
+                          ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self, leadingTrivia: [.newlines(1), .spaces(12)])))
+                          ExprSyntax(AssignmentExprSyntax(equal: .equalToken()))
+                          ExprSyntax(
+                            FunctionCallExprSyntax(
+                              callee: MemberAccessExprSyntax(
+                                period: .periodToken(),
+                                declName: DeclReferenceExprSyntax(baseName: .identifier("other"))
+                              )
+                            ) {
+                              LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("rawValue"))))
+                            })
+                        }
+                      }
+                    }
+                    .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1)]))
+                  ))))
+          }
+        ))
+      MemberBlockItemSyntax(
+        decl: DeclSyntax(
+          VariableDeclSyntax(
+            modifiers: DeclModifierListSyntax([
+              DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(4)]))
+            ]),
+            bindingSpecifier: .keyword(.var),
+            bindings: PatternBindingListSyntax([
+              PatternBindingSyntax(
+                pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("rawValue"))),
+                typeAnnotation: TypeAnnotationSyntax(
+                  colon: .colonToken(),
+                  type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String")))
+                ),
+                accessorBlock: AccessorBlockSyntax(
+                  leftBrace: .leftBraceToken(),
+                  accessors: AccessorBlockSyntax.Accessors(
+                    CodeBlockItemListSyntax([
+                      CodeBlockItemSyntax(
+                        item: CodeBlockItemSyntax.Item(
+                          ExpressionStmtSyntax(
+                            expression: ExprSyntax(
+                              SwitchExprSyntax(
+                                leadingTrivia: [.newlines(1), .spaces(8)],
+                                subject: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self)))
+                              ) {
+                                SwitchCaseSyntax(
+                                  label: SwitchCaseSyntax.Label(
+                                    SwitchCaseLabelSyntax(
+                                      leadingTrivia: [.newlines(1), .spaces(8)]) {
+                                        SwitchCaseItemSyntax(
+                                          pattern: PatternSyntax(
+                                            ValueBindingPatternSyntax(
+                                              bindingSpecifier: .keyword(.let),
+                                              pattern: PatternSyntax(
+                                                ExpressionPatternSyntax(
+                                                  expression: FunctionCallExprSyntax(
+                                                    callee: MemberAccessExprSyntax(
+                                                      period: .periodToken(),
+                                                      declName: DeclReferenceExprSyntax(baseName: .identifier("other"))
+                                                    )
+                                                  ) {
+                                                    LabeledExprSyntax(expression: PatternExprSyntax(pattern: IdentifierPatternSyntax(identifier: .identifier("string"))))
+                                                  }
+                                                )
+                                              )
+                                            )))
+                                      },
+                                  )
+                                ) {
+                                  ReturnStmtSyntax(
+                                    leadingTrivia: [.newlines(1), .spaces(12)],
+                                    expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("string")))
+                                  )
+                                }
+                                SwitchCaseSyntax(
+                                  label: SwitchCaseSyntax.Label(
+                                    SwitchCaseLabelSyntax(
+                                      leadingTrivia: [.newlines(1), .spaces(8)],
+                                      caseItems: SwitchCaseItemListSyntax([
+                                        SwitchCaseItemSyntax(
+                                          pattern: PatternSyntax(
+                                            ExpressionPatternSyntax(
+                                              expression: ExprSyntax(
+                                                MemberAccessExprSyntax(
+                                                  period: .periodToken(),
+                                                  declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                                )))))
+                                      ]),
+                                      colon: .colonToken()
+                                    ))
+                                ) {
+                                  ReturnStmtSyntax(
+                                    leadingTrivia: [.newlines(1), .spaces(12)],
+                                    expression: ExprSyntax(
+                                      StringLiteralExprSyntax(
+                                        openingQuote: .stringQuoteToken(),
+                                        segments: StringLiteralSegmentListSyntax([
+                                          StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment("application/json")))
+                                        ]),
+                                        closingQuote: .stringQuoteToken()
+                                      ))
+                                  )
+                                }
+                              }
+                              .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(8)]))
+                            ))))
+                    ])),
+                  rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+                )
+              )
+            ])
+          )))
+      MemberBlockItemSyntax(
+        decl: DeclSyntax(
+          VariableDeclSyntax(
+            modifiers: DeclModifierListSyntax([
+              DeclModifierSyntax(name: .keyword(.public, leadingTrivia: [.newlines(1), .spaces(4)])),
+              DeclModifierSyntax(name: .keyword(.static)),
+            ]),
+            bindingSpecifier: .keyword(.var),
+            bindings: PatternBindingListSyntax([
+              PatternBindingSyntax(
+                pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("allCases"))),
+                typeAnnotation: TypeAnnotationSyntax(
+                  colon: .colonToken(),
+                  type: TypeSyntax(
+                    ArrayTypeSyntax(
+                      leftSquare: .leftSquareToken(),
+                      element: TypeSyntax(IdentifierTypeSyntax(name: .keyword(.Self))),
+                      rightSquare: .rightSquareToken()
+                    ))
+                ),
+                accessorBlock: AccessorBlockSyntax(
+                  leftBrace: .leftBraceToken(),
+                  accessors: AccessorBlockSyntax.Accessors(
+                    CodeBlockItemListSyntax([
+                      CodeBlockItemSyntax(
+                        item: CodeBlockItemSyntax.Item(
+                          ArrayExprSyntax(leadingTrivia: [.newlines(1), .spaces(8)], rightSquare: .rightSquareToken(leadingTrivia: [.newlines(1), .spaces(8)])) {
+                            ArrayElementSyntax(
+                              expression: MemberAccessExprSyntax(
+                                period: .periodToken(leadingTrivia: [.newlines(1), .spaces(12)]),
+                                declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                              ))
+                          }
+                        )
+                      )
+                    ])),
+                  rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])
+                )
+              )
+            ])
+          )))
+    }
   }
 }

--- a/Sources/SwiftAtprotoLex/Definitions/RecordDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/RecordDefinition.swift
@@ -1,6 +1,10 @@
 import Foundation
 import SwiftSyntax
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 struct RecordDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGeneratable {
   typealias DecodingConfiguration = TypeSchema.DecodingConfiguration
 
@@ -30,7 +34,10 @@ struct RecordDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGenerat
     try container.encode(record, forKey: .record)
   }
 
-  func generateDeclaration(leadingTrivia: Trivia? = nil, ts: TypeSchema, name: String, type typeName: String, defMap: ExtDefMap) -> any DeclSyntaxProtocol {
-    record.generateDeclaration(leadingTrivia: leadingTrivia, ts: ts, name: name, type: typeName, defMap: defMap)
+  func generateDeclaration(
+    leadingTrivia: Trivia? = nil, ts: TypeSchema, name: String, type typeName: String,
+    defMap: ExtDefMap, generate: GenerateOption
+  ) -> any DeclSyntaxProtocol {
+    record.generateDeclaration(leadingTrivia: leadingTrivia, ts: ts, name: name, type: typeName, defMap: defMap, generate: generate)
   }
 }

--- a/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
@@ -1,5 +1,9 @@
 import SwiftSyntax
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
   var type: FieldType { .string }
   let description: String?
@@ -29,7 +33,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
     `enum` == nil
   }
 
-  func generateDeclaration(leadingTrivia: Trivia? = nil, ts _: TypeSchema, name: String, type typeName: String, defMap: ExtDefMap) -> any DeclSyntaxProtocol {
+  func generateDeclaration(leadingTrivia: Trivia? = nil, ts _: TypeSchema, name: String, type typeName: String, defMap: ExtDefMap, generate: GenerateOption) -> any DeclSyntaxProtocol {
     if let knownValues = knownValues {
       genCodeStringWithKnownValues(leadingTrivia: leadingTrivia, name: name, knownValues: knownValues)
     } else if let cases = `enum` {

--- a/Sources/SwiftAtprotoLex/Definitions/SwiftCodeGeneratable.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/SwiftCodeGeneratable.swift
@@ -1,5 +1,12 @@
 import SwiftSyntax
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 protocol SwiftCodeGeneratable {
-  func generateDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name: String, type typeName: String, defMap: ExtDefMap) -> any DeclSyntaxProtocol
+  func generateDeclaration(
+    leadingTrivia: Trivia?, ts: TypeSchema, name: String, type typeName: String,
+    defMap: ExtDefMap, generate: GenerateOption
+  ) -> any DeclSyntaxProtocol
 }

--- a/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
@@ -1,12 +1,19 @@
 import SwiftSyntax
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 struct UnionTypeDefinition: Codable, SwiftCodeGeneratable {
   var type: FieldType { .union }
   let description: String?
   let refs: [String]
   let closed: Bool?
 
-  func generateDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name: String, type typeName: String, defMap: ExtDefMap) -> any DeclSyntaxProtocol {
+  func generateDeclaration(
+    leadingTrivia: Trivia?, ts: TypeSchema, name: String, type typeName: String,
+    defMap: ExtDefMap, generate: GenerateOption
+  ) -> any DeclSyntaxProtocol {
     var tss = [TypeSchema]()
     for ref in refs {
       let refName: String =

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -1,0 +1,974 @@
+import Foundation
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension Lex {
+  static func genXRPCAPIProtocolFile(for schemasMap: [String: [Schema]], defMap: ExtDefMap) -> String {
+    var procedureTypes = [(key: String, prefix: String, value: TypeSchema, def: ProcedureTypeDefinition)]()
+    for schemas in schemasMap {
+      for schema in schemas.value {
+        if let main = schema.defs["main"], case .procedure(let def) = main.type {
+          let prefix = Lex.structNameFor(prefix: main.prefix)
+          procedureTypes.append((Self.nameFromId(id: schema.id, prefix: schema.prefix), prefix, main, def))
+        }
+      }
+    }
+    procedureTypes = procedureTypes.sorted(by: { $0.value.id < $1.value.id })
+    let src = SourceFileSyntax(
+      leadingTrivia: fileHeader,
+      statementsBuilder: {
+        ImportDeclSyntax(
+          path: [ImportPathComponentSyntax(name: "SwiftAtproto")]
+        )
+        ImportDeclSyntax(
+          path: [ImportPathComponentSyntax(name: "HTTPTypes")]
+        )
+        ImportDeclSyntax(
+          path: [ImportPathComponentSyntax(name: "Foundation")]
+        )
+        ImportDeclSyntax(
+          attributes: AttributeListSyntax {
+            AttributeSyntax(
+              atSign: .atSignToken(),
+              attributeName: IdentifierTypeSyntax(name: .identifier("_spi")),
+              leftParen: .leftParenToken(),
+              arguments: AttributeSyntax.Arguments([
+                LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("Generated"))))
+              ]),
+              rightParen: .rightParenToken()
+            )
+          },
+          path: [
+            ImportPathComponentSyntax(name: .identifier("OpenAPIRuntime"))
+          ],
+          trailingTrivia: .newlines(2)
+        )
+        genXRPCAPIProtocol(for: procedureTypes)
+        genXRPCExtension(for: procedureTypes)
+        genUnversalServerExtension(for: procedureTypes, defMap: defMap)
+      },
+      trailingTrivia: .newlines(2))
+    return src.formatted().description
+  }
+
+  private static func genXRPCAPIProtocol(leadingTrivia _: Trivia? = nil, for procedureTypes: [(key: String, prefix: String, value: TypeSchema, def: ProcedureTypeDefinition)]) -> ProtocolDeclSyntax {
+    ProtocolDeclSyntax(
+      leadingTrivia: nil,
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public))
+      ],
+      name: .identifier("XRPCAPIProtocol"),
+      inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable"])
+    ) {
+      for (key, _, scheme, _) in procedureTypes {
+        genXRPCFunctionDeclSyntax(key: key, scheme: scheme)
+      }
+    }
+  }
+
+  private static func genXRPCExtension(leadingTrivia: Trivia? = nil, for procedureTypes: [(key: String, prefix: String, value: TypeSchema, def: ProcedureTypeDefinition)]) -> ExtensionDeclSyntax {
+    ExtensionDeclSyntax(
+      extendedType: IdentifierTypeSyntax(name: .identifier("XRPCAPIProtocol"))
+    ) {
+      for (key, prefix, _, _) in procedureTypes {
+        makeXRPCMethodStub(key: key, prefix: prefix)
+      }
+      genRegisterHandlers(for: procedureTypes)
+    }
+  }
+
+  private static func makeXRPCMethodStub(leadingTrivia: Trivia? = nil, key: String, prefix: String) -> FunctionDeclSyntax {
+    FunctionDeclSyntax(
+      leadingTrivia: .spaces(2),
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      name: .identifier("\(prefix)_\(key)"),
+      signature: FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax {
+          FunctionParameterSyntax(
+            firstName: .wildcardToken(),
+            secondName: .identifier("input"),
+            colon: .colonToken(),
+            type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input")])
+          )
+        },
+        effectSpecifiers: FunctionEffectSpecifiersSyntax(
+          asyncSpecifier: .keyword(.async),
+          throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+        ),
+        returnClause: ReturnClauseSyntax(
+          type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Output")])
+        )
+      )
+    ) {
+      FunctionCallExprSyntax(
+        callee: MemberAccessExprSyntax(
+          leadingTrivia: .newline,
+          declName: DeclReferenceExprSyntax(baseName: .identifier("undocumented"))
+        )
+      ) {
+        LabeledExprSyntax(
+          label: .identifier("statusCode"),
+          colon: .colonToken(),
+          expression: IntegerLiteralExprSyntax(literal: .integerLiteral("501")),
+        )
+        LabeledExprSyntax(
+          expression: FunctionCallExprSyntax(
+            callee: MemberAccessExprSyntax(declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))))
+        )
+      }
+      .with(\.leadingTrivia, .spaces(4))
+    }
+    .with(\.body!.rightBrace, .rightBraceToken(leadingTrivia: [.spaces(2)]))
+    .with(\.trailingTrivia, .newlines(2))
+  }
+
+  private static func genXRPCFunctionDeclSyntax(leadingTrivia: Trivia? = nil, key: String, scheme: TypeSchema) -> FunctionDeclSyntax {
+    let prefix = Lex.structNameFor(prefix: scheme.prefix)
+    return FunctionDeclSyntax(
+      leadingTrivia: [.newlines(1), .spaces(2)],
+      name: .identifier("\(prefix)_\(key)"),
+      signature: FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax(
+          leftParen: .leftParenToken(),
+          parameters: [
+            FunctionParameterSyntax(
+              firstName: .wildcardToken(),
+              secondName: .identifier("input"),
+              colon: .colonToken(),
+              type: MemberTypeSyntax(
+                baseType: MemberTypeSyntax(
+                  baseType: IdentifierTypeSyntax(name: .identifier(prefix)),
+                  period: .periodToken(),
+                  name: .identifier(key)
+                ),
+                period: .periodToken(),
+                name: .identifier("Input")
+              )
+            )
+          ],
+          rightParen: .rightParenToken()
+        ),
+        effectSpecifiers: FunctionEffectSpecifiersSyntax(
+          asyncSpecifier: .keyword(.async),
+          throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+        ),
+        returnClause: ReturnClauseSyntax(
+          arrow: .arrowToken(),
+          type: MemberTypeSyntax(
+            baseType: MemberTypeSyntax(
+              baseType: IdentifierTypeSyntax(name: .identifier(prefix)),
+              period: .periodToken(),
+              name: .identifier(key)
+            ),
+            period: .periodToken(),
+            name: .identifier("Output")
+          )
+        )
+      )
+    )
+  }
+
+  private static func makeHandlerRegistration(leadingTrivia: Trivia? = nil, prefix: String, type: String) -> TryExprSyntax {
+    TryExprSyntax(
+      leadingTrivia: leadingTrivia,
+      expression: FunctionCallExprSyntax(
+        callee: MemberAccessExprSyntax(parts: [.identifier("transport"), .identifier("register")])
+      ) {
+        LabeledExprSyntax(
+          leadingTrivia: [.newlines(1), .spaces(6)],
+          expression: ClosureExprSyntax(rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(4)])) {
+            TryExprSyntax(
+              leadingTrivia: [.newlines(1), .spaces(8)],
+              expression: AwaitExprSyntax(
+                expression: FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(parts: [.identifier("server"), .identifier("\(prefix)_\(type)")])
+                ) {
+                  for (i, label) in ["request", "body", "metadata"].enumerated() {
+                    LabeledExprSyntax(
+                      label: .identifier(label, leadingTrivia: [.newlines(1), .spaces(10)]),
+                      colon: .colonToken(),
+                      expression: DeclReferenceExprSyntax(baseName: .dollarIdentifier("$\(i)")),
+                    )
+                  }
+                }
+                .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(8)]))
+              )
+            )
+          }
+          .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(6)]))
+        )
+        LabeledExprSyntax(
+          label: .identifier("method", leadingTrivia: [.newlines(1), .spaces(6)]),
+          colon: .colonToken(),
+          expression: MemberAccessExprSyntax(declName: DeclReferenceExprSyntax(baseName: .identifier("post")))
+        )
+        LabeledExprSyntax(
+          label: .identifier("path", leadingTrivia: [.newlines(1), .spaces(6)]),
+          colon: .colonToken(),
+          expression: FunctionCallExprSyntax(
+            callee: MemberAccessExprSyntax(parts: [.identifier("server"), .identifier("apiPathComponentsWithServerPrefix")])
+          ) {
+            LabeledExprSyntax(
+              expression: StringLiteralExprSyntax {
+                StringSegmentSyntax(content: .stringSegment("/"))
+                ExpressionSegmentSyntax {
+                  LabeledExprSyntax(
+                    expression: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(type), .identifier("id")])
+                  )
+                }
+                StringSegmentSyntax(content: .stringSegment(""))
+              }
+            )
+          }
+        )
+      }
+      .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(4)]))
+    )
+  }
+
+  private static func genRegisterHandlers(leadingTrivia: Trivia? = nil, for procedureTypes: [(key: String, prefix: String, value: TypeSchema, def: ProcedureTypeDefinition)]) -> FunctionDeclSyntax {
+    FunctionDeclSyntax(
+      leadingTrivia: .spaces(2),
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public))
+      ],
+      name: .identifier("registerHandlers"),
+      signature: FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax(
+          leftParen: .leftParenToken(),
+          rightParen: .rightParenToken(leadingTrivia: [.newlines(1), .spaces(2)])
+        ) {
+          FunctionParameterSyntax(
+            leadingTrivia: [.newlines(1), .spaces(4)],
+            firstName: .identifier("on"),
+            secondName: .identifier("transport"),
+            colon: .colonToken(),
+            type: TypeSyntax(
+              SomeOrAnyTypeSyntax(
+                someOrAnySpecifier: .keyword(.any),
+                constraint: TypeSyntax(IdentifierTypeSyntax(name: .identifier("ServerTransport")))
+              ))
+          )
+          FunctionParameterSyntax(
+            leadingTrivia: [.newlines(1), .spaces(4)],
+            firstName: .identifier("serverURL"),
+            colon: .colonToken(),
+            type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("URL"))),
+            defaultValue: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: MemberAccessExprSyntax(declName: DeclReferenceExprSyntax(baseName: .identifier("defaultOpenAPIServerURL")))
+            )
+          )
+          FunctionParameterSyntax(
+            leadingTrivia: [.newlines(1), .spaces(4)],
+            firstName: .identifier("configuration"),
+            colon: .colonToken(),
+            type: IdentifierTypeSyntax(name: .identifier("Configuration")),
+            defaultValue: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`)))
+              )
+            )
+          )
+          FunctionParameterSyntax(
+            leadingTrivia: [.newlines(1), .spaces(4)],
+            firstName: .identifier("middlewares"),
+            colon: .colonToken(),
+            type: ArrayTypeSyntax(
+              element: SomeOrAnyTypeSyntax(
+                someOrAnySpecifier: .keyword(.any),
+                constraint: IdentifierTypeSyntax(name: .identifier("ServerMiddleware"))
+              ),
+            ),
+            defaultValue: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: ArrayExprSyntax {}
+            )
+          )
+        },
+        effectSpecifiers: FunctionEffectSpecifiersSyntax(throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws)))
+      )
+    ) {
+      VariableDeclSyntax(
+        bindingSpecifier: .keyword(.let, leadingTrivia: [.newlines(1), .spaces(4)])
+      ) {
+        PatternBindingSyntax(
+          pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("server"))),
+          initializer: InitializerClauseSyntax(
+            equal: .equalToken(),
+            value: FunctionCallExprSyntax(
+              callee: DeclReferenceExprSyntax(baseName: .identifier("UniversalServer"))
+            ) {
+              LabeledExprSyntax(
+                label: .identifier("serverURL", leadingTrivia: [.newlines(1), .spaces(6)]),
+                colon: .colonToken(),
+                expression: DeclReferenceExprSyntax(baseName: .identifier("serverURL")),
+              )
+              LabeledExprSyntax(
+                label: .identifier("handler", leadingTrivia: [.newlines(1), .spaces(6)]),
+                colon: .colonToken(),
+                expression: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+              )
+              LabeledExprSyntax(
+                label: .identifier("configuration", leadingTrivia: [.newlines(1), .spaces(6)]),
+                colon: .colonToken(),
+                expression: DeclReferenceExprSyntax(baseName: .identifier("configuration"))
+              )
+              LabeledExprSyntax(
+                label: .identifier("middlewares", leadingTrivia: [.newlines(1), .spaces(6)]),
+                colon: .colonToken(),
+                expression: DeclReferenceExprSyntax(baseName: .identifier("middlewares"))
+              )
+            }
+            .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(4)]))
+          )
+        )
+      }
+
+      for (type, prefix, _, _) in procedureTypes {
+        makeHandlerRegistration(leadingTrivia: .spaces(4), prefix: prefix, type: type)
+      }
+    }
+    .with(\.body!.rightBrace, .rightBraceToken(leadingTrivia: [.spaces(2)]))
+  }
+
+  private static func genUnversalServerExtension(
+    leadingTrivia: Trivia? = nil, for procedureTypes: [(key: String, prefix: String, value: TypeSchema, def: ProcedureTypeDefinition)],
+    defMap: ExtDefMap
+  ) -> ExtensionDeclSyntax {
+    ExtensionDeclSyntax(
+      extendedType: IdentifierTypeSyntax(name: .identifier("UniversalServer")),
+      genericWhereClause: GenericWhereClauseSyntax(
+        requirements: GenericRequirementListSyntax([
+          GenericRequirementSyntax(
+            requirement: GenericRequirementSyntax.Requirement(
+              ConformanceRequirementSyntax(
+                leftType: IdentifierTypeSyntax(name: .identifier("APIHandler")),
+                colon: .colonToken(),
+                rightType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("XRPCAPIProtocol")))
+              )))
+        ])
+      )
+    ) {
+      for (key, prefix, schema, def) in procedureTypes {
+        makeHandlerMethod(key: key, prefix: prefix, schema: schema, def: def, defMap: defMap)
+      }
+    }
+  }
+
+  private static func makeHandlerMethod(leadingTrivia: Trivia? = nil, key: String, prefix: String, schema: TypeSchema, def: ProcedureTypeDefinition, defMap: ExtDefMap) -> FunctionDeclSyntax {
+    FunctionDeclSyntax(
+      leadingTrivia: .spaces(2),
+      name: .identifier("\(prefix)_\(key)"),
+      signature: FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax {
+          FunctionParameterSyntax(
+            firstName: .identifier("request", leadingTrivia: [.newlines(1), .spaces(4)]),
+            colon: .colonToken(),
+            type: MemberTypeSyntax(parts: [.identifier("HTTPTypes"), .identifier("HTTPRequest")])
+          )
+          FunctionParameterSyntax(
+            firstName: .identifier("body", leadingTrivia: [.newlines(1), .spaces(4)]),
+            colon: .colonToken(),
+            type: OptionalTypeSyntax(
+              wrappedType: MemberTypeSyntax(
+                baseType: IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime")),
+                period: .periodToken(),
+                name: .identifier("HTTPBody")
+              ),
+              questionMark: .postfixQuestionMarkToken()
+            )
+          )
+          FunctionParameterSyntax(
+            firstName: .identifier("metadata", leadingTrivia: [.newlines(1), .spaces(4)]),
+            colon: .colonToken(),
+            type: MemberTypeSyntax(
+              baseType: IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime")),
+              period: .periodToken(),
+              name: .identifier("ServerRequestMetadata")
+            )
+          )
+        },
+        effectSpecifiers: FunctionEffectSpecifiersSyntax(
+          asyncSpecifier: .keyword(.async),
+          throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+        ),
+        returnClause: ReturnClauseSyntax(
+          type: TupleTypeSyntax(
+            elements: TupleTypeElementListSyntax {
+              TupleTypeElementSyntax(
+                type: MemberTypeSyntax(
+                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("HTTPTypes"))),
+                  period: .periodToken(),
+                  name: .identifier("HTTPResponse")
+                )
+              )
+              TupleTypeElementSyntax(
+                type: OptionalTypeSyntax(
+                  wrappedType: TypeSyntax(
+                    MemberTypeSyntax(
+                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime"))),
+                      period: .periodToken(),
+                      name: .identifier("HTTPBody")
+                    )),
+                  questionMark: .postfixQuestionMarkToken()
+                ))
+            }
+          )
+        )
+      )
+    ) {
+      TryExprSyntax(
+        leadingTrivia: [.newlines(1), .spaces(6)],
+        expression: AwaitExprSyntax(
+          expression: FunctionCallExprSyntax(
+            callee: DeclReferenceExprSyntax(baseName: .identifier("handle"))
+          ) {
+            LabeledExprSyntax(
+              label: .identifier("request", leadingTrivia: [.newlines(1), .spaces(8)]),
+              colon: .colonToken(),
+              expression: DeclReferenceExprSyntax(baseName: .identifier("request")),
+            )
+            LabeledExprSyntax(
+              label: .identifier("requestBody", leadingTrivia: [.newlines(1), .spaces(8)]),
+              colon: .colonToken(),
+              expression: DeclReferenceExprSyntax(baseName: .identifier("body"))
+            )
+            LabeledExprSyntax(
+              label: .identifier("metadata", leadingTrivia: [.newlines(1), .spaces(8)]),
+              colon: .colonToken(),
+              expression: DeclReferenceExprSyntax(baseName: .identifier("metadata"))
+            )
+            LabeledExprSyntax(
+              label: .identifier("forOperation", leadingTrivia: [.newlines(1), .spaces(8)]),
+              colon: .colonToken(),
+              expression: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("id")])
+            )
+            LabeledExprSyntax(
+              label: .identifier("using", leadingTrivia: [.newlines(1), .spaces(8)]),
+              colon: .colonToken(),
+              expression: ClosureExprSyntax {
+                FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(
+                    leadingTrivia: [.newlines(1), .spaces(10)],
+                    parts: [.identifier("APIHandler"), .identifier("\(prefix)_\(key)")]
+                  )
+                ) {
+                  LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: .dollarIdentifier("$0")))
+                }
+              }
+              .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(8)]))
+            )
+            LabeledExprSyntax(
+              label: .identifier("deserializer", leadingTrivia: [.newlines(1), .spaces(8)]),
+              colon: .colonToken(),
+              expression: makeDeserializerExpr(key: key, prefix: prefix, schema: schema, def: def, defMap: defMap)
+            )
+            LabeledExprSyntax(
+              label: .identifier("serializer", leadingTrivia: [.newlines(1), .spaces(8)]),
+              colon: .colonToken(),
+              expression: makeSerializerExpr()
+            )
+          }
+          .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(6)]))
+        )
+      )
+    }
+    .with(\.body!.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(2)]))
+  }
+
+  /// `deserializer`
+  private static func makeDeserializerExpr(key: String, prefix: String, schema: TypeSchema, def: ProcedureTypeDefinition, defMap: ExtDefMap) -> ClosureExprSyntax {
+    ClosureExprSyntax(signaturesBuilder: {
+      ClosureShorthandParameterSyntax(name: .identifier("request"))
+      ClosureShorthandParameterSyntax(name: .identifier("requestBody"))
+      ClosureShorthandParameterSyntax(name: .identifier("metadata"))
+    }) {
+      VariableDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        bindingSpecifier: .keyword(.let)
+      ) {
+        PatternBindingSyntax(
+          pattern: IdentifierPatternSyntax(identifier: .identifier("headers")),
+          typeAnnotation: TypeAnnotationSyntax(
+            colon: .colonToken(),
+            type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Headers")])
+          ),
+          initializer: InitializerClauseSyntax(
+            equal: .equalToken(),
+            value: FunctionCallExprSyntax(
+              callee: MemberAccessExprSyntax(declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`)))
+            ) {
+              LabeledExprSyntax(
+                label: .identifier("accept"),
+                colon: .colonToken(),
+                expression: TryExprSyntax(
+                  expression: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(parts: [
+                      .identifier("converter"),
+                      .identifier("extractAcceptHeaderIfPresent"),
+                    ])
+                  ) {
+                    LabeledExprSyntax(
+                      label: .identifier("in"),
+                      colon: .colonToken(),
+                      expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")])
+                    )
+                  })
+              )
+            }
+          )
+        )
+      }
+      VariableDeclSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        bindingSpecifier: .keyword(.let),
+        bindings: PatternBindingListSyntax([
+          PatternBindingSyntax(
+            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("contentType"))),
+            initializer: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(parts: [.identifier("converter"), .identifier("extractContentTypeIfPresent")])
+              ) {
+                LabeledExprSyntax(
+                  label: .identifier("in"),
+                  colon: .colonToken(),
+                  expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")])
+                )
+              }
+            )
+          )
+        ])
+      )
+      VariableDeclSyntax(
+        bindingSpecifier: .keyword(.let, leadingTrivia: [.newlines(1), .spaces(10)]),
+        bindings: PatternBindingListSyntax([
+          PatternBindingSyntax(
+            pattern: IdentifierPatternSyntax(identifier: .identifier("body")),
+            typeAnnotation: TypeAnnotationSyntax(
+              colon: .colonToken(),
+              type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Body")])
+            )
+          )
+        ])
+      )
+      genChosenContentType(key: key, def: def, prefix: prefix)
+      genInputBodySwitch(key: key, schema: schema, def: def, prefix: prefix, defMap: defMap)
+      ReturnStmtSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        expression: FunctionCallExprSyntax(
+          callee: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input")])
+        ) {
+          LabeledExprSyntax(
+            leadingTrivia: [.newlines(1), .spaces(12)],
+            label: .identifier("headers"),
+            colon: .colonToken(),
+            expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("headers"))),
+          )
+          LabeledExprSyntax(
+            leadingTrivia: [.newlines(1), .spaces(12)],
+            label: .identifier("body"),
+            colon: .colonToken(),
+            expression: DeclReferenceExprSyntax(baseName: .identifier("body"))
+          )
+        }
+        .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(10)]))
+      )
+    }
+    .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(8)]))
+  }
+  /// `serializer`
+  private static func makeSerializerExpr() -> ClosureExprSyntax {
+    ClosureExprSyntax(signaturesBuilder: {
+      ClosureShorthandParameterSyntax(name: .identifier("output"))
+      ClosureShorthandParameterSyntax(name: .identifier("request"))
+    }) {
+      SwitchExprSyntax(
+        leadingTrivia: [.newlines(1), .spaces(10)],
+        subject: DeclReferenceExprSyntax(baseName: .identifier("output")),
+      ) {
+        SwitchCaseSyntax(
+          label: SwitchCaseSyntax.Label(
+            SwitchCaseLabelSyntax(
+              leadingTrivia: [.newlines(1), .spaces(10)]) {
+                SwitchCaseItemSyntax(
+                  pattern: ExpressionPatternSyntax(
+                    expression: FunctionCallExprSyntax(
+                      callee: MemberAccessExprSyntax(declName: DeclReferenceExprSyntax(baseName: .identifier("ok")))
+                    ) {
+                      LabeledExprSyntax(
+                        expression: PatternExprSyntax(
+                          pattern: ValueBindingPatternSyntax(
+                            bindingSpecifier: .keyword(.let),
+                            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("value")))
+                          )))
+                    }
+                  ))
+              }
+          )
+        ) {
+          FunctionCallExprSyntax(
+            callee: DeclReferenceExprSyntax(baseName: .identifier("suppressUnusedWarning"))
+          ) {
+            LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("value"))))
+          }
+          .with(\.leadingTrivia, [.newlines(1), .spaces(12)])
+          VariableDeclSyntax(
+            leadingTrivia: [.newlines(1), .spaces(12)],
+            bindingSpecifier: .keyword(.var),
+            bindings: [
+              PatternBindingSyntax(
+                pattern: IdentifierPatternSyntax(identifier: .identifier("response")),
+                initializer: InitializerClauseSyntax(
+                  equal: .equalToken(),
+                  value: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(parts: [.identifier("HTTPTypes"), .identifier("HTTPResponse")])
+                  ) {
+                    LabeledExprSyntax(
+                      label: .identifier("soar_statusCode"),
+                      colon: .colonToken(),
+                      expression: IntegerLiteralExprSyntax(literal: .integerLiteral("201"))
+                    )
+                  }
+                )
+              )
+            ]
+          )
+          FunctionCallExprSyntax(
+            callee: DeclReferenceExprSyntax(baseName: .identifier("suppressMutabilityWarning", leadingTrivia: [.newlines(1), .spaces(10)]))
+          ) {
+            LabeledExprSyntax(
+              expression: InOutExprSyntax(
+                ampersand: .prefixAmpersandToken(),
+                expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("response")))
+              ))
+          }
+          VariableDeclSyntax(
+            bindingSpecifier: .keyword(.let, leadingTrivia: [.newlines(1), .spaces(12)]),
+            bindings: PatternBindingListSyntax([
+              PatternBindingSyntax(
+                pattern: IdentifierPatternSyntax(identifier: .identifier("body")),
+                typeAnnotation: TypeAnnotationSyntax(
+                  colon: .colonToken(),
+                  type: MemberTypeSyntax(
+                    baseType: IdentifierTypeSyntax(name: .identifier("OpenAPIRuntime")),
+                    period: .periodToken(),
+                    name: .identifier("HTTPBody")
+                  )
+                )
+              )
+            ])
+          )
+          ExpressionStmtSyntax(
+            expression: SwitchExprSyntax(
+              leadingTrivia: [.newlines(1), .spaces(12)],
+              subject: MemberAccessExprSyntax(parts: [.identifier("value"), .identifier("body")])
+            ) {
+              SwitchCaseSyntax(
+                label: SwitchCaseSyntax.Label(
+                  SwitchCaseLabelSyntax(
+                    leadingTrivia: [.newlines(1), .spaces(12)]) {
+                      SwitchCaseItemSyntax(
+                        pattern: ExpressionPatternSyntax(
+                          expression: FunctionCallExprSyntax(
+                            callee: MemberAccessExprSyntax(
+                              period: .periodToken(),
+                              declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                            )
+                          ) {
+                            LabeledExprSyntax(
+                              expression: PatternExprSyntax(
+                                pattern: ValueBindingPatternSyntax(
+                                  bindingSpecifier: .keyword(.let),
+                                  pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("value")))
+                                )))
+                          }
+                        ))
+                    }
+                )
+              ) {
+                TryExprSyntax(
+                  leadingTrivia: [.newlines(1), .spaces(14)],
+                  expression: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(parts: [
+                      .identifier("converter"),
+                      .identifier("validateAcceptIfPresent"),
+                    ])
+                  ) {
+                    LabeledExprSyntax(
+                      leadingTrivia: [.newlines(1), .spaces(16)],
+                      expression: StringLiteralExprSyntax(content: "application/json")
+                    )
+                    LabeledExprSyntax(
+                      label: .identifier("in", leadingTrivia: [.newlines(1), .spaces(16)]),
+                      colon: .colonToken(),
+                      expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")])
+                    )
+                  }
+                  .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(14)]))
+                )
+                SequenceExprSyntax {
+                  DeclReferenceExprSyntax(
+                    leadingTrivia: [.newlines(1), .spaces(14)],
+                    baseName: .identifier("body"))
+                  AssignmentExprSyntax(equal: .equalToken())
+                  TryExprSyntax(
+                    expression: FunctionCallExprSyntax(
+                      callee: MemberAccessExprSyntax(
+                        base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("converter"))),
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .identifier("setResponseBodyAsJSON"))
+                      )
+                    ) {
+                      LabeledExprSyntax(
+                        leadingTrivia: [.newlines(1), .spaces(16)],
+                        expression: DeclReferenceExprSyntax(baseName: .identifier("value")),
+                      )
+                      LabeledExprSyntax(
+                        leadingTrivia: [.newlines(1), .spaces(16)],
+                        label: .identifier("headerFields"),
+                        colon: .colonToken(),
+                        expression: InOutExprSyntax(
+                          ampersand: .prefixAmpersandToken(),
+                          expression: MemberAccessExprSyntax(parts: [.identifier("response"), .identifier("headerFields")])
+                        )
+                      )
+                      LabeledExprSyntax(
+                        leadingTrivia: [.newlines(1), .spaces(16)],
+                        label: .identifier("contentType"),
+                        colon: .colonToken(),
+                        expression: StringLiteralExprSyntax(content: "application/json; charset=utf-8")
+                      )
+                    }
+                    .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(14)]))
+                  )
+                }
+              }
+            }
+            .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(12)]))
+          )
+          ReturnStmtSyntax(
+            leadingTrivia: [.newlines(1), .spaces(12)],
+            expression: ExprSyntax(
+              TupleExprSyntax(
+                leftParen: .leftParenToken(),
+                elements: LabeledExprListSyntax([
+                  LabeledExprSyntax(
+                    expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("response"))),
+                    trailingComma: .commaToken()
+                  ),
+                  LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("body")))),
+                ]),
+                rightParen: .rightParenToken()
+              ))
+          )
+        }
+        SwitchCaseSyntax(
+          label: SwitchCaseSyntax.Label(
+            SwitchCaseLabelSyntax(
+              leadingTrivia: [.newlines(1), .spaces(10)]) {
+                SwitchCaseItemSyntax(
+                  pattern: ExpressionPatternSyntax(
+                    expression: FunctionCallExprSyntax(
+                      callee: MemberAccessExprSyntax(
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .identifier("undocumented"))
+                      )
+                    ) {
+                      LabeledExprSyntax(
+                        expression: PatternExprSyntax(
+                          pattern: PatternSyntax(
+                            ValueBindingPatternSyntax(
+                              bindingSpecifier: .keyword(.let),
+                              pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("statusCode")))
+                            )))
+                      )
+                      LabeledExprSyntax(expression: ExprSyntax(DiscardAssignmentExprSyntax(wildcard: .wildcardToken())))
+                    }
+                  ))
+              }
+          )
+        ) {
+          ReturnStmtSyntax(
+            leadingTrivia: [.newlines(1), .spaces(12)],
+            expression: TupleExprSyntax {
+              LabeledExprSyntax(
+                expression: FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(
+                    period: .periodToken(),
+                    declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+                  )
+                ) {
+                  LabeledExprSyntax(
+                    label: .identifier("soar_statusCode"),
+                    colon: .colonToken(),
+                    expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("statusCode")))
+                  )
+                },
+                trailingComma: .commaToken()
+              )
+              LabeledExprSyntax(expression: NilLiteralExprSyntax(nilKeyword: .keyword(.nil)))
+            }
+          )
+        }
+      }
+      .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(10)]))
+    }
+    .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(8)]))
+  }
+
+  private static func genChosenContentType(leadingTrivia: Trivia? = nil, key: String, def: ProcedureTypeDefinition, prefix: String) -> VariableDeclSyntax {
+    VariableDeclSyntax(
+      bindingSpecifier: .keyword(.let, leadingTrivia: [.newlines(1), .spaces(10)]),
+      bindings: [
+        PatternBindingSyntax(
+          pattern: IdentifierPatternSyntax(identifier: .identifier("chosenContentType")),
+          initializer: InitializerClauseSyntax(
+            equal: .equalToken(),
+            value: TryExprSyntax(
+              expression: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(
+                  base: DeclReferenceExprSyntax(baseName: .identifier("converter")),
+                  declName: DeclReferenceExprSyntax(baseName: .identifier("bestContentType"))
+                )
+              ) {
+                LabeledExprSyntax(
+                  leadingTrivia: [.newlines(1), .spaces(12)],
+                  label: .identifier("received"),
+                  colon: .colonToken(),
+                  expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("contentType"))),
+                )
+                LabeledExprSyntax(
+                  leadingTrivia: [.newlines(1), .spaces(12)],
+                  label: .identifier("options"),
+                  colon: .colonToken(),
+                  expression: ArrayExprSyntax {
+                    ArrayElementSyntax(
+                      expression: StringLiteralExprSyntax(content: def.input?.encoding.rawValue ?? "application/json")
+                    )
+                  }
+                )
+              }
+              .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(10)]))
+            )
+          )
+        )
+      ]
+    )
+  }
+
+  private static func genInputBodySwitch(leadingTrivia: Trivia? = nil, key: String, schema: TypeSchema, def: ProcedureTypeDefinition, prefix: String, defMap: ExtDefMap) -> SwitchExprSyntax {
+    SwitchExprSyntax(
+      leadingTrivia: [.newlines(1), .spaces(10)],
+      subject: DeclReferenceExprSyntax(baseName: .identifier("chosenContentType")),
+      rightBrace: .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(10)])
+    ) {
+      SwitchCaseSyntax(
+        label: SwitchCaseSyntax.Label(
+          SwitchCaseLabelSyntax(
+            leadingTrivia: [.newlines(1), .spaces(10)]) {
+              SwitchCaseItemSyntax(
+                pattern: ExpressionPatternSyntax(
+                  expression: StringLiteralExprSyntax(content: def.input?.encoding.rawValue ?? "application/json")
+                ))
+            }
+        )
+      ) {
+        SequenceExprSyntax {
+          let asType = def.inputType(fname: key, defMap: defMap, prefix: prefix, binaryTypeName: "HTTPBody")
+          DeclReferenceExprSyntax(baseName: .identifier("body", leadingTrivia: [.newlines(1), .spaces(12)]))
+          AssignmentExprSyntax(equal: .equalToken())
+          TryExprSyntax(
+            expression: def.isBinary ? makeGetRequiredRequestBodyAsBinary() : makeGetRequiredRequestBodyAsJSON(asType: asType)
+          )
+        }
+      }
+      SwitchCaseSyntax(
+        label: SwitchCaseSyntax.Label(
+          SwitchDefaultLabelSyntax(
+            leadingTrivia: [.newlines(1), .spaces(10)],
+            colon: .colonToken()
+          ))
+      ) {
+        FunctionCallExprSyntax(
+          callee: DeclReferenceExprSyntax(baseName: .identifier("preconditionFailure", leadingTrivia: [.newlines(1), .spaces(12)]))
+        ) {
+          LabeledExprSyntax(
+            expression: StringLiteralExprSyntax(
+              openingQuote: .stringQuoteToken(),
+              segments: StringLiteralSegmentListSyntax([
+                StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment("bestContentType chose an invalid content type.")))
+              ]),
+              closingQuote: .stringQuoteToken()
+            ))
+        }
+      }
+    }
+  }
+
+  private static func makeGetRequiredRequestBody(
+    leadingTrivia: Trivia? = nil,
+    asType: ExprSyntax,
+    converterMethod: String,
+    transformEnumCase: String,
+    isAwait: Bool = false
+  ) -> ExprSyntax {
+    let functionCall = FunctionCallExprSyntax(
+      callee: MemberAccessExprSyntax(
+        base: DeclReferenceExprSyntax(baseName: .identifier("converter")),
+        declName: DeclReferenceExprSyntax(baseName: .identifier(converterMethod))
+      )
+    ) {
+      LabeledExprSyntax(
+        expression: MemberAccessExprSyntax(base: asType, declName: DeclReferenceExprSyntax(baseName: .keyword(.self)))
+      )
+      LabeledExprSyntax(
+        label: .identifier("from", leadingTrivia: [.newlines(1), .spaces(14)]),
+        colon: .colonToken(),
+        expression: DeclReferenceExprSyntax(baseName: .identifier("requestBody"))
+      )
+      LabeledExprSyntax(
+        label: .identifier("transforming", leadingTrivia: [.newlines(1), .spaces(14)]),
+        colon: .colonToken(),
+        expression: ClosureExprSyntax(signaturesBuilder: {
+          ClosureShorthandParameterSyntax(name: .identifier("value"))
+        }) {
+          FunctionCallExprSyntax(
+            callee: MemberAccessExprSyntax(
+              leadingTrivia: [.newlines(1), .spaces(16)],
+              declName: DeclReferenceExprSyntax(baseName: .identifier(transformEnumCase))
+            )
+          ) {
+            LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: .identifier("value")))
+          }
+        }
+        .with(\.rightBrace, .rightBraceToken(leadingTrivia: [.newlines(1), .spaces(14)]))
+      )
+    }
+    .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(12)]))
+    let expression = isAwait ? ExprSyntax(AwaitExprSyntax(expression: functionCall)) : ExprSyntax(functionCall)
+    return expression.with(\.leadingTrivia, leadingTrivia ?? [])
+  }
+
+  private static func makeGetRequiredRequestBodyAsJSON(leadingTrivia: Trivia? = nil, asType: ExprSyntax) -> ExprSyntax {
+    makeGetRequiredRequestBody(
+      leadingTrivia: leadingTrivia,
+      asType: asType,
+      converterMethod: "getRequiredRequestBodyAsJSON",
+      transformEnumCase: "json",
+      isAwait: true
+    )
+  }
+
+  private static func makeGetRequiredRequestBodyAsBinary(leadingTrivia: Trivia? = nil) -> ExprSyntax {
+    makeGetRequiredRequestBody(
+      leadingTrivia: leadingTrivia,
+      asType: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("HTTPBody"))),
+      converterMethod: "getRequiredRequestBodyAsBinary",
+      transformEnumCase: "binary",
+      isAwait: false
+    )
+  }
+}

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -2,14 +2,18 @@ import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-public func main(outdir: String, path: String) async throws {
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
+public func main(outdir: String, path: String, generate: GenerateOption) async throws {
   let url = URL(filePath: path)
 
   let fileURLs = collectJSONFileURLs(at: url)
   let schemasMap = try await decodeSchemasByPrefix(from: fileURLs, baseURL: url)
   let defMap = Lex.buildExtDefMap(schemasMap: schemasMap)
   let outdirBaseURL = URL(filePath: outdir)
-  try await writeSchemaCode(for: schemasMap, with: defMap, to: outdirBaseURL)
+  try await writeSchemaCode(for: schemasMap, with: defMap, to: outdirBaseURL, generate: generate)
 }
 
 func collectJSONFileURLs(at baseURL: URL) -> [URL] {
@@ -63,7 +67,8 @@ func createOutputDirectory(for prefix: String, baseURL: URL) throws {
 func writeSchemaCode(
   for schemasMap: [String: [Schema]],
   with defMap: ExtDefMap,
-  to baseURL: URL
+  to baseURL: URL,
+  generate: GenerateOption
 ) async throws {
   try await withThrowingTaskGroup(of: Void.self) { group in
     let src = Lex.genUnknownRecord(for: schemasMap)
@@ -83,7 +88,7 @@ func writeSchemaCode(
         try await withThrowingTaskGroup(of: Void.self) { innerGroup in
           for schema in schemas {
             innerGroup.addTask {
-              if let src = Lex.genCode(for: schema, defMap: defMap) {
+              if let src = Lex.genCode(for: schema, defMap: defMap, generate: generate) {
                 let schemaURL = outdirURL.appending(path: "\(filePrefix)_\(schema.name).swift")
                 try src.write(to: schemaURL, atomically: true, encoding: .utf8)
               }
@@ -141,7 +146,7 @@ enum Lex {
     return src.formatted().description
   }
 
-  static func genCode(for schema: Schema, defMap: ExtDefMap) -> String? {
+  static func genCode(for schema: Schema, defMap: ExtDefMap, generate: GenerateOption) -> String? {
     let prefix = schema.prefix
     let structName = Lex.structNameFor(prefix: prefix)
     let allTypes = schema.allTypes(prefix: prefix).sorted(by: {
@@ -167,7 +172,13 @@ enum Lex {
         if enumExtensionIsNeeded {
           ExtensionDeclSyntax(extendedType: TypeSyntax(stringLiteral: structName)) {
             for (i, (name, ot)) in otherTypes.enumerated() {
-              ot.lex(leadingTrivia: i == 0 ? nil : .newlines(2), name: name, type: (ot.defName.isEmpty || ot.defName == "main") ? ot.id : "\(ot.id)#\(ot.defName)", defMap: defMap)
+              ot.lex(
+                leadingTrivia: i == 0 ? nil : .newlines(2),
+                name: name,
+                type: (ot.defName.isEmpty || ot.defName == "main") ? ot.id : "\(ot.id)#\(ot.defName)",
+                defMap: defMap,
+                generate: generate
+              )
             }
             for method in methods {
               TypeAliasDeclSyntax(
@@ -229,7 +240,13 @@ enum Lex {
           }
         }
         for (i, (name, ot)) in recordTypes.enumerated() {
-          ot.lex(leadingTrivia: (!enumExtensionIsNeeded && i == 0) ? nil : .newlines(2), name: name, type: (ot.defName.isEmpty || ot.defName == "main") ? ot.id : "\(ot.id)#\(ot.defName)", defMap: defMap)
+          ot.lex(
+            leadingTrivia: (!enumExtensionIsNeeded && i == 0) ? nil : .newlines(2),
+            name: name,
+            type: (ot.defName.isEmpty || ot.defName == "main") ? ot.id : "\(ot.id)#\(ot.defName)",
+            defMap: defMap,
+            generate: generate
+          )
         }
       },
       trailingTrivia: .newline)

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -74,6 +74,11 @@ func writeSchemaCode(
     let src = Lex.genUnknownRecord(for: schemasMap)
     let recordURL = baseURL.appending(path: "UnknownATPValue.swift")
     try src.write(to: recordURL, atomically: true, encoding: .utf8)
+    if generate.contains(.server) {
+      let serverSrc = Lex.genXRPCAPIProtocolFile(for: schemasMap, defMap: defMap)
+      let serverURL = baseURL.appending(path: "XRPCAPIProtocol.swift")
+      try serverSrc.write(to: serverURL, atomically: true, encoding: .utf8)
+    }
     for (prefix, schemas) in schemasMap {
       try createOutputDirectory(for: prefix, baseURL: baseURL)
       group.addTask {
@@ -112,7 +117,7 @@ extension URL {
 }
 
 enum Lex {
-  private static var fileHeader: Trivia {
+  static var fileHeader: Trivia {
     Trivia(pieces: [
       .lineComment("//"),
       .newlines(1),
@@ -166,11 +171,28 @@ enum Lex {
           path: [ImportPathComponentSyntax(name: "SwiftAtproto")]
         )
         ImportDeclSyntax(
-          path: [ImportPathComponentSyntax(name: "Foundation")],
-          trailingTrivia: .newlines(2)
+          path: [ImportPathComponentSyntax(name: "Foundation")]
         )
+        if generate.contains(.server) {
+          ImportDeclSyntax(
+            attributes: AttributeListSyntax {
+              AttributeSyntax(
+                atSign: .atSignToken(),
+                attributeName: IdentifierTypeSyntax(name: .identifier("_spi")),
+                leftParen: .leftParenToken(),
+                arguments: AttributeSyntax.Arguments([
+                  LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("Generated"))))
+                ]),
+                rightParen: .rightParenToken()
+              )
+            },
+            path: [
+              ImportPathComponentSyntax(name: .identifier("OpenAPIRuntime"))
+            ]
+          )
+        }
         if enumExtensionIsNeeded {
-          ExtensionDeclSyntax(extendedType: TypeSyntax(stringLiteral: structName)) {
+          ExtensionDeclSyntax(leadingTrivia: .newlines(2), extendedType: TypeSyntax(stringLiteral: structName)) {
             for (i, (name, ot)) in otherTypes.enumerated() {
               ot.lex(
                 leadingTrivia: i == 0 ? nil : .newlines(2),
@@ -226,7 +248,7 @@ enum Lex {
             }
           }
         }
-        if !methods.isEmpty {
+        if generate.contains(.client) && !methods.isEmpty {
           ExtensionDeclSyntax(extendedType: TypeSyntax(stringLiteral: "XRPCClientProtocol")) {
             for method in methods {
               writeMethod(
@@ -239,9 +261,9 @@ enum Lex {
             }
           }
         }
-        for (i, (name, ot)) in recordTypes.enumerated() {
+        for (name, ot) in recordTypes {
           ot.lex(
-            leadingTrivia: (!enumExtensionIsNeeded && i == 0) ? nil : .newlines(2),
+            leadingTrivia: .newlines(2),
             name: name,
             type: (ot.defName.isEmpty || ot.defName == "main") ? ot.id : "\(ot.id)#\(ot.defName)",
             defMap: defMap,

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -2,6 +2,10 @@ import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 struct TypeInfo {
   let name: String
   let type: TypeSchema
@@ -414,22 +418,22 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
     }
   }
 
-  func lex(leadingTrivia: Trivia? = nil, name: String, type typeName: String, defMap: ExtDefMap) -> DeclSyntaxProtocol {
+  func lex(leadingTrivia: Trivia? = nil, name: String, type typeName: String, defMap: ExtDefMap, generate: GenerateOption) -> DeclSyntaxProtocol {
     switch type {
     case .string(let def):
-      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap)
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .object(let def):
-      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap)
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .record(let def):
-      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap)
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .union(let def):
-      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap)
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .array(let def):
-      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap)
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .procedure(let def):
-      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap)
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .query(let def):
-      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap)
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     default:
       fatalError()
     }

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -320,7 +320,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
   func writeRPC(leadingTrivia: Trivia? = nil, def: any HTTPAPITypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String) -> DeclSyntaxProtocol {
     let fname = typeName
     let arguments = def.rpcArguments(ts: self, fname: fname, defMap: defMap, prefix: prefix)
-    let output = def.rpcOutput(ts: self, fname: fname, defMap: defMap, prefix: prefix)
+    let output = def.rpcOutput(fname: fname, defMap: defMap, prefix: prefix)
     return FunctionDeclSyntax(
       leadingTrivia: leadingTrivia,
       modifiers: [
@@ -563,6 +563,38 @@ struct OutputType: Encodable, DecodableWithConfiguration {
     encoding = try container.decode(EncodingType.self, forKey: .encoding)
     schema = try container.decodeIfPresent(TypeSchema.self, forKey: .schema, configuration: configuration)
     description = try container.decodeIfPresent(String.self, forKey: .description)
+  }
+
+  func typeName(fname: String, prefix: String, defMap: ExtDefMap, binaryTypeName: String = "Data", isOutput: Bool) -> TokenSyntax {
+    switch encoding {
+    case .json, .jsonl:
+      let token: String = {
+        guard let schema = schema else {
+          return "EmptyResponse"
+        }
+        let outname: String
+        if case .ref(let def) = schema.type {
+          (_, outname) = schema.namesFromRef(ref: def.ref, defMap: defMap)
+        } else {
+          outname = isOutput ? "\(fname)_Output" : "\(fname)_Input"
+        }
+        return "\(prefix).\(outname)"
+      }()
+      return .identifier(token)
+    case .text:
+      return .identifier("String")
+    case .cbor, .car, .any, .mp4:
+      return .identifier(binaryTypeName)
+    }
+  }
+
+  var isBinary: Bool {
+    switch encoding {
+    case .cbor, .car, .any, .mp4:
+      true
+    default:
+      false
+    }
   }
 }
 

--- a/Sources/SwiftAtprotoLex/misc.swift
+++ b/Sources/SwiftAtprotoLex/misc.swift
@@ -60,3 +60,16 @@ private let keywords: [String] = [
 func isNeedEscapingKeyword(_ string: String) -> Bool {
   keywords.contains(string)
 }
+
+#if !os(macOS) && !os(Linux)
+  public struct GenerateOption: OptionSet, Codable, Sendable {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+      self.rawValue = rawValue
+    }
+
+    public static let client = Self(rawValue: 1 << 0)
+    public static let server = Self(rawValue: 1 << 1)
+  }
+#endif


### PR DESCRIPTION
This PR introduces the ability to generate server-side boilerplate code from Lexicon definitions. It allows developers to specify whether to generate client code, server code, or both, via a new configuration option.