### PR TITLE
Add SwiftPM build plugin support

### DIFF
--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -20,6 +20,8 @@ struct Lexgen: AsyncParsableCommand {
     var configuration: String
     @Option(name: .long)
     var outdir: String?
+    @Flag(name: .customLong("fetch-only"))
+    var fetchOnly = false
   #endif
 
   mutating func run() async throws {
@@ -27,6 +29,7 @@ struct Lexgen: AsyncParsableCommand {
       let configurationURL = URL(filePath: configuration)
       let rootURL = configurationURL.deletingLastPathComponent()
       let config = try SourceControl.main(configurationURL: configurationURL, outdir: outdir)
+      guard !fetchOnly else { return }
       try await SwiftAtprotoLex.main(
         outdir: config.module,
         path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path(),

--- a/Package.swift
+++ b/Package.swift
@@ -114,6 +114,17 @@ let package = Package(
       dependencies: ["ATProtoCrypto"]
     ),
     .plugin(
+      name: "ATProtoLexiconFetcher",
+      capability: .command(
+        intent: .custom(verb: "swift-atproto-fetch", description: "Fetch AT Protocol lexicons files from remote resources."),
+        permissions: [
+          .writeToPackageDirectory(reason: "To save the downloaded lexicons to your project."),
+          .allowNetworkConnections(scope: .all(ports: [443]), reason: "fetch lexicons"),
+        ]
+      ),
+      dependencies: [.target(name: "swift-atproto")],
+    ),
+    .plugin(
       name: "Generate Source Code",
       capability: .command(
         intent: .custom(verb: "swift-atproto", description: "Formats Swift source files using SwiftFormat"),
@@ -124,5 +135,6 @@ let package = Package(
       ),
       dependencies: [.target(name: "swift-atproto")],
       path: "Plugins/SwiftAtprotoPlugin"),
+    .plugin(name: "ATProtoGenerator", capability: .buildTool(), dependencies: ["swift-atproto"]),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,8 +23,16 @@ let package = Package(
       targets: ["swift-atproto"]
     ),
     .plugin(
+      name: "ATProtoLexiconFetcher",
+      targets: ["ATProtoLexiconFetcher"]
+    ),
+    .plugin(
       name: "SwiftAtprotoPlugin",
       targets: ["Generate Source Code"]
+    ),
+    .plugin(
+      name: "ATProtoGenerator",
+      targets: ["ATProtoGenerator"]
     ),
   ],
   dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
     .plugin(
       name: "Generate Source Code",
       capability: .command(
-        intent: .custom(verb: "swift-atproto", description: "Formats Swift source files using SwiftFormat"),
+        intent: .custom(verb: "swift-atproto", description: "Generate source code from AT Protocol definitions."),
         permissions: [
           .writeToPackageDirectory(reason: "This command reformats source files"),
           .allowNetworkConnections(scope: .all(ports: [443]), reason: "fetch lexicons"),

--- a/Plugins/ATProtoGenerator/plugin.swift
+++ b/Plugins/ATProtoGenerator/plugin.swift
@@ -1,0 +1,64 @@
+import Foundation
+import PackagePlugin
+
+@main struct ATProtoGeneratorPlugin {
+  func createBuildCommands(
+    pluginWorkDirectoryURL: URL,
+    configurationFileURL: URL,
+    tool: (String) throws -> PluginContext.Tool,
+    sourceFiles: FileList,
+    targetName: String
+  ) throws -> [Command] {
+    let tool = try tool("swift-atproto")
+    let codeGenerationExec = tool.url
+    var arguments = [String]()
+    let outdir = pluginWorkDirectoryURL.appending(components: "GeneratedSources")
+    arguments.append(contentsOf: ["--atproto-configuration", configurationFileURL.path()])
+    arguments.append(contentsOf: ["--outdir", outdir.path()])
+    return [
+      .buildCommand(
+        displayName: "Running swift-atproto-generator",
+        executable: codeGenerationExec,
+        arguments: arguments,
+        environment: [:],
+        inputFiles: [configurationFileURL],
+        outputFiles: [
+          outdir.appending(component: "UnknownATPValue.swift"),
+          outdir.appending(component: "XRPCAPIProtocol.swift"),
+          outdir.appending(component: "XRPCAPIClient.swift"),
+        ]
+      )
+    ]
+  }
+}
+
+extension ATProtoGeneratorPlugin: BuildToolPlugin {
+  func createBuildCommands(context: PluginContext, target: Target) async throws -> [Command] {
+    guard let swiftTarget = target as? SwiftSourceModuleTarget else {
+      fatalError()
+    }
+    return try createBuildCommands(
+      pluginWorkDirectoryURL: context.pluginWorkDirectoryURL,
+      configurationFileURL: context.package.directoryURL.appending(component: ".atproto.json"),
+      tool: context.tool,
+      sourceFiles: swiftTarget.sourceFiles,
+      targetName: target.name
+    )
+  }
+}
+
+#if canImport(XcodeProjectPlugin)
+  import XcodeProjectPlugin
+
+  extension ATProtoGeneratorPlugin: XcodeBuildToolPlugin {
+    func createBuildCommands(context: XcodePluginContext, target: XcodeTarget) throws -> [Command] {
+      try createBuildCommands(
+        pluginWorkDirectoryURL: context.pluginWorkDirectoryURL,
+        configurationFileURL: context.xcodeProject.directoryURL.appending(component: ".atproto.json"),
+        tool: context.tool,
+        sourceFiles: target.inputFiles,
+        targetName: target.displayName
+      )
+    }
+  }
+#endif

--- a/Plugins/ATProtoLexiconFetcher/plugin.swift
+++ b/Plugins/ATProtoLexiconFetcher/plugin.swift
@@ -1,0 +1,70 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct SwiftAtprotoPlugin {
+  func codeGenerate(tool: PluginContext.Tool, outputDirectoryPath: String?, configurationFilePath: String?) throws {
+    let codeGenerationExec = tool.url
+    var arguments = [String]()
+    if let configurationFilePath {
+      arguments.append(contentsOf: ["--atproto-configuration", configurationFilePath])
+    }
+    if let outputDirectoryPath {
+      arguments.append(contentsOf: ["--outdir", outputDirectoryPath])
+    }
+    arguments.append("--fetch-only")
+    let process = try Process.run(codeGenerationExec, arguments: arguments)
+    process.waitUntilExit()
+
+    if process.terminationReason == .exit, process.terminationStatus == 0 {
+      print("lexicon files are downloaded")
+    } else {
+      let problem = "\(process.terminationReason):\(process.terminationStatus)"
+      Diagnostics.error("swift-atproto invocation failed: \(problem)")
+    }
+  }
+}
+
+extension SwiftAtprotoPlugin: CommandPlugin {
+  func performCommand(
+    context: PluginContext,
+    arguments: [String]
+  ) async throws {
+    let codeGenerationTool = try context.tool(named: "swift-atproto")
+    var argExtractor = ArgumentExtractor(arguments)
+    let configurationFilePath: String? =
+      if argExtractor.extractOption(named: "atproto-configuration").first == nil {
+        context.package.directoryURL.appending(component: ".atproto.json").path()
+      } else {
+        nil
+      }
+    let outputDirectoryPath = argExtractor.extractOption(named: "outdir").first
+    try codeGenerate(
+      tool: codeGenerationTool,
+      outputDirectoryPath: outputDirectoryPath,
+      configurationFilePath: configurationFilePath)
+  }
+}
+
+#if canImport(XcodeProjectPlugin)
+  import XcodeProjectPlugin
+
+  extension SwiftAtprotoPlugin: XcodeCommandPlugin {
+    func performCommand(context: XcodeProjectPlugin.XcodePluginContext, arguments: [String]) throws {
+      let codeGenerationTool = try context.tool(named: "swift-atproto")
+      var argExtractor = ArgumentExtractor(arguments)
+      let configurationFilePath: String? =
+        if argExtractor.extractOption(named: "atproto-configuration").first == nil {
+          context.xcodeProject.directoryURL.appending(component: ".atproto.json").path()
+        } else {
+          nil
+        }
+
+      let outputDirectoryPath = argExtractor.extractOption(named: "outdir").first
+      try codeGenerate(
+        tool: codeGenerationTool,
+        outputDirectoryPath: outputDirectoryPath,
+        configurationFilePath: configurationFilePath)
+    }
+  }
+#endif

--- a/Sources/SourceControl/LexiconConfig.swift
+++ b/Sources/SourceControl/LexiconConfig.swift
@@ -43,7 +43,7 @@ public struct GenerateOption: OptionSet, Codable, Sendable {
   public static let server = Self(rawValue: 1 << 1)
 }
 
-public struct LexiconConfig: Codable, Sendable {
+public struct LexiconConfig: Encodable, DecodableWithConfiguration, Sendable {
   public let dependencies: [LexiconDependency]
   public let module: String
   public let generate: GenerateOption
@@ -54,10 +54,10 @@ public struct LexiconConfig: Codable, Sendable {
     case generate
   }
 
-  public init(from decoder: Decoder) throws {
+  public init(from decoder: Decoder, configuration outdir: String?) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     dependencies = try container.decode([LexiconDependency].self, forKey: .dependencies)
-    module = try container.decodeIfPresent(String.self, forKey: .module) ?? Self.defaultModule
+    module = try outdir ?? container.decodeIfPresent(String.self, forKey: .module) ?? Self.defaultModule
     generate = try container.decodeIfPresent(GenerateOption.self, forKey: .generate) ?? .client
   }
 

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -36,8 +36,8 @@ public func lockFileURL(packageRootURL: URL) -> URL {
 public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig {
   let data = try Data(contentsOf: configurationURL)
   let originHash = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
-  let config = try JSONDecoder().decode(LexiconConfig.self, from: data)
-  let module = outdir ?? config.module
+  let config = try JSONDecoder().decode(LexiconConfig.self, from: data, configuration: outdir)
+
   let rootURL = configurationURL.deletingLastPathComponent()
   let checkoutDirectory = checkoutDirectoryURL(packageRootURL: rootURL)
   let lexiconsDirectory = lexiconsDirectoryURL(packageRootURL: rootURL)
@@ -95,7 +95,7 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
     }
   }
   guard resolvedDendencies.count == config.dependencies.count else { return config }
-  let store = LexiconsStore(originHash: originHash, generator: version, module: module, dependencies: resolvedDendencies)
+  let store = LexiconsStore(originHash: originHash, generator: version, module: config.module, dependencies: resolvedDendencies)
   try store.write(to: lockFileURL)
   return config
 }

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -74,11 +74,14 @@ func writeSchemaCode(
     let src = Lex.genUnknownRecord(for: schemasMap)
     let recordURL = baseURL.appending(path: "UnknownATPValue.swift")
     try src.write(to: recordURL, atomically: true, encoding: .utf8)
+    let serverSrc: String
     if generate.contains(.server) {
-      let serverSrc = Lex.genXRPCAPIProtocolFile(for: schemasMap, defMap: defMap)
-      let serverURL = baseURL.appending(path: "XRPCAPIProtocol.swift")
-      try serverSrc.write(to: serverURL, atomically: true, encoding: .utf8)
+      serverSrc = Lex.genXRPCAPIProtocolFile(for: schemasMap, defMap: defMap)
+    } else {
+      serverSrc = ""
     }
+    let serverURL = baseURL.appending(path: "XRPCAPIProtocol.swift")
+    try serverSrc.write(to: serverURL, atomically: true, encoding: .utf8)
     for (i, (prefix, schemas)) in schemasMap.enumerated() {
       group.addTask {
         let baseSrc = Lex.baseFile(prefix: prefix)

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -70,7 +70,7 @@ func writeSchemaCode(
   to baseURL: URL,
   generate: GenerateOption
 ) async throws {
-  try await withThrowingTaskGroup(of: Void.self) { group in
+  var srcs = try await withThrowingTaskGroup(of: (String?, Int).self) { group in
     let src = Lex.genUnknownRecord(for: schemasMap)
     let recordURL = baseURL.appending(path: "UnknownATPValue.swift")
     try src.write(to: recordURL, atomically: true, encoding: .utf8)
@@ -79,32 +79,45 @@ func writeSchemaCode(
       let serverURL = baseURL.appending(path: "XRPCAPIProtocol.swift")
       try serverSrc.write(to: serverURL, atomically: true, encoding: .utf8)
     }
-    for (prefix, schemas) in schemasMap {
-      try createOutputDirectory(for: prefix, baseURL: baseURL)
+    for (i, (prefix, schemas)) in schemasMap.enumerated() {
       group.addTask {
-        let filePrefix = prefix.split(separator: ".").joined()
-        let outdirURL = baseURL.appending(path: filePrefix)
-
-        let enumName = Lex.structNameFor(prefix: prefix)
-        let baseFileURL = outdirURL.appending(path: "\(enumName).swift")
         let baseSrc = Lex.baseFile(prefix: prefix)
-        try baseSrc.write(to: baseFileURL, atomically: true, encoding: .utf8)
-
-        try await withThrowingTaskGroup(of: Void.self) { innerGroup in
-          for schema in schemas {
+        let srcs = try await withThrowingTaskGroup(of: (String?, Int).self) { innerGroup in
+          for (j, schema) in schemas.enumerated() {
             innerGroup.addTask {
-              if let src = Lex.genCode(for: schema, defMap: defMap, generate: generate) {
-                let schemaURL = outdirURL.appending(path: "\(filePrefix)_\(schema.name).swift")
-                try src.write(to: schemaURL, atomically: true, encoding: .utf8)
-              }
+              let src: String? = Lex.genCode(for: schema, defMap: defMap, generate: generate)
+              return (src, j)
             }
           }
-          try await innerGroup.waitForAll()
+          var srcs: [String?] = Array(repeating: nil, count: schemas.count)
+          for try await (src, j) in innerGroup {
+            srcs[j] = src
+          }
+          return srcs
         }
+        return (baseSrc + srcs.compactMap({ $0 }).joined(separator: "\n"), i)
       }
     }
-    try await group.waitForAll()
+    var srcs: [String?] = Array(repeating: nil, count: schemasMap.count)
+    for try await (src, i) in group {
+      srcs[i] = src
+    }
+    return srcs
   }
+  srcs.insert(
+    SourceFileSyntax(leadingTrivia: Lex.fileHeader) {
+      ImportDeclSyntax(
+        path: [ImportPathComponentSyntax(name: "Foundation")]
+      )
+      ImportDeclSyntax(
+        path: [ImportPathComponentSyntax(name: "SwiftAtproto")],
+        trailingTrivia: .newlines(2)
+      )
+    }.formatted().description, at: 0)
+
+  let clientSrc = srcs.compactMap({ $0 }).joined(separator: "\n")
+  let clientURL = baseURL.appending(path: "XRPCAPIClient.swift")
+  try clientSrc.write(to: clientURL, atomically: true, encoding: .utf8)
 }
 
 extension URL {
@@ -134,12 +147,7 @@ enum Lex {
 
   static func baseFile(prefix: String) -> String {
     let src = SourceFileSyntax(
-      leadingTrivia: Self.fileHeader,
       statementsBuilder: {
-        ImportDeclSyntax(
-          path: [ImportPathComponentSyntax(name: "SwiftAtproto")],
-          trailingTrivia: .newlines(2)
-        )
         EnumDeclSyntax(
           modifiers: [
             DeclModifierSyntax(name: .keyword(.public))
@@ -165,14 +173,7 @@ enum Lex {
       return nil
     }
     let src = SourceFileSyntax(
-      leadingTrivia: Self.fileHeader,
       statementsBuilder: {
-        ImportDeclSyntax(
-          path: [ImportPathComponentSyntax(name: "SwiftAtproto")]
-        )
-        ImportDeclSyntax(
-          path: [ImportPathComponentSyntax(name: "Foundation")]
-        )
         if generate.contains(.server) {
           ImportDeclSyntax(
             attributes: AttributeListSyntax {


### PR DESCRIPTION
This PR adds SwiftPM plugin support for working with AT Protocol lexicons.

It introduces a command plugin for fetching lexicons and a build tool plugin
that runs `swift-atproto` to generate source code during the build.