### PR TITLE
refactor: use namespaced records instead of underscore-prefixed top-level types

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -74,13 +74,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
               pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("nsId"))),
               initializer: InitializerClauseSyntax(
                 equal: .equalToken(),
-                value: StringLiteralExprSyntax(
-                  openingQuote: .stringQuoteToken(),
-                  segments: StringLiteralSegmentListSyntax([
-                    StringLiteralSegmentListSyntax.Element(StringSegmentSyntax(content: .stringSegment(typeName)))
-                  ]),
-                  closingQuote: .stringQuoteToken()
-                )
+                value: StringLiteralExprSyntax(content: typeName),
               )
             )
           ])

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -58,7 +58,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     return StructDeclSyntax(
       leadingTrivia: leadingTrivia,
       modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-      name: .init(stringLiteral: ts.isRecord ? "\(Lex.structNameFor(prefix: ts.prefix))_\(name)" : name),
+      name: .identifier(name),
       inheritanceClause: InheritanceClauseSyntax(typeNames: ts.isRecord ? ["ATProtoRecord"] : ["Codable", "Hashable", "Sendable"])
     ) {
       if ts.isRecord {
@@ -112,7 +112,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
       }
       for (key, property) in sortedProperties {
         let isRequired = required[key] ?? false
-        let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: !ts.isRecord)
+        let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: true)
         property.variable(name: key, type: type, isMutable: !ts.isRecord)
       }
       VariableDeclSyntax(
@@ -152,7 +152,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                   equal: .equalToken(),
                   value: NilLiteralExprSyntax()
                 )
-              let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: !ts.isRecord)
+              let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: true)
               FunctionParameterSyntax(firstName: .identifier(key), type: type, defaultValue: defaultValue)
             }
           }
