### PR TITLE
Refine handling of empty inputs and outputs for RPC definitions

### DIFF
--- a/Sources/SwiftAtproto/SwiftAtproto.swift
+++ b/Sources/SwiftAtproto/SwiftAtproto.swift
@@ -1,7 +1,7 @@
 import CID
 import Foundation
 
-public struct EmptyResponse: Codable {}
+public struct EmptyResponse: Codable, Sendable, Hashable {}
 
 public protocol ATProtoRecord: Codable, Sendable, Hashable {
   static var nsId: String { get }

--- a/Sources/SwiftAtproto/XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/XRPCClientProtocol.swift
@@ -206,6 +206,12 @@ extension ATPClientProtocol {
         throw NSError(domain: Self.errorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Server error: \(message)(\(statusCode))"])
       }
     }
+    if X.ResponseBody.self == EmptyResponse.self {
+      return EmptyResponse() as! X.ResponseBody
+    }
+    if X.ResponseBody.self == Data.self {
+      return data as! X.ResponseBody
+    }
     return try decoder.decode(X.ResponseBody.self, from: data)
   }
 
@@ -251,8 +257,8 @@ extension ATPClientProtocol {
       }
     }
 
-    if X.ResponseBody.self == Bool.self {
-      return true as! X.ResponseBody
+    if X.ResponseBody.self == EmptyResponse.self {
+      return EmptyResponse() as! X.ResponseBody
     }
     if X.ResponseBody.self == Data.self {
       return data as! X.ResponseBody

--- a/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
@@ -7,8 +7,6 @@ protocol HTTPAPITypeDefinition: Encodable, DecodableWithConfiguration, SwiftCode
   var output: OutputType? { get }
   var description: String? { get }
   var errors: [ErrorResponse]? { get }
-  var contentType: String { get }
-  var inputRPCValue: ExprSyntax { get }
   func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax]
   func rpcOutput(fname: String, defMap: ExtDefMap, prefix: String) -> ReturnClauseSyntax
   func rpcParams(id: String, prefix: String) -> ExprSyntaxProtocol

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -48,7 +48,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     return "*/*"
   }
 
-  func inputBody(fname: String, defMap: ExtDefMap, prefix: String) -> EnumCaseElementSyntax {
+  func inputBody(fname: String, defMap: ExtDefMap, prefix: String) -> EnumCaseElementSyntax? {
     if let input {
       switch input.encoding {
       case .json, .jsonl:
@@ -104,18 +104,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         )
       }
     }
-    return EnumCaseElementSyntax(
-      name: .identifier("json"),
-      parameterClause: EnumCaseParameterClauseSyntax(
-        leftParen: .leftParenToken(),
-        parameters: EnumCaseParameterListSyntax([
-          EnumCaseParameterSyntax(
-            type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("Bool")))
-          )
-        ]),
-        rightParen: .rightParenToken()
-      )
-    )
+    return nil
   }
 
   func requestBody(fname: String, defMap: ExtDefMap, prefix: String) -> IdentifierTypeSyntax {
@@ -371,31 +360,33 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                   )
                 ])
               )
-              EnumDeclSyntax(
-                leadingTrivia: [.newlines(2), .spaces(4)],
-                attributes: AttributeListSyntax {
-                  AttributeSyntax(
-                    atSign: .atSignToken(),
-                    attributeName: IdentifierTypeSyntax(name: .identifier("frozen"))
-                  )
-                },
-                modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-                name: .identifier("Body"),
-                inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
-              ) {
-                EnumCaseDeclSyntax(leadingTrivia: [.newlines(1), .spaces(6)]) {
-                  inputBody(fname: name, defMap: defMap, prefix: prefix)
+              if let input = inputBody(fname: name, defMap: defMap, prefix: prefix) {
+                EnumDeclSyntax(
+                  leadingTrivia: [.newlines(2), .spaces(4)],
+                  attributes: AttributeListSyntax {
+                    AttributeSyntax(
+                      atSign: .atSignToken(),
+                      attributeName: IdentifierTypeSyntax(name: .identifier("frozen"))
+                    )
+                  },
+                  modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+                  name: .identifier("Body"),
+                  inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable", "Hashable"])
+                ) {
+                  EnumCaseDeclSyntax(leadingTrivia: [.newlines(1), .spaces(6)]) {
+                    input
+                  }
                 }
+                varDecl(
+                  ident: "body",
+                  type: MemberTypeSyntax(
+                    baseType: MemberTypeSyntax(
+                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                      name: .identifier("Input")
+                    ),
+                    name: .identifier("Body")
+                  ))
               }
-              varDecl(
-                ident: "body",
-                type: MemberTypeSyntax(
-                  baseType: MemberTypeSyntax(
-                    baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
-                    name: .identifier("Input")
-                  ),
-                  name: .identifier("Body")
-                ))
               procedureInputInitializer(leadingTrivia: [.newlines(2), .spaces(4)], typeName: ts.typeName)
             }
           ))
