### PR TITLE
fix: improve reliability of path resolution and lexicon download logic

### DIFF
--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -29,7 +29,7 @@ struct Lexgen: AsyncParsableCommand {
       let config = try SourceControl.main(configurationURL: configurationURL, outdir: outdir)
       guard !fetchOnly else { return }
       try await SwiftAtprotoLex.main(
-        outdir: config.module,
+        outdir: rootURL.appending(component: config.module),
         path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path(),
         generate: config.generate
       )

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -42,12 +42,14 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
   let checkoutDirectory = checkoutDirectoryURL(packageRootURL: rootURL)
   let lexiconsDirectory = lexiconsDirectoryURL(packageRootURL: rootURL)
   let lockFileURL = lockFileURL(packageRootURL: rootURL)
-  if let resolvedStore = try? LexiconsStore.load(from: lockFileURL),
+  let lexiconsIsExisting = FileManager.default.fileExists(atPath: lexiconsDirectory.path())
+  if lexiconsIsExisting,
+    let resolvedStore = try? LexiconsStore.load(from: lockFileURL),
     originHash == resolvedStore.originHash
   {
     return config
   }
-  if FileManager.default.fileExists(atPath: lexiconsDirectory.path()) {
+  if lexiconsIsExisting {
     try FileManager.default.removeItem(at: lexiconsDirectory)
   }
   try FileManager.default.createDirectory(at: lexiconsDirectory, withIntermediateDirectories: true)

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -6,13 +6,12 @@ import SwiftSyntaxBuilder
   import SourceControl
 #endif
 
-public func main(outdir: String, path: String, generate: GenerateOption) async throws {
+public func main(outdir outdirBaseURL: URL, path: String, generate: GenerateOption) async throws {
   let url = URL(filePath: path)
 
   let fileURLs = collectJSONFileURLs(at: url)
   let schemasMap = try await decodeSchemasByPrefix(from: fileURLs, baseURL: url)
   let defMap = Lex.buildExtDefMap(schemasMap: schemasMap)
-  let outdirBaseURL = URL(filePath: outdir)
   try await writeSchemaCode(for: schemasMap, with: defMap, to: outdirBaseURL, generate: generate)
 }
 


### PR DESCRIPTION
This PR fixes two issues related to file path handling and generation consistency:
1.  Resolves output paths to absolute URLs to prevent incorrect output locations when running from different directories.
2.  Ensures lexicons are re-downloaded if the directory is missing, even if a valid lock file exists.
