### PR TITLE
Relax swift-syntax dependency version requirement

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "28fb83f544045a023a5b77b4bbe6d17fc11acf61601ae80f0802b1b7d97f8050",
+  "originHash" : "88a0a0ff61f7cf61689c113932f46c958068c7c8ba048f3f17b6083fc4c36844",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -213,8 +213,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/swift-libp2p/swift-cid", exact: "0.0.1"),
     .package(url: "https://github.com/swift-libp2p/swift-multibase.git", exact: "0.0.2"),
-    .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "602.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"603.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", exact: "1.3.1"),
     .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
     .package(url: "https://github.com/apple/swift-nio.git", from: "2.63.0"),

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -220,12 +220,11 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                   leftAngle: .leftAngleToken(),
                                   arguments: GenericArgumentListSyntax([
                                     GenericArgumentSyntax(
-                                      argument: GenericArgumentSyntax.Argument(
-                                        MemberTypeSyntax(
-                                          baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
-                                          period: .periodToken(),
-                                          name: .identifier("AcceptableContentType")
-                                        )))
+                                      argument: MemberTypeSyntax(
+                                        baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                        period: .periodToken(),
+                                        name: .identifier("AcceptableContentType")
+                                      ))
                                   ]),
                                   rightAngle: .rightAngleToken()
                                 )
@@ -256,12 +255,11 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                               name: .identifier("AcceptHeaderContentType"),
                               genericArgumentClause: GenericArgumentClauseSyntax {
                                 GenericArgumentSyntax(
-                                  argument: GenericArgumentSyntax.Argument(
-                                    MemberTypeSyntax(
-                                      baseType: IdentifierTypeSyntax(name: .identifier(ts.typeName)),
-                                      period: .periodToken(),
-                                      name: .identifier("AcceptableContentType")
-                                    ))
+                                  argument: MemberTypeSyntax(
+                                    baseType: IdentifierTypeSyntax(name: .identifier(ts.typeName)),
+                                    period: .periodToken(),
+                                    name: .identifier("AcceptableContentType")
+                                  )
                                 )
                               }
                             ),

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -312,7 +312,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                 genericArgumentClause: GenericArgumentClauseSyntax(
                                   leftAngle: .leftAngleToken(),
                                   arguments: GenericArgumentListSyntax([
-                                    GenericArgumentSyntax(argument: GenericArgumentSyntax.Argument(IdentifierTypeSyntax(name: .identifier("AcceptableContentType"))))
+                                    GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("AcceptableContentType")))
                                   ]),
                                   rightAngle: .rightAngleToken()
                                 )
@@ -348,7 +348,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                   genericArgumentClause: GenericArgumentClauseSyntax(
                                     leftAngle: .leftAngleToken(),
                                     arguments: GenericArgumentListSyntax([
-                                      GenericArgumentSyntax(argument: GenericArgumentSyntax.Argument(IdentifierTypeSyntax(name: .identifier("AcceptableContentType"))))
+                                      GenericArgumentSyntax(argument: IdentifierTypeSyntax(name: .identifier("AcceptableContentType")))
                                     ]),
                                     rightAngle: .rightAngleToken()
                                   )


### PR DESCRIPTION
Changed swift-syntax dependency from an exact version to a range (600.0.0..<603.0.0) to improve compatibility with other packages.