### PR TITLE
Generate XRPCClientProtocol requirements to support Dependency Injection

### DIFF
--- a/Sources/ATProtoMacro/ATProtoMacro.swift
+++ b/Sources/ATProtoMacro/ATProtoMacro.swift
@@ -7,6 +7,7 @@
 
 import SwiftAtproto
 
+@available(*, deprecated, message: "Use the code-generated `XRPCClientProtocol` instead. `_XRPCClientProtocol` only provides internal infrastructure and lacks XRPC API method requirements.")
 @attached(member, names: named(init))
 @attached(extension, conformances: _XRPCClientProtocol)
 public macro XRPCClient() = #externalMacro(module: "Macros", type: "XRPCClientMacro")

--- a/Sources/ATProtoMacro/ATProtoMacro.swift
+++ b/Sources/ATProtoMacro/ATProtoMacro.swift
@@ -8,5 +8,5 @@
 import SwiftAtproto
 
 @attached(member, names: named(init))
-@attached(extension, conformances: XRPCClientProtocol)
+@attached(extension, conformances: _XRPCClientProtocol)
 public macro XRPCClient() = #externalMacro(module: "Macros", type: "XRPCClientMacro")

--- a/Sources/Macros/Macros.swift
+++ b/Sources/Macros/Macros.swift
@@ -94,7 +94,7 @@
           extensionKeyword: .keyword(.extension),
           extendedType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(type.trimmedDescription))),
           inheritanceClause: InheritanceClauseSyntax {
-            InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCClientProtocol")))
+            InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("_XRPCClientProtocol")))
           }
         ) {}
       ]

--- a/Sources/SwiftAtproto/XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/XRPCClientProtocol.swift
@@ -30,7 +30,7 @@ public protocol ATPClientProtocol: Sendable {
   static var errorDomain: String { get }
 }
 
-public protocol XRPCClientProtocol: ATPClientProtocol {
+public protocol _XRPCClientProtocol: ATPClientProtocol {
   var auth: any XRPCAuth { get set }
 
   func signout()
@@ -94,7 +94,7 @@ public protocol XRPCClientProtocol: ATPClientProtocol {
   }
 #endif
 
-extension XRPCClientProtocol {
+extension _XRPCClientProtocol {
   public static var errorDomain: String { "XRPCErrorDomain" }
   public static var moduleName: String { _typeName(type(of: self)).split(separator: ".").first.flatMap { String($0) } ?? "" }
 }

--- a/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
@@ -7,7 +7,7 @@ protocol HTTPAPITypeDefinition: Encodable, DecodableWithConfiguration, SwiftCode
   var output: OutputType? { get }
   var description: String? { get }
   var errors: [ErrorResponse]? { get }
-  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax]
+  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String, protocolRequirement: Bool) -> [FunctionParameterSyntax]
   func rpcOutput(fname: String, defMap: ExtDefMap, prefix: String) -> ReturnClauseSyntax
   func rpcParams(id: String, prefix: String) -> ExprSyntaxProtocol
   func makeErrorDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name typeName: String, type: String) -> any DeclSyntaxProtocol

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -159,7 +159,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     return IdentifierTypeSyntax(name: .identifier("EmptyResponse"))
   }
 
-  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax] {
+  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String, protocolRequirement _: Bool) -> [FunctionParameterSyntax] {
     var arguments = [FunctionParameterSyntax]()
     guard let input else { return arguments }
     switch input.encoding {

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -118,7 +118,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     return .identifier("EmptyResponse")
   }
 
-  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [FunctionParameterSyntax] {
+  func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String, protocolRequirement: Bool) -> [FunctionParameterSyntax] {
     var arguments = [FunctionParameterSyntax]()
     guard let parameters else { return arguments }
     var required = [String: Bool]()
@@ -135,13 +135,18 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         tn = TypeSchema.typeNameForField(name: name, k: "", v: ts, defMap: defMap, dropPrefix: false)
       }
       let type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(tn)))