@@ -244,10 +244,10 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
           let tname: String = {
             if case .string(let def) = property, def.enum != nil || def.knownValues != nil {
               let tname = "\(name)_\(key.titleCased())"
-              return ts.isRecord ? "\(Lex.structNameFor(prefix: ts.prefix)).\(tname)" : tname
+              return "\(Lex.structNameFor(prefix: ts.prefix)).\(tname)"
             } else {
               let cts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: key, type: property)
-              return TypeSchema.typeNameForField(name: name, k: key, v: cts, defMap: defMap, dropPrefix: !ts.isRecord)
+              return TypeSchema.typeNameForField(name: name, k: key, v: cts, defMap: defMap, dropPrefix: true)
             }
           }()
           SequenceExprSyntax {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -92,12 +92,11 @@ func writeSchemaCode(
               let allTypes = schema.allTypes(prefix: prefix).sorted(by: {
                 $0.key.localizedStandardCompare($1.key) == .orderedAscending
               })
-              let otherTypes = allTypes.filter { !$0.value.isRecord }
               let methodTypes = allTypes.filter { !$0.value.isRecord && $0.value.isMethod }
               let recordTypes = allTypes.filter(\.value.isRecord)
 
-              let types = Lex.genTypes(prefix: prefix, otherTypes: otherTypes, methods: methodTypes, defMap: defMap, generate: generate)
-              let methods = Lex.genMethods(leadingTrivia: otherTypes.isEmpty ? nil : .spaces(2), prefix: prefix, otherTypes: otherTypes, methods: methodTypes, defMap: defMap, generate: generate)
+              let types = Lex.genTypes(prefix: prefix, otherTypes: allTypes, methods: methodTypes, defMap: defMap, generate: generate)
+              let methods = Lex.genMethods(leadingTrivia: allTypes.isEmpty ? nil : .spaces(2), prefix: prefix, methods: methodTypes, defMap: defMap, generate: generate)
               let records = Lex.genRecords(recordTypes: recordTypes, defMap: defMap, generate: generate)
               return (types, methods, records, j)
             }
@@ -290,7 +289,7 @@ enum Lex {
   }
 
   @MemberBlockItemListBuilder
-  static func genMethods(leadingTrivia: Trivia? = nil, prefix: String, otherTypes: [[String: TypeSchema].Element], methods: [[String: TypeSchema].Element], defMap: ExtDefMap, generate: GenerateOption) -> MemberBlockItemListSyntax {
+  static func genMethods(leadingTrivia: Trivia? = nil, prefix: String, methods: [[String: TypeSchema].Element], defMap: ExtDefMap, generate: GenerateOption) -> MemberBlockItemListSyntax {
     if generate.contains(.client) {
       for (i, method) in methods.enumerated() {
         writeMethod(
@@ -307,12 +306,47 @@ enum Lex {
   @CodeBlockItemListBuilder
   static func genRecords(recordTypes: [[String: TypeSchema].Element], defMap: ExtDefMap, generate: GenerateOption) -> CodeBlockItemListSyntax {
     for (name, ot) in recordTypes {
-      ot.lex(
+      TypeAliasDeclSyntax(
         leadingTrivia: .newlines(2),
-        name: name,
-        type: (ot.defName.isEmpty || ot.defName == "main") ? ot.id : "\(ot.id)#\(ot.defName)",
-        defMap: defMap,
-        generate: generate
+        attributes: [
+          AttributeListSyntax.Element(
+            AttributeSyntax(
+              atSign: .atSignToken(),
+              attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("available"))),
+              leftParen: .leftParenToken(),
+              arguments: AttributeSyntax.Arguments(
+                AvailabilityArgumentListSyntax {
+                  AvailabilityArgumentSyntax(
+                    argument: AvailabilityArgumentSyntax.Argument(.binaryOperator("*"))
+                  )
+                  AvailabilityArgumentSyntax(
+                    argument: AvailabilityArgumentSyntax.Argument(.keyword(.deprecated))
+                  )
+                  AvailabilityArgumentSyntax(
+                    argument: AvailabilityArgumentSyntax.Argument(
+                      AvailabilityLabeledArgumentSyntax(
+                        label: .keyword(.message),
+                        colon: .colonToken(),
+                        value: AvailabilityLabeledArgumentSyntax.Value(
+                          SimpleStringLiteralExprSyntax(
+                            openingQuote: .stringQuoteToken(),
+                            segments: SimpleStringLiteralSegmentListSyntax([
+                              StringSegmentSyntax(content: .stringSegment("Use `\(Lex.structNameFor(prefix: ot.prefix)).\(name)` instead."))
+                            ]),
+                            closingQuote: .stringQuoteToken()
+                          ))
+                      )))
+                }),
+              rightParen: .rightParenToken()
+            )
+          )
+        ],
+        modifiers: [DeclModifierSyntax(name: .keyword(.public, leadingTrivia: .newline))],
+        name: .identifier("\(Lex.structNameFor(prefix: ot.prefix))_\(name)"),
+        initializer: TypeInitializerClauseSyntax(
+          equal: .equalToken(),
+          value: MemberTypeSyntax(parts: [.identifier(Lex.structNameFor(prefix: ot.prefix)), .identifier(name)])
+        )
       )
     }
   }
@@ -420,11 +454,7 @@ enum Lex {
                     DictionaryElementSyntax(
                       key: StringLiteralExprSyntax(openingQuote: .stringQuoteToken(leadingTrivia: [.newlines(1), .spaces(4)]), content: recordType.id),
                       colon: .colonToken(),
-                      value: MemberAccessExprSyntax(
-                        base: DeclReferenceExprSyntax(baseName: .identifier("\(Lex.structNameFor(prefix: recordType.prefix))_\(name)")),
-                        period: .periodToken(),
-                        declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
-                      ),
+                      value: MemberAccessExprSyntax(parts: [.identifier(Lex.structNameFor(prefix: recordType.prefix)), .identifier(name), .keyword(.self)]),
                       trailingComma: .commaToken()
                     )
                   }

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -196,9 +196,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
       return ("INVALID", "String")
     }
     let tname: String =
-      if ts.isRecord {
-        "\(Lex.structNameFor(prefix: ts.prefix))_\(ts.typeName)"
-      } else if dropPrefix, ts.prefix == prefix {
+      if dropPrefix, ts.prefix == prefix {
         ts.typeName
       } else {
         "\(Lex.structNameFor(prefix: ts.prefix)).\(ts.typeName)"


### PR DESCRIPTION
Previously, records were defined as top-level types with `${prefix}_${name}` to support dynamic resolution via `getTypeByName(typeName:)`. Since this dynamic lookup is no longer required, this commit moves records into their respective namespaces as `${prefix}.${name}`.