### PR TITLE
feat: refactor namespace to nested enums (e.g. Com.Atproto)

### DIFF
--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -83,17 +83,18 @@ extension Lex {
   }
 
   private static func makeXRPCMethodStub(leadingTrivia: Trivia? = nil, key: String, prefix: String) -> FunctionDeclSyntax {
-    FunctionDeclSyntax(
+    let prefixIdent: [TokenSyntax] = Lex.structNameFor(prefix: prefix).split(separator: ".").map({ .identifier(String($0)) })
+    return FunctionDeclSyntax(
       leadingTrivia: .spaces(2),
       modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-      name: .identifier("\(prefix)_\(key)"),
+      name: .identifier("\(Lex.enumNameFor(prefix: prefix))_\(key)"),
       signature: FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax {
           FunctionParameterSyntax(
             firstName: .wildcardToken(),
             secondName: .identifier("input"),
             colon: .colonToken(),
-            type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input")])
+            type: MemberTypeSyntax(parts: prefixIdent + [.identifier(key), .identifier("Input")])
           )
         },
         effectSpecifiers: FunctionEffectSpecifiersSyntax(
@@ -101,7 +102,7 @@ extension Lex {
           throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
         ),
         returnClause: ReturnClauseSyntax(
-          type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Output")])
+          type: MemberTypeSyntax(parts: prefixIdent + [.identifier(key), .identifier("Output")])
         )
       )
     ) {
@@ -131,7 +132,7 @@ extension Lex {
     let prefix = Lex.structNameFor(prefix: scheme.prefix)
     return FunctionDeclSyntax(
       leadingTrivia: [.newlines(1), .spaces(2)],
-      name: .identifier("\(prefix)_\(key)"),
+      name: .identifier("\(Lex.enumNameFor(prefix: scheme.prefix))_\(key)"),
       signature: FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax(
           leftParen: .leftParenToken(),
@@ -177,7 +178,7 @@ extension Lex {
     let prefix = Lex.structNameFor(prefix: scheme.prefix)
     return FunctionDeclSyntax(
       leadingTrivia: [.newlines(1), .spaces(2)],
-      name: .identifier("\(prefix)_\(key)"),
+      name: .identifier("\(Lex.enumNameFor(prefix: scheme.prefix))_\(key)"),
       signature: FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax(
           leftParen: .leftParenToken(),
@@ -220,7 +221,8 @@ extension Lex {
   }
 
   private static func makeHandlerRegistration(leadingTrivia: Trivia? = nil, prefix: String, type: String, method: String) -> TryExprSyntax {
-    TryExprSyntax(
+    let prefixIdent: [TokenSyntax] = Lex.structNameFor(prefix: prefix).split(separator: ".").map({ .identifier(String($0)) })
+    return TryExprSyntax(
       leadingTrivia: leadingTrivia,
       expression: FunctionCallExprSyntax(
         callee: MemberAccessExprSyntax(parts: [.identifier("transport"), .identifier("register")])
@@ -232,7 +234,7 @@ extension Lex {
               leadingTrivia: [.newlines(1), .spaces(8)],
               expression: AwaitExprSyntax(
                 expression: FunctionCallExprSyntax(
-                  callee: MemberAccessExprSyntax(parts: [.identifier("server"), .identifier("\(prefix)_\(type)")])
+                  callee: MemberAccessExprSyntax(parts: [.identifier("server"), .identifier("\(Lex.enumNameFor(prefix: prefix))_\(type)")])
                 ) {
                   for (i, label) in ["request", "body", "metadata"].enumerated() {
                     LabeledExprSyntax(
@@ -264,7 +266,7 @@ extension Lex {
                 StringSegmentSyntax(content: .stringSegment("/"))
                 ExpressionSegmentSyntax {
                   LabeledExprSyntax(
-                    expression: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(type), .identifier("id")])
+                    expression: MemberAccessExprSyntax(parts: prefixIdent + [.identifier(type), .identifier("id")])
                   )
                 }
                 StringSegmentSyntax(content: .stringSegment(""))
@@ -420,7 +422,7 @@ extension Lex {
   private static func makeHandlerMethod(leadingTrivia: Trivia? = nil, key: String, prefix: String, schema: TypeSchema, def: any HTTPAPITypeDefinition, defMap: ExtDefMap) -> FunctionDeclSyntax {
     FunctionDeclSyntax(
       leadingTrivia: .spaces(2),
-      name: .identifier("\(prefix)_\(key)"),
+      name: .identifier("\(Lex.enumNameFor(prefix: prefix))_\(key)"),
       signature: FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax {
           FunctionParameterSyntax(
@@ -512,7 +514,7 @@ extension Lex {
                 FunctionCallExprSyntax(
                   callee: MemberAccessExprSyntax(
                     leadingTrivia: [.newlines(1), .spaces(10)],
-                    parts: [.identifier("APIHandler"), .identifier("\(prefix)_\(key)")]
+                    parts: [.identifier("APIHandler"), .identifier("\(Lex.enumNameFor(prefix: prefix))_\(key)")]
                   )
                 ) {
                   LabeledExprSyntax(expression: DeclReferenceExprSyntax(baseName: .dollarIdentifier("$0")))

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -114,11 +114,8 @@ func writeSchemaCode(
         return (
           makeItemList(
             initialDecl: DeclSyntax(
-              EnumDeclSyntax(
-                modifiers: [
-                  DeclModifierSyntax(name: .keyword(.public))
-                ],
-                name: .identifier(Lex.structNameFor(prefix: prefix))
+              ExtensionDeclSyntax(
+                extendedType: TypeSyntax(MemberTypeSyntax(parts: Lex.enumIdentifiersFor(prefix: prefix)))
               ) { types }
             ), parts: records),
           methods,
@@ -134,6 +131,7 @@ func writeSchemaCode(
     }
     return (combine(blocks.compactMap({ $0 })), combine(methods.compactMap({ $0 })))
   }
+  let prefixes = schemasArray.map(\.0)
   let clientSrc: String = SourceFileSyntax(leadingTrivia: Lex.fileHeader) {
     ImportDeclSyntax(
       path: [ImportPathComponentSyntax(name: "Foundation")]
@@ -160,6 +158,12 @@ func writeSchemaCode(
         ],
         trailingTrivia: .newlines(2)
       )
+    }
+    for node in EnumDeclSyntaxNode.buildTree(from: prefixes) {
+      node.generateEnums()
+    }
+    for prefix in prefixes {
+      genDeprecatedEnum(prefix: prefix)
     }
     blocks
     if !methods.isEmpty {
@@ -192,6 +196,95 @@ func combine(_ parts: [MemberBlockItemListSyntax]) -> MemberBlockItemListSyntax 
   }
 }
 
+class EnumDeclSyntaxNode {
+  let name: String
+  var children: [String: EnumDeclSyntaxNode] = [:]
+
+  init(name: String) {
+    self.name = name
+  }
+
+  func generateEnums() -> EnumDeclSyntax {
+    EnumDeclSyntax(
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public))
+      ],
+      name: .identifier(name)
+    ) {
+      for childKey in children.keys.sorted() {
+        children[childKey]!.generateEnums()
+      }
+    }
+  }
+
+  static func buildTree(from strings: [String]) -> [EnumDeclSyntaxNode] {
+    var roots: [String: EnumDeclSyntaxNode] = [:]
+
+    for s in strings {
+      let parts = s.components(separatedBy: ".")
+      guard let firstPart = parts.first else { continue }
+
+      if roots[firstPart] == nil {
+        roots[firstPart] = EnumDeclSyntaxNode(name: firstPart.capitalized)
+      }
+
+      var current = roots[firstPart]!
+      for part in parts.dropFirst() {
+        if current.children[part] == nil {
+          current.children[part] = EnumDeclSyntaxNode(name: part.capitalized)
+        }
+        current = current.children[part]!
+      }
+    }
+    return roots.values.sorted { $0.name < $1.name }
+  }
+}
+
+func genDeprecatedEnum(prefix: String) -> TypeAliasDeclSyntax {
+  TypeAliasDeclSyntax(
+    leadingTrivia: .newlines(2),
+    attributes: [
+      AttributeListSyntax.Element(
+        AttributeSyntax(
+          atSign: .atSignToken(),
+          attributeName: TypeSyntax(IdentifierTypeSyntax(name: .identifier("available"))),
+          leftParen: .leftParenToken(),
+          arguments: AttributeSyntax.Arguments(
+            AvailabilityArgumentListSyntax {
+              AvailabilityArgumentSyntax(
+                argument: AvailabilityArgumentSyntax.Argument(.binaryOperator("*"))
+              )
+              AvailabilityArgumentSyntax(
+                argument: AvailabilityArgumentSyntax.Argument(.keyword(.deprecated))
+              )
+              AvailabilityArgumentSyntax(
+                argument: AvailabilityArgumentSyntax.Argument(
+                  AvailabilityLabeledArgumentSyntax(
+                    label: .keyword(.message),
+                    colon: .colonToken(),
+                    value: AvailabilityLabeledArgumentSyntax.Value(
+                      SimpleStringLiteralExprSyntax(
+                        openingQuote: .stringQuoteToken(),
+                        segments: SimpleStringLiteralSegmentListSyntax([
+                          StringSegmentSyntax(content: .stringSegment("Use `\(Lex.structNameFor(prefix: prefix))` instead."))
+                        ]),
+                        closingQuote: .stringQuoteToken()
+                      ))
+                  )))
+            }),
+          rightParen: .rightParenToken()
+        )
+      )
+    ],
+    modifiers: [DeclModifierSyntax(name: .keyword(.public, leadingTrivia: .newline))],
+    name: .identifier(Lex.enumNameFor(prefix: prefix)),
+    initializer: TypeInitializerClauseSyntax(
+      equal: .equalToken(),
+      value: MemberTypeSyntax(parts: Lex.enumIdentifiersFor(prefix: prefix))
+    )
+  )
+}
+
 extension URL {
   fileprivate func prefix(baseURL: URL) -> String {
     precondition(path.hasPrefix(baseURL.path))
@@ -215,20 +308,6 @@ enum Lex {
       .lineComment("//"),
       .newlines(2),
     ])
-  }
-
-  static func baseFile(prefix: String) -> String {
-    let src = SourceFileSyntax(
-      statementsBuilder: {
-        EnumDeclSyntax(
-          modifiers: [
-            DeclModifierSyntax(name: .keyword(.public))
-          ],
-          name: .identifier(Lex.structNameFor(prefix: prefix))
-        ) {}
-      },
-      trailingTrivia: .newline)
-    return src.formatted().description
   }
 
   @MemberBlockItemListBuilder
@@ -331,7 +410,7 @@ enum Lex {
                           SimpleStringLiteralExprSyntax(
                             openingQuote: .stringQuoteToken(),
                             segments: SimpleStringLiteralSegmentListSyntax([
-                              StringSegmentSyntax(content: .stringSegment("Use `\(Lex.structNameFor(prefix: ot.prefix)).\(name)` instead."))
+                              StringSegmentSyntax(content: .stringSegment("Use `\(Lex.enumNameFor(prefix: ot.prefix)).\(name)` instead."))
                             ]),
                             closingQuote: .stringQuoteToken()
                           ))
@@ -342,7 +421,7 @@ enum Lex {
           )
         ],
         modifiers: [DeclModifierSyntax(name: .keyword(.public, leadingTrivia: .newline))],
-        name: .identifier("\(Lex.structNameFor(prefix: ot.prefix))_\(name)"),
+        name: .identifier("\(Lex.enumNameFor(prefix: ot.prefix))_\(name)"),
         initializer: TypeInitializerClauseSyntax(
           equal: .equalToken(),
           value: MemberTypeSyntax(parts: [.identifier(Lex.structNameFor(prefix: ot.prefix)), .identifier(name)])
@@ -454,7 +533,7 @@ enum Lex {
                     DictionaryElementSyntax(
                       key: StringLiteralExprSyntax(openingQuote: .stringQuoteToken(leadingTrivia: [.newlines(1), .spaces(4)]), content: recordType.id),
                       colon: .colonToken(),
-                      value: MemberAccessExprSyntax(parts: [.identifier(Lex.structNameFor(prefix: recordType.prefix)), .identifier(name), .keyword(.self)]),
+                      value: MemberAccessExprSyntax(parts: Lex.enumIdentifiersFor(prefix: recordType.prefix) + [.identifier(name), .keyword(.self)]),
                       trailingComma: .commaToken()
                     )
                   }
@@ -732,7 +811,15 @@ enum Lex {
   }
 
   static func structNameFor(prefix: String) -> String {
+    prefix.split(separator: ".").map({ $0.capitalized }).joined(separator: ".")
+  }
+
+  static func enumNameFor(prefix: String) -> String {
     "\(prefix.split(separator: ".").joined())types"
+  }
+
+  static func enumIdentifiersFor(prefix: String) -> [TokenSyntax] {
+    prefix.split(separator: ".").map({ .identifier(.init(String($0).capitalized)) })
   }
 
   static func caseNameFromId(id: String, prefix: String) -> String {

--- a/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
@@ -2,6 +2,33 @@ import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+extension EnumDeclSyntax {
+  public init(
+    leadingTrivia: Trivia? = nil,
+    modifiers: DeclModifierListSyntax = [],
+    parts: [TokenSyntax],
+    @MemberBlockItemListBuilder memberBlockBuilder: () throws -> MemberBlockItemListSyntax
+  ) rethrows {
+    precondition(!parts.isEmpty, "MemberAccessExprSyntax.init(parts:) requires at least one token.")
+    if parts.count == 1 {
+      try self.init(
+        leadingTrivia: leadingTrivia,
+        modifiers: modifiers,
+        name: parts[0],
+        memberBlockBuilder: memberBlockBuilder
+      )
+    } else {
+      let reversed = Array(parts.reversed())
+      let initialEnum = try EnumDeclSyntax(modifiers: modifiers, name: reversed[0], memberBlockBuilder: memberBlockBuilder)
+      self = reversed.dropFirst().reduce(initialEnum) { currentBase, token in
+        EnumDeclSyntax(modifiers: modifiers, name: token) {
+          currentBase
+        }
+      }
+    }
+  }
+}
+
 extension MemberAccessExprSyntax {
   init(leadingTrivia: Trivia? = nil, parts: [TokenSyntax], isRoot: Bool = true) {
     precondition(!parts.isEmpty, "MemberAccessExprSyntax.init(parts:) requires at least one token.")


### PR DESCRIPTION
## Description

This PR refactors the type generation logic to use **nested Enums** for namespaces instead of the previous flattened naming convention.

### Changes
Previously, the generated types were namespaced using a flattened string (e.g., `comatprototypes`). This update introduces a hierarchical structure using nested Enums to improve readability and align with Swift's idiomatic API design.

### Namespace Mapping Example

| From (Original / Flat) | To (New / Nested) |
| :--- | :--- |
| `comatprototypes` | `Com.Atproto` |
| `appbskytypes` | `App.Bsky` |

### Key Improvements

* **Hierarchical Structure:** Namespaces are now generated as a tree of Enums (e.g., `Com.Atproto.Repo.CreateRecord`).
* **Backward Compatibility:** Added `@available(deprecated)` typealiases for the old flattened names (e.g., `typealias comatprototypes = Com.Atproto`) to ensure existing code continues to compile while providing a clear migration path via compiler warnings.
* **Lexicon Generator Update:** Enhanced `SwiftAtprotoLex` to handle multi-part identifiers and dynamic Enum tree generation.

---

### Code Example

**Before:**
```swift
let parentRef = comatprototypes.RepoStrongRef(cid: parent.cid, uri: parent.uri)
```
**After:**
```swift
let parentRef = Com.Atproto.RepoStrongRef(cid: parent.cid, uri: parent.uri)
// `comatprototypes` still works but shows a deprecation warning.
```