-      let defaultValue: InitializerClauseSyntax? =
-        isRequired
-        ? nil
-        : InitializerClauseSyntax(
-          equal: .equalToken(),
-          value: NilLiteralExprSyntax()
-        )
+      let defaultValue: InitializerClauseSyntax?
+      if protocolRequirement {
+        defaultValue = nil
+      } else {
+        defaultValue =
+          isRequired
+          ? nil
+          : InitializerClauseSyntax(
+            equal: .equalToken(),
+            value: NilLiteralExprSyntax()
+          )
+      }
       arguments.append(
         .init(
           firstName: .identifier(name),
@@ -265,7 +270,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
           modifiers: [DeclModifierSyntax(name: .keyword(.public))],
           signature: FunctionSignatureSyntax(
             parameterClause: FunctionParameterClauseSyntax {
-              rpcArguments(ts: ts, fname: name, defMap: defMap, prefix: prefix)
+              rpcArguments(ts: ts, fname: name, defMap: defMap, prefix: prefix, protocolRequirement: false)
             })
         ) {
           for (key, _) in parameters?.sortedProperties ?? [] {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -70,7 +70,7 @@ func writeSchemaCode(
   generate: GenerateOption
 ) async throws {
   let schemasArray = schemasMap.sorted { $0.key < $1.key }
-  let (blocks, methods) = try await withThrowingTaskGroup(of: (DeclSyntax, MemberBlockItemListSyntax, Int).self) { group in
+  let (blocks, methods, requirements) = try await withThrowingTaskGroup(of: (DeclSyntax, MemberBlockItemListSyntax, MemberBlockItemListSyntax, Int).self) { group in
     let src = Lex.genUnknownRecord(for: schemasMap)
     let recordURL = baseURL.appending(path: "UnknownATPValue.swift")
     try src.write(to: recordURL, atomically: true, encoding: .utf8)
@@ -84,7 +84,7 @@ func writeSchemaCode(
     try serverSrc.write(to: serverURL, atomically: true, encoding: .utf8)
     for (i, (prefix, schemas)) in schemasArray.enumerated() {
       group.addTask {
-        let (types, methods) = try await withThrowingTaskGroup(of: (MemberBlockItemListSyntax, MemberBlockItemListSyntax, Int).self) { innerGroup in
+        let (types, methods, requirements) = try await withThrowingTaskGroup(of: (MemberBlockItemListSyntax, MemberBlockItemListSyntax, MemberBlockItemListSyntax, Int).self) { innerGroup in
           for (j, schema) in schemas.sorted(by: { $0.id < $1.id }).enumerated() {
             innerGroup.addTask {
               let prefix = schema.prefix
@@ -93,17 +93,20 @@ func writeSchemaCode(
               })
               let methodTypes = allTypes.filter { $0.value.isMethod }
               let types = Lex.genTypes(prefix: prefix, otherTypes: allTypes, methods: methodTypes, defMap: defMap, generate: generate)
-              let methods = Lex.genMethods(leadingTrivia: allTypes.isEmpty ? nil : .spaces(2), prefix: prefix, methods: methodTypes, defMap: defMap, generate: generate)
-              return (types, methods, j)
+              let methods = Lex.genMethods(leadingTrivia: allTypes.isEmpty ? nil : .spaces(2), prefix: prefix, methods: methodTypes, defMap: defMap, generate: generate, protocolRequirement: false)
+              let requirements = Lex.genMethods(leadingTrivia: allTypes.isEmpty ? nil : .spaces(2), prefix: prefix, methods: methodTypes, defMap: defMap, generate: generate, protocolRequirement: true)
+              return (types, methods, requirements, j)
             }
           }
           var types: [MemberBlockItemListSyntax] = Array(repeating: .empty, count: schemas.count)
           var methods: [MemberBlockItemListSyntax] = Array(repeating: .empty, count: schemas.count)
-          for try await (type, method, j) in innerGroup {
+          var requirements: [MemberBlockItemListSyntax] = Array(repeating: .empty, count: schemas.count)
+          for try await (type, method, requrement, j) in innerGroup {
             types[j] = type
             methods[j] = method
+            requirements[j] = requrement
           }
-          return (combine(types), combine(methods))
+          return (combine(types), combine(methods), combine(requirements))
         }
         return (
           DeclSyntax(
@@ -111,6 +114,7 @@ func writeSchemaCode(
               extendedType: TypeSyntax(MemberTypeSyntax(parts: Lex.enumIdentifiersFor(prefix: prefix)))
             ) { types }),
           methods,
+          requirements,
           i
         )
       }
@@ -118,11 +122,13 @@ func writeSchemaCode(
 
     var blocks: [CodeBlockItemListSyntax] = Array(repeating: .empty, count: schemasMap.count)
     var methods: [MemberBlockItemListSyntax] = Array(repeating: .empty, count: schemasMap.count)
-    for try await (decl, method, i) in group {
+    var requirements: [MemberBlockItemListSyntax] = Array(repeating: .empty, count: schemasMap.count)
+    for try await (decl, method, requirement, i) in group {
       blocks[i] = CodeBlockItemListSyntax { decl }
       methods[i] = method
+      requirements[i] = requirement
     }
-    return (combine(blocks), combine(methods))
+    return (combine(blocks), combine(methods), combine(requirements))
   }
   let prefixes = schemasArray.map(\.0)
   let clientSrc: String = SourceFileSyntax(leadingTrivia: Lex.fileHeader) {
@@ -157,6 +163,16 @@ func writeSchemaCode(
     }
     blocks
     if !methods.isEmpty {
+      ProtocolDeclSyntax(
+        leadingTrivia: nil,
+        modifiers: [
+          DeclModifierSyntax(name: .keyword(.public))
+        ],
+        name: .identifier("XRPCClientProtocol"),
+        inheritanceClause: InheritanceClauseSyntax(typeNames: ["_XRPCClientProtocol"])
+      ) {
+        requirements
+      }
       ExtensionDeclSyntax(extendedType: TypeSyntax(stringLiteral: "XRPCClientProtocol")) {
         methods
       }
@@ -249,7 +265,7 @@ enum Lex {
   }
 
   @MemberBlockItemListBuilder
-  static func genMethods(leadingTrivia: Trivia? = nil, prefix: String, methods: [[String: TypeSchema].Element], defMap: ExtDefMap, generate: GenerateOption) -> MemberBlockItemListSyntax {
+  static func genMethods(leadingTrivia: Trivia? = nil, prefix: String, methods: [[String: TypeSchema].Element], defMap: ExtDefMap, generate: GenerateOption, protocolRequirement: Bool) -> MemberBlockItemListSyntax {
     if generate.contains(.client) {
       for (i, method) in methods.enumerated() {
         writeMethod(
@@ -257,18 +273,19 @@ enum Lex {
           typeName: Self.nameFromId(id: method.value.id, prefix: method.value.prefix),
           typeSchema: method.value,
           defMap: defMap,
-          prefix: structNameFor(prefix: prefix)
+          prefix: structNameFor(prefix: prefix),
+          protocolRequirement: protocolRequirement
         )
       }
     }
   }
 
-  static func writeMethod(leadingTrivia: Trivia? = nil, typeName: String, typeSchema ts: TypeSchema, defMap: ExtDefMap, prefix: String) -> DeclSyntaxProtocol {
+  static func writeMethod(leadingTrivia: Trivia? = nil, typeName: String, typeSchema ts: TypeSchema, defMap: ExtDefMap, prefix: String, protocolRequirement: Bool) -> DeclSyntaxProtocol {
     switch ts.type {
     case .procedure(let def):
-      ts.writeProcedure(leadingTrivia: nil, def: def, typeName: typeName, defMap: defMap, prefix: prefix)
+      ts.writeProcedure(leadingTrivia: nil, def: def, typeName: typeName, defMap: defMap, prefix: prefix, protocolRequirement: protocolRequirement)
     case .query(let def):
-      ts.writeQuery(leadingTrivia: nil, def: def, typeName: typeName, defMap: defMap, prefix: prefix)
+      ts.writeQuery(leadingTrivia: nil, def: def, typeName: typeName, defMap: defMap, prefix: prefix, protocolRequirement: protocolRequirement)
     default:
       fatalError()
     }

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -315,120 +315,132 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
     }
   }
 
-  func writeProcedure(leadingTrivia: Trivia? = nil, def: ProcedureTypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String) -> DeclSyntaxProtocol {
+  func writeProcedure(leadingTrivia: Trivia? = nil, def: ProcedureTypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String, protocolRequirement: Bool) -> DeclSyntaxProtocol {
     let prefixIdentifiers = Lex.enumIdentifiersFor(prefix: prefix)
     return FunctionDeclSyntax(
-      modifiers: DeclModifierListSyntax([
-        DeclModifierSyntax(name: .keyword(.public))
-      ]),
+      modifiers: DeclModifierListSyntax(
+        protocolRequirement
+          ? []
+          : [
+            DeclModifierSyntax(name: .keyword(.public))
+          ]),
       name: .identifier(typeName),
       signature: FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax {
-          def.rpcArguments(ts: self, fname: typeName, defMap: defMap, prefix: prefix)
+          def.rpcArguments(ts: self, fname: typeName, defMap: defMap, prefix: prefix, protocolRequirement: protocolRequirement)
         },
         effectSpecifiers: FunctionEffectSpecifiersSyntax(
           asyncSpecifier: .keyword(.async),
           throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
         ),
         returnClause: ReturnClauseSyntax(type: MemberTypeSyntax(parts: prefixIdentifiers + [.identifier(typeName), .identifier("ResponseBody")]))
-      )
-    ) {
-      TryExprSyntax(
-        leadingTrivia: [.newlines(1), .spaces(2)],
-        expression: ExprSyntax(
-          AwaitExprSyntax(
-            awaitKeyword: .keyword(.await),
+      ),
+      body: protocolRequirement
+        ? nil
+        : .init {
+          TryExprSyntax(
+            leadingTrivia: [.newlines(1), .spaces(2)],
             expression: ExprSyntax(
-              FunctionCallExprSyntax(
-                callee: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("call")))
-              ) {
-                LabeledExprSyntax(
-                  expression: MemberAccessExprSyntax(parts: prefixIdentifiers + [.identifier(typeName), .keyword(.self)])
+              AwaitExprSyntax(
+                awaitKeyword: .keyword(.await),
+                expression: ExprSyntax(
+                  FunctionCallExprSyntax(
+                    callee: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("call")))
+                  ) {
+                    LabeledExprSyntax(
+                      expression: MemberAccessExprSyntax(parts: prefixIdentifiers + [.identifier(typeName), .keyword(.self)])
+                    )
+                    if def.input != nil {
+                      LabeledExprSyntax(
+                        label: .identifier("input"),
+                        colon: .colonToken(),
+                        expression: DeclReferenceExprSyntax(baseName: .identifier("input")),
+                        trailingComma: .commaToken()
+                      )
+                    }
+                    LabeledExprSyntax(
+                      label: .identifier("retry"),
+                      colon: .colonToken(),
+                      expression: ExprSyntax(BooleanLiteralExprSyntax(literal: .keyword(.true)))
+                    )
+                  }
                 )
-                if def.input != nil {
-                  LabeledExprSyntax(
-                    label: .identifier("input"),
-                    colon: .colonToken(),
-                    expression: DeclReferenceExprSyntax(baseName: .identifier("input")),
-                    trailingComma: .commaToken()
-                  )
-                }
-                LabeledExprSyntax(
-                  label: .identifier("retry"),
-                  colon: .colonToken(),
-                  expression: ExprSyntax(BooleanLiteralExprSyntax(literal: .keyword(.true)))
-                )
-              }
-            )
-          ))
-      )
-    }
+              ))
+          )
+        })
   }
 
-  func writeQuery(leadingTrivia: Trivia? = nil, def: QueryTypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String) -> DeclSyntaxProtocol {
+  func writeQuery(leadingTrivia: Trivia? = nil, def: QueryTypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String, protocolRequirement: Bool) -> DeclSyntaxProtocol {
     let prefixIdentifiers = Lex.enumIdentifiersFor(prefix: prefix)
+
     return FunctionDeclSyntax(
-      modifiers: DeclModifierListSyntax([
-        DeclModifierSyntax(name: .keyword(.public))
-      ]),
+      modifiers: DeclModifierListSyntax(
+        protocolRequirement
+          ? []
+          : [
+            DeclModifierSyntax(name: .keyword(.public))
+          ]),
       name: .identifier(typeName),
       signature: FunctionSignatureSyntax(
         parameterClause: FunctionParameterClauseSyntax {
-          def.rpcArguments(ts: self, fname: typeName, defMap: defMap, prefix: prefix)
+          def.rpcArguments(ts: self, fname: typeName, defMap: defMap, prefix: prefix, protocolRequirement: protocolRequirement)
         },
         effectSpecifiers: FunctionEffectSpecifiersSyntax(
           asyncSpecifier: .keyword(.async),
           throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
         ),
         returnClause: ReturnClauseSyntax(type: MemberTypeSyntax(parts: prefixIdentifiers + [.identifier(typeName), .identifier("ResponseBody")]))
-      )
-    ) {
-      TryExprSyntax(
-        leadingTrivia: [.newlines(1), .spaces(2)],
-        expression: ExprSyntax(
-          AwaitExprSyntax(
-            awaitKeyword: .keyword(.await),
+      ),
+      body: protocolRequirement
+        ? nil
+        : .init {
+          TryExprSyntax(
+            leadingTrivia: [.newlines(1), .spaces(2)],
             expression: ExprSyntax(
-              FunctionCallExprSyntax(
-                callee: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("call")))
-              ) {
-                LabeledExprSyntax(
-                  expression: MemberAccessExprSyntax(parts: prefixIdentifiers + [.identifier(typeName), .keyword(.self)])
-                )
-                LabeledExprSyntax(
-                  label: .identifier("input"),
-                  colon: .colonToken(),
-                  expression: ExprSyntax(
-                    FunctionCallExprSyntax(
-                      callee: ExprSyntax(
-                        MemberAccessExprSyntax(
-                          period: .periodToken(),
-                          declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
-                        ))
-                    ) {
-                      if let properties = def.parameters?.sortedProperties {
-                        for (name, _) in properties {
-                          LabeledExprSyntax(
-                            label: .identifier(name),
-                            colon: .colonToken(),
-                            expression: DeclReferenceExprSyntax(baseName: .identifier(name))
-                          )
+              AwaitExprSyntax(
+                awaitKeyword: .keyword(.await),
+                expression: ExprSyntax(
+                  FunctionCallExprSyntax(
+                    callee: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("call")))
+                  ) {
+                    LabeledExprSyntax(
+                      expression: MemberAccessExprSyntax(parts: prefixIdentifiers + [.identifier(typeName), .keyword(.self)])
+                    )
+                    LabeledExprSyntax(
+                      label: .identifier("input"),
+                      colon: .colonToken(),
+                      expression: ExprSyntax(
+                        FunctionCallExprSyntax(
+                          callee: ExprSyntax(
+                            MemberAccessExprSyntax(
+                              period: .periodToken(),
+                              declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+                            ))
+                        ) {
+                          if let properties = def.parameters?.sortedProperties {
+                            for (name, _) in properties {
+                              LabeledExprSyntax(
+                                label: .identifier(name),
+                                colon: .colonToken(),
+                                expression: DeclReferenceExprSyntax(baseName: .identifier(name))
+                              )
+                            }
+                          }
                         }
-                      }
-                    }
-                  ),
-                  trailingComma: .commaToken()
+                      ),
+                      trailingComma: .commaToken()
+                    )
+                    LabeledExprSyntax(
+                      label: .identifier("retry"),
+                      colon: .colonToken(),
+                      expression: ExprSyntax(BooleanLiteralExprSyntax(literal: .keyword(.true)))
+                    )
+                  }
                 )
-                LabeledExprSyntax(
-                  label: .identifier("retry"),
-                  colon: .colonToken(),
-                  expression: ExprSyntax(BooleanLiteralExprSyntax(literal: .keyword(.true)))
-                )
-              }
-            )
-          ))
-      )
-    }
+              ))
+          )
+        }
+    )
   }
 
   func typeIdentifier(name: String, property: FieldTypeDefinition, defMap: ExtDefMap, key: String, isRequired: Bool, dropPrefix: Bool = true) -> TypeSyntax {

--- a/Tests/MacrosTests/MacrosTests.swift
+++ b/Tests/MacrosTests/MacrosTests.swift
@@ -47,7 +47,7 @@
             }
           }
 
-          extension TestClient: XRPCClientProtocol {
+          extension TestClient: _XRPCClientProtocol {
           }
           """,
         macros: testMacros,

--- a/Tests/SwiftAtprotoTests/SwiftAtprotoTests.swift
+++ b/Tests/SwiftAtprotoTests/SwiftAtprotoTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 @testable import SwiftAtproto
 
-struct XRPCTestClient: XRPCClientProtocol {
+struct XRPCTestClient: _XRPCClientProtocol {
   var serviceEndpoint: URL
 
   var decoder: JSONDecoder


### PR DESCRIPTION
This PR updates the code generator to produce `XRPCClientProtocol` with full method requirements, enabling users to easily implement mocks and facilitate Dependency Injection (DI).