### PR TITLE
Introduce change detection for LexiconConfig using SHA256 hashing

### DIFF
--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -24,11 +24,11 @@ struct Lexgen: AsyncParsableCommand {
 
   mutating func run() async throws {
     #if os(macOS)
-      let configurationtURL = URL(filePath: configuration)
-      let data = try Data(contentsOf: configurationtURL)
+      let configurationURL = URL(filePath: configuration)
+      let data = try Data(contentsOf: configurationURL)
       let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
       let module = outdir ?? config.module ?? Self.defaultModulePath
-      let rootURL = configurationtURL.deletingLastPathComponent()
+      let rootURL = configurationURL.deletingLastPathComponent()
       try SourceControl.main(rootURL: rootURL, config: config, module: module)
       try await SwiftAtprotoLex.main(
         outdir: module,

--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -25,13 +25,10 @@ struct Lexgen: AsyncParsableCommand {
   mutating func run() async throws {
     #if os(macOS)
       let configurationURL = URL(filePath: configuration)
-      let data = try Data(contentsOf: configurationURL)
-      let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
-      let module = outdir ?? config.module ?? Self.defaultModulePath
       let rootURL = configurationURL.deletingLastPathComponent()
-      try SourceControl.main(rootURL: rootURL, config: config, module: module)
+      let config = try SourceControl.main(configurationURL: configurationURL, outdir: outdir)
       try await SwiftAtprotoLex.main(
-        outdir: module,
+        outdir: config.module,
         path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path(),
         generate: config.generate
       )

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f562a622b82ffeff7911b55df18b3d581d563a79486e217428f74748e5934998",
+  "originHash" : "91c49faba1ec09c67cc0286b8f448e1b23ebb046c67db996cecd31b43fa35591",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -38,6 +38,15 @@
       }
     },
     {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "810496cf121e525d660cd0ea89a758740476b85f",
+        "version" : "1.5.1"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
@@ -71,6 +80,15 @@
       "state" : {
         "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
         "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto",
+      "state" : {
+        "revision" : "b828ba476ab068f0b00d6b41f92f364961b0f323",
+        "version" : "3.10.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.3.1"),
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),
+    .package(url: "https://github.com/apple/swift-crypto", exact: "3.10.2"),
   ],
   targets: [
     .target(
@@ -49,7 +50,10 @@ let package = Package(
       ]
     ),
     .target(
-      name: "SourceControl"
+      name: "SourceControl",
+      dependencies: [
+        .product(name: "Crypto", package: "swift-crypto")
+      ]
     ),
     .executableTarget(
       name: "swift-atproto",

--- a/Sources/SourceControl/GitRepository.swift
+++ b/Sources/SourceControl/GitRepository.swift
@@ -103,6 +103,17 @@ public final class GitRepository {
     }
   }
 
+  public func fetch() throws {
+    try lock.withLock {
+      _ = try callGit([
+        "remote",
+        "-v",
+        "update",
+        "-p",
+      ])
+    }
+  }
+
   func isBare() throws -> Bool {
     try lock.withLock {
       let output = try callGit([

--- a/Sources/SourceControl/LexiconConfig.swift
+++ b/Sources/SourceControl/LexiconConfig.swift
@@ -45,7 +45,7 @@ public struct GenerateOption: OptionSet, Codable, Sendable {
 
 public struct LexiconConfig: Codable, Sendable {
   public let dependencies: [LexiconDependency]
-  public let module: String?
+  public let module: String
   public let generate: GenerateOption
 
   enum CodingKeys: String, CodingKey {
@@ -57,9 +57,11 @@ public struct LexiconConfig: Codable, Sendable {
   public init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     dependencies = try container.decode([LexiconDependency].self, forKey: .dependencies)
-    module = try container.decodeIfPresent(String.self, forKey: .module)
+    module = try container.decodeIfPresent(String.self, forKey: .module) ?? Self.defaultModule
     generate = try container.decodeIfPresent(GenerateOption.self, forKey: .generate) ?? .client
   }
+
+  private static let defaultModule = "Sources/Lexicon"
 }
 
 public struct LexiconDependency: Codable, Sendable {

--- a/Sources/SourceControl/LexiconsStore.swift
+++ b/Sources/SourceControl/LexiconsStore.swift
@@ -1,15 +1,29 @@
 import Foundation
 
 public struct LexiconsStore: Codable {
+  public let originHash: String?
   public let generator: String
   public let module: String
   public let dependencies: [ResolvedLexiconDependency]
+
+  public init(originHash: String, generator: String, module: String, dependencies: [ResolvedLexiconDependency]) {
+    self.originHash = originHash
+    self.generator = generator
+    self.module = module
+    self.dependencies = dependencies
+  }
 
   public func write(to url: URL) throws {
     let encoder = JSONEncoder()
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
     let data = try encoder.encode(self)
     try data.write(to: url)
+  }
+
+  public static func load(from url: URL) throws -> Self {
+    let data = try Data(contentsOf: url)
+    let decoder = JSONDecoder()
+    return try decoder.decode(Self.self, from: data)
   }
 }
 

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -1,3 +1,4 @@
+import Crypto
 import Foundation
 
 public var version: String { "0.33.0" }
@@ -28,9 +29,19 @@ public func lexiconsDirectoryURL(packageRootURL: URL) -> URL {
   packageRootURL.appending(components: ".lexicons", "lexicons")
 }
 
-public func main(rootURL: URL, config: LexiconConfig, module: String) throws {
+public func lockFileURL(packageRootURL: URL) -> URL {
+  packageRootURL.appending(component: ".atproto-lock.json")
+}
+
+public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig {
+  let data = try Data(contentsOf: configurationURL)
+  let originHash = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+  let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
+  let module = outdir ?? config.module
+  let rootURL = configurationURL.deletingLastPathComponent()
   let checkoutDirectory = checkoutDirectoryURL(packageRootURL: rootURL)
   let lexiconsDirectory = lexiconsDirectoryURL(packageRootURL: rootURL)
+  let lockFileURL = lockFileURL(packageRootURL: rootURL)
 
   if !FileManager.default.fileExists(atPath: lexiconsDirectory.path()) {
     try FileManager.default.createDirectory(at: lexiconsDirectory, withIntermediateDirectories: true)
@@ -42,21 +53,32 @@ public func main(rootURL: URL, config: LexiconConfig, module: String) throws {
       name = String(name.dropLast(4))
     }
     let destURL = checkoutDirectory.appending(component: name)
+    let clone: GitRepository
     if !GitRepositoryProvider.workingCopyExists(at: destURL.path()) {
-      let clone = try GitRepositoryProvider.createWorkingCopy(
+      clone = try GitRepositoryProvider.createWorkingCopy(
         sourcePath: dependency.location.absoluteString,
         at: destURL.path())
-      let revision: String
-      switch dependency.state {
-      case .tag(let tag):
-        try clone.checkout(tag: tag)
-        revision = try clone.resolveRevision(tag: tag)
-      case .revision(let identifier):
-        revision = try clone.resolveRevision(identifier: identifier)
-        try clone.checkout(revision: revision)
+    } else {
+      if let resolvedStore = try? LexiconsStore.load(from: lockFileURL),
+        originHash == resolvedStore.originHash
+      {
+        return config
       }
-      resolvedDendencies.append(.init(config: dependency, revision: revision))
+      clone = GitRepositoryProvider.openWorkingCopy(at: destURL.path())
+      // try clone.fetch()
     }
+
+    let revision: String
+    switch dependency.state {
+    case .tag(let tag):
+      try clone.checkout(tag: tag)
+      revision = try clone.resolveRevision(tag: tag)
+    case .revision(let identifier):
+      revision = try clone.resolveRevision(identifier: identifier)
+      try clone.checkout(revision: revision)
+    }
+    resolvedDendencies.append(.init(config: dependency, revision: revision))
+
     for lexicon in dependency.lexicons {
       let srcBaseURL = destURL.appending(component: lexicon.path)
       for name in try FileManager.default.contentsOfDirectory(atPath: srcBaseURL.path()) {
@@ -72,8 +94,8 @@ public func main(rootURL: URL, config: LexiconConfig, module: String) throws {
       }
     }
   }
-  if resolvedDendencies.count == config.dependencies.count {
-    let store = LexiconsStore(generator: version, module: module, dependencies: resolvedDendencies)
-    try store.write(to: rootURL.appending(component: ".atproto-lock.json"))
-  }
+  guard resolvedDendencies.count == config.dependencies.count else { return config }
+  let store = LexiconsStore(originHash: originHash, generator: version, module: module, dependencies: resolvedDendencies)
+  try store.write(to: lockFileURL)
+  return config
 }


### PR DESCRIPTION
This PR introduces a change detection mechanism to the lexicon generation process.

The tool now generates a SHA256 hash of the input configuration file (.atproto.json) and stores it as originHash inside the .atproto-lock.json file. On subsequent runs, the tool compares the current configuration's hash with the one stored in the lock file. If they match, the generation process is skipped, avoiding unnecessary remote repository checks and file I/O.