@@ -1141,17 +1132,19 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
   }
 
   private func procedureInputInitializer(leadingTrivia: Trivia? = nil, typeName: String) -> InitializerDeclSyntax {
-    memberInitializer(
-      leadingTrivia: leadingTrivia,
-      members: [
-        (
-          "headers",
-          MemberTypeSyntax(parts: [.identifier(typeName), .identifier("Input"), .identifier("Headers")])
-        ),
+    var members: [(String, MemberTypeSyntax)] = [
+      (
+        "headers",
+        MemberTypeSyntax(parts: [.identifier(typeName), .identifier("Input"), .identifier("Headers")])
+      )
+    ]
+    if self.input != nil {
+      members.append(
         (
           "body",
           MemberTypeSyntax(parts: [.identifier(typeName), .identifier("Input"), .identifier("Body")])
-        ),
-      ])
+        ))
+    }
+    return memberInitializer(leadingTrivia: leadingTrivia, members: members)
   }
 }

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -48,22 +48,6 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     return "*/*"
   }
 
-  var inputRPCValue: ExprSyntax {
-    if input != nil {
-      ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("input")))
-    } else {
-      ExprSyntax(
-        MemberAccessExprSyntax(
-          base: OptionalChainingExprSyntax(
-            expression: DeclReferenceExprSyntax(baseName: .identifier("Bool")),
-            questionMark: .postfixQuestionMarkToken()
-          ),
-          period: .periodToken(),
-          declName: DeclReferenceExprSyntax(baseName: .identifier("none"))
-        ))
-    }
-  }
-
   func inputBody(fname: String, defMap: ExtDefMap, prefix: String) -> EnumCaseElementSyntax {
     if let input {
       switch input.encoding {

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -1146,27 +1146,11 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       members: [
         (
           "headers",
-          MemberTypeSyntax(
-            baseType: MemberTypeSyntax(
-              baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(typeName))),
-              period: .periodToken(),
-              name: .identifier("Input")
-            ),
-            period: .periodToken(),
-            name: .identifier("Headers")
-          )
+          MemberTypeSyntax(parts: [.identifier(typeName), .identifier("Input"), .identifier("Headers")])
         ),
         (
           "body",
-          MemberTypeSyntax(
-            baseType: MemberTypeSyntax(
-              baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(typeName))),
-              period: .periodToken(),
-              name: .identifier("Input")
-            ),
-            period: .periodToken(),
-            name: .identifier("Body")
-          )
+          MemberTypeSyntax(parts: [.identifier(typeName), .identifier("Input"), .identifier("Body")])
         ),
       ])
   }

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -156,7 +156,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         return IdentifierTypeSyntax(name: .identifier("Data"))
       }
     }
-    return IdentifierTypeSyntax(name: .identifier("Bool"))
+    return IdentifierTypeSyntax(name: .identifier("EmptyResponse"))
   }
 
   func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax] {
@@ -202,6 +202,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
 
   func generateDeclaration(leadingTrivia: SwiftSyntax.Trivia?, ts: TypeSchema, name: String, type: String, defMap: ExtDefMap, generate: GenerateOption) -> any DeclSyntaxProtocol {
     let prefix = Lex.structNameFor(prefix: ts.prefix)
+    let responseBody = responseBody(fname: name, defMap: defMap, prefix: Lex.structNameFor(prefix: ts.prefix))
     return EnumDeclSyntax(
       modifiers: [
         DeclModifierSyntax(name: .keyword(.public))
@@ -226,7 +227,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         name: .identifier("ResponseBody"),
         initializer: TypeInitializerClauseSyntax(
           equal: .equalToken(),
-          value: responseBody(fname: name, defMap: defMap, prefix: Lex.structNameFor(prefix: ts.prefix))
+          value: responseBody
         )
       )
       if generate.contains(.server) {
@@ -444,12 +445,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                               leftParen: .leftParenToken(),
                                               parameters: EnumCaseParameterListSyntax([
                                                 EnumCaseParameterSyntax(
-                                                  type: TypeSyntax(
-                                                    MemberTypeSyntax(
-                                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
-                                                      period: .periodToken(),
-                                                      name: .identifier("Bool")
-                                                    ))
+                                                  type: TypeSyntax(responseBody)
                                                 )
                                               ]),
                                               rightParen: .rightParenToken()
@@ -469,12 +465,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                             pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("json"))),
                                             typeAnnotation: TypeAnnotationSyntax(
                                               colon: .colonToken(),
-                                              type: TypeSyntax(
-                                                MemberTypeSyntax(
-                                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier("Swift"))),
-                                                  period: .periodToken(),
-                                                  name: .identifier("Bool")
-                                                ))
+                                              type: TypeSyntax(responseBody)
                                             ),
                                             accessorBlock: AccessorBlockSyntax(
                                               leftBrace: .leftBraceToken(),

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -115,7 +115,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         return .identifier("Data")
       }
     }
-    return .identifier("Bool")
+    return .identifier("EmptyResponse")
   }
 
   func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax] {

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -95,22 +95,6 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     return queries
   }
 
-  var contentType: String {
-    "*/*"
-  }
-
-  var inputRPCValue: ExprSyntax {
-    ExprSyntax(
-      MemberAccessExprSyntax(
-        base: OptionalChainingExprSyntax(
-          expression: DeclReferenceExprSyntax(baseName: .identifier("Bool")),
-          questionMark: .postfixQuestionMarkToken()
-        ),
-        period: .periodToken(),
-        declName: DeclReferenceExprSyntax(baseName: .identifier("none"))
-      ))
-  }
-
   func output(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> TokenSyntax {
     if let output {
       switch output.encoding {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -553,7 +553,8 @@ extension Lex {
   }
 
   private static func makeDeserializerExpr(key: String, prefix: String, schema: TypeSchema, def: ProcedureTypeDefinition, defMap: ExtDefMap) -> ClosureExprSyntax {
-    ClosureExprSyntax(signaturesBuilder: {
+    let hasInput = def.input != nil
+    return ClosureExprSyntax(signaturesBuilder: {
       ClosureShorthandParameterSyntax(name: .identifier("request"))
       ClosureShorthandParameterSyntax(name: .identifier("requestBody"))
       ClosureShorthandParameterSyntax(name: .identifier("metadata"))
@@ -594,41 +595,43 @@ extension Lex {
           )
         )
       }
-      VariableDeclSyntax(
-        leadingTrivia: [.newlines(1), .spaces(10)],
-        bindingSpecifier: .keyword(.let),
-        bindings: PatternBindingListSyntax([
-          PatternBindingSyntax(
-            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("contentType"))),
-            initializer: InitializerClauseSyntax(
-              equal: .equalToken(),
-              value: FunctionCallExprSyntax(
-                callee: MemberAccessExprSyntax(parts: [.identifier("converter"), .identifier("extractContentTypeIfPresent")])
-              ) {
-                LabeledExprSyntax(
-                  label: .identifier("in"),
-                  colon: .colonToken(),
-                  expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")])
-                )
-              }
+      if hasInput {
+        VariableDeclSyntax(
+          leadingTrivia: [.newlines(1), .spaces(10)],
+          bindingSpecifier: .keyword(.let),
+          bindings: PatternBindingListSyntax([
+            PatternBindingSyntax(
+              pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("contentType"))),
+              initializer: InitializerClauseSyntax(
+                equal: .equalToken(),
+                value: FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(parts: [.identifier("converter"), .identifier("extractContentTypeIfPresent")])
+                ) {
+                  LabeledExprSyntax(
+                    label: .identifier("in"),
+                    colon: .colonToken(),
+                    expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")])
+                  )
+                }
+              )
             )
-          )
-        ])
-      )
-      VariableDeclSyntax(
-        bindingSpecifier: .keyword(.let, leadingTrivia: [.newlines(1), .spaces(10)]),
-        bindings: PatternBindingListSyntax([
-          PatternBindingSyntax(
-            pattern: IdentifierPatternSyntax(identifier: .identifier("body")),
-            typeAnnotation: TypeAnnotationSyntax(
-              colon: .colonToken(),
-              type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Body")])
+          ])
+        )
+        VariableDeclSyntax(
+          bindingSpecifier: .keyword(.let, leadingTrivia: [.newlines(1), .spaces(10)]),
+          bindings: PatternBindingListSyntax([
+            PatternBindingSyntax(
+              pattern: IdentifierPatternSyntax(identifier: .identifier("body")),
+              typeAnnotation: TypeAnnotationSyntax(
+                colon: .colonToken(),
+                type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Body")])
+              )
             )
-          )
-        ])
-      )
-      genChosenContentType(key: key, def: def, prefix: prefix)
-      genInputBodySwitch(key: key, schema: schema, def: def, prefix: prefix, defMap: defMap)
+          ])
+        )
+        genChosenContentType(key: key, def: def, prefix: prefix)
+        genInputBodySwitch(key: key, schema: schema, def: def, prefix: prefix, defMap: defMap)
+      }
       ReturnStmtSyntax(
         leadingTrivia: [.newlines(1), .spaces(10)],
         expression: FunctionCallExprSyntax(
@@ -640,12 +643,14 @@ extension Lex {
             colon: .colonToken(),
             expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("headers"))),
           )
-          LabeledExprSyntax(
-            leadingTrivia: [.newlines(1), .spaces(12)],
-            label: .identifier("body"),
-            colon: .colonToken(),
-            expression: DeclReferenceExprSyntax(baseName: .identifier("body"))
-          )
+          if hasInput {
+            LabeledExprSyntax(
+              leadingTrivia: [.newlines(1), .spaces(12)],
+              label: .identifier("body"),
+              colon: .colonToken(),
+              expression: DeclReferenceExprSyntax(baseName: .identifier("body"))
+            )
+          }
         }
         .with(\.rightParen, .rightParenToken(leadingTrivia: [.newlines(1), .spaces(10)]))
       )


### PR DESCRIPTION
This PR improves the code generation and runtime handling for RPC (Query and Procedure) definitions that do not have associated input or output data.