### PR TITLE
fix: fail early when union reference is missing in lexicon

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
@@ -22,9 +22,10 @@ struct UnionTypeDefinition: Codable, SwiftCodeGeneratable {
         } else {
           ref
         }
-      if let cts = defMap[refName]?.type {
-        tss.append(cts)
+      guard let cts = defMap[refName] else {
+        fatalError("no such ref: \(refName)")
       }
+      tss.append(cts.type)
     }
 
     return EnumDeclSyntax(


### PR DESCRIPTION
Ensures that the process terminates with a fatal error if a referenced NSID is not found in the definition map. This prevents inconsistent code generation when lexicons are incomplete.