### PR TITLE
Escape Swift keywords in generated identifiers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -100,6 +100,13 @@ let package = Package(
       dependencies: ["SwiftAtproto"]
     ),
     .testTarget(
+      name: "SwiftAtprotoLexTests",
+      dependencies: [
+        "SwiftAtprotoLex",
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
       name: "MacrosTests",
       dependencies: [
         "Macros",

--- a/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
@@ -35,7 +35,7 @@ extension HTTPAPITypeDefinition {
         }
         EnumCaseDeclSyntax(leadingTrivia: docTrivia) {
           EnumCaseElementSyntax(
-            name: .identifier(error.name.camelCased()),
+            name: .lexIdentifier(error.name.camelCased()),
             parameterClause: EnumCaseParameterClauseSyntax(
               parameters: [
                 EnumCaseParameterSyntax(type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String"))))
@@ -94,7 +94,7 @@ extension HTTPAPITypeDefinition {
                 FunctionCallExprSyntax(
                   callee: MemberAccessExprSyntax(
                     period: .periodToken(),
-                    declName: DeclReferenceExprSyntax(baseName: .identifier(error.name.camelCased()))
+                    declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(error.name.camelCased()))
                   )
                 ) {
                   LabeledExprSyntax(
@@ -179,7 +179,7 @@ extension HTTPAPITypeDefinition {
                                 pattern: ExpressionPatternSyntax(
                                   expression: MemberAccessExprSyntax(
                                     period: .periodToken(),
-                                    declName: DeclReferenceExprSyntax(baseName: .identifier(error.name.camelCased()))
+                                    declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(error.name.camelCased()))
                                   )
                                 )
                               )
@@ -258,7 +258,7 @@ extension HTTPAPITypeDefinition {
                                       expression: FunctionCallExprSyntax(
                                         callee: MemberAccessExprSyntax(
                                           period: .periodToken(),
-                                          declName: DeclReferenceExprSyntax(baseName: .identifier(error.name.camelCased()))
+                                          declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(error.name.camelCased()))
                                         )
                                       ) {
                                         LabeledExprSyntax(

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -63,7 +63,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     return StructDeclSyntax(
       leadingTrivia: leadingTrivia,
       modifiers: [declModifierSyntax],
-      name: .identifier(name),
+      name: .lexIdentifier(name),
       inheritanceClause: InheritanceClauseSyntax(typeNames: ts.isRecord ? ["ATProtoRecord"] : ["Codable", "Hashable", "Sendable"])
     ) {
       if ts.isRecord {
@@ -161,7 +161,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                   value: NilLiteralExprSyntax()
                 )
               let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: true)
-              FunctionParameterSyntax(firstName: .identifier(key), type: type, defaultValue: defaultValue)
+              FunctionParameterSyntax(firstName: .lexIdentifier(key), type: type, defaultValue: defaultValue)
             }
           }
         )
@@ -171,10 +171,10 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
             MemberAccessExprSyntax(
               base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
               period: .periodToken(),
-              declName: DeclReferenceExprSyntax(baseName: .identifier(key))
+              declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
             )
             AssignmentExprSyntax(equal: .equalToken())
-            DeclReferenceExprSyntax(baseName: .identifier(key.escapedSwiftKeyword))
+            DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
           }
         }
         SequenceExprSyntax {
@@ -262,7 +262,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
             MemberAccessExprSyntax(
               base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self))),
               period: .periodToken(),
-              declName: DeclReferenceExprSyntax(baseName: .identifier(key))
+              declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
             )
             AssignmentExprSyntax(equal: .equalToken())
             TryExprSyntax(
@@ -286,7 +286,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                   colon: .colonToken(),
                   expression: MemberAccessExprSyntax(
                     period: .periodToken(),
-                    declName: DeclReferenceExprSyntax(baseName: .identifier(key))
+                    declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
                   )
                 )
               }
@@ -468,7 +468,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                 expression: MemberAccessExprSyntax(
                   base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
                   period: .periodToken(),
-                  declName: DeclReferenceExprSyntax(baseName: .identifier(key))
+                  declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
                 ),
                 trailingComma: .commaToken()
               )
@@ -477,7 +477,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                 colon: .colonToken(),
                 expression: MemberAccessExprSyntax(
                   period: .periodToken(),
-                  declName: DeclReferenceExprSyntax(baseName: .identifier(key))
+                  declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
                 )
               )
             }

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -275,7 +275,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
               ) {
                 LabeledExprSyntax(
                   expression: MemberAccessExprSyntax(
-                    base: DeclReferenceExprSyntax(baseName: .identifier(tname)),
+                    base: Lex.refExpr(tname),
                     period: .periodToken(),
                     declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
                   ),

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -212,7 +212,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       modifiers: [
         declModifierSyntax
       ],
-      name: .identifier(ts.typeName),
+      name: .lexIdentifier(ts.typeName),
       inheritanceClause: InheritanceClauseSyntax {
         InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCProcedure")))
       }
@@ -272,7 +272,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                   arguments: GenericArgumentListSyntax([
                                     GenericArgumentSyntax.create(
                                       argument: MemberTypeSyntax(
-                                        baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                        baseType: TypeSyntax(IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName))),
                                         period: .periodToken(),
                                         name: .identifier("AcceptableContentType")
                                       ))
@@ -307,7 +307,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                               genericArgumentClause: GenericArgumentClauseSyntax {
                                 GenericArgumentSyntax.create(
                                   argument: MemberTypeSyntax(
-                                    baseType: IdentifierTypeSyntax(name: .identifier(ts.typeName)),
+                                    baseType: IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName)),
                                     period: .periodToken(),
                                     name: .identifier("AcceptableContentType")
                                   )
@@ -355,7 +355,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                         MemberTypeSyntax(
                           baseType: TypeSyntax(
                             MemberTypeSyntax(
-                              baseType: IdentifierTypeSyntax(name: .identifier(ts.typeName)),
+                              baseType: IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName)),
                               period: .periodToken(),
                               name: .identifier("Input")
                             )),
@@ -387,7 +387,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                   ident: "body",
                   type: MemberTypeSyntax(
                     baseType: MemberTypeSyntax(
-                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName))),
                       name: .identifier("Input")
                     ),
                     name: .identifier("Body")
@@ -560,7 +560,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                           MemberTypeSyntax(
                                             baseType: TypeSyntax(
                                               MemberTypeSyntax(
-                                                baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                                baseType: TypeSyntax(IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName))),
                                                 period: .periodToken(),
                                                 name: .identifier("Output")
                                               )),
@@ -594,7 +594,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                             MemberTypeSyntax(
                                               baseType: TypeSyntax(
                                                 MemberTypeSyntax(
-                                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                                  baseType: TypeSyntax(IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName))),
                                                   period: .periodToken(),
                                                   name: .identifier("Output")
                                                 )),
@@ -645,7 +645,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                     MemberTypeSyntax(
                                       baseType: TypeSyntax(
                                         MemberTypeSyntax(
-                                          baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                          baseType: TypeSyntax(IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName))),
                                           period: .periodToken(),
                                           name: .identifier("Output")
                                         )),
@@ -675,7 +675,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                 MemberTypeSyntax(
                                   baseType: TypeSyntax(
                                     MemberTypeSyntax(
-                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .identifier(ts.typeName))),
+                                      baseType: TypeSyntax(IdentifierTypeSyntax(name: .lexIdentifier(ts.typeName))),
                                       period: .periodToken(),
                                       name: .identifier("Output")
                                     )),

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -70,7 +70,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
             leftParen: .leftParenToken(),
             parameters: EnumCaseParameterListSyntax([
               EnumCaseParameterSyntax(
-                type: IdentifierTypeSyntax(name: .identifier(token))
+                type: Lex.typeSyntax(token)
               )
             ]),
             rightParen: .rightParenToken()
@@ -107,7 +107,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     return nil
   }
 
-  func requestBody(fname: String, defMap: ExtDefMap, prefix: String) -> IdentifierTypeSyntax {
+  func requestBody(fname: String, defMap: ExtDefMap, prefix: String) -> TypeSyntax {
     if let input {
       switch input.encoding {
       case .json, .jsonl:
@@ -123,17 +123,17 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
           }
           return outname
         }()
-        return IdentifierTypeSyntax(name: .identifier(token))
+        return Lex.typeSyntax(token)
       case .text:
-        return IdentifierTypeSyntax(name: .identifier("String"))
+        return Lex.typeSyntax("String")
       case .cbor, .car, .any, .mp4:
-        return IdentifierTypeSyntax(name: .identifier("Data"))
+        return Lex.typeSyntax("Data")
       }
     }
-    return IdentifierTypeSyntax(name: .identifier("Bool"))
+    return Lex.typeSyntax("Bool")
   }
 
-  func responseBody(fname: String, defMap: ExtDefMap, prefix: String) -> IdentifierTypeSyntax {
+  func responseBody(fname: String, defMap: ExtDefMap, prefix: String) -> TypeSyntax {
     if let output {
       switch output.encoding {
       case .json, .jsonl:
@@ -149,14 +149,14 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
           }
           return outname
         }()
-        return IdentifierTypeSyntax(name: .identifier(token))
+        return Lex.typeSyntax(token)
       case .text:
-        return IdentifierTypeSyntax(name: .identifier("String"))
+        return Lex.typeSyntax("String")
       case .cbor, .car, .any, .mp4:
-        return IdentifierTypeSyntax(name: .identifier("Data"))
+        return Lex.typeSyntax("Data")
       }
     }
-    return IdentifierTypeSyntax(name: .identifier("EmptyResponse"))
+    return Lex.typeSyntax("EmptyResponse")
   }
 
   func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String, protocolRequirement _: Bool) -> [FunctionParameterSyntax] {

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -54,11 +54,11 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       }
       let type: TypeSyntax
       if isRequired {
-        type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(tn)))
+        type = Lex.typeSyntax(tn)
       } else {
         type = TypeSyntax(
           OptionalTypeSyntax(
-            wrappedType: IdentifierTypeSyntax(name: .identifier(tn)),
+            wrappedType: Lex.typeSyntax(tn),
             questionMark: .postfixQuestionMarkToken()
           ))
       }
@@ -73,8 +73,8 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     return queries
   }
 
-  func params(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [(key: String, isRequired: Bool, type: DeclReferenceExprSyntax)] {
-    var queries = [(key: String, isRequired: Bool, type: DeclReferenceExprSyntax)]()
+  func params(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [(key: String, isRequired: Bool, type: ExprSyntax)] {
+    var queries = [(key: String, isRequired: Bool, type: ExprSyntax)]()
     guard let parameters else { return queries }
     var required = [String: Bool]()
     for req in parameters.required ?? [] {
@@ -89,18 +89,18 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         let ts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: name, type: t)
         tn = TypeSchema.typeNameForField(name: name, k: "", v: ts, defMap: defMap, dropPrefix: false)
       }
-      let type = DeclReferenceExprSyntax(baseName: .identifier(tn))
+      let type = Lex.refExpr(tn)
       queries.append((key: name, isRequired: isRequired, type: type))
     }
     return queries
   }
 
-  func output(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> TokenSyntax {
+  func output(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> TypeSyntax {
     if let output {
       switch output.encoding {
       case .json, .jsonl:
         guard let schema = output.schema else {
-          return .identifier("EmptyResponse")
+          return Lex.typeSyntax("EmptyResponse")
         }
         let outname: String
         if case .ref(let def) = schema.type {
@@ -108,14 +108,14 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         } else {
           outname = "\(fname)_Output"
         }
-        return .identifier("\(prefix).\(outname)")
+        return Lex.typeSyntax("\(prefix).\(outname)")
       case .text:
-        return .identifier("String")
+        return Lex.typeSyntax("String")
       case .cbor, .car, .any, .mp4:
-        return .identifier("Data")
+        return Lex.typeSyntax("Data")
       }
     }
-    return .identifier("EmptyResponse")
+    return Lex.typeSyntax("EmptyResponse")
   }
 
   func rpcArguments(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String, protocolRequirement: Bool) -> [FunctionParameterSyntax] {
@@ -134,7 +134,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         let ts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: name, type: t)
         tn = TypeSchema.typeNameForField(name: name, k: "", v: ts, defMap: defMap, dropPrefix: false)
       }
-      let type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(tn)))
+      let type = Lex.typeSyntax(tn)
       let defaultValue: InitializerClauseSyntax?
       if protocolRequirement {
         defaultValue = nil
@@ -170,9 +170,9 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
           let isRequired = required[name] ?? false
           let stringLiteral =
             if case .string(let def) = t, def.enum != nil || def.knownValues != nil {
-              isRequired ? ".\(tn)(\(name).rawValue)" : ".\(tn)(\(name)?.rawValue)"
+              isRequired ? ".\(tn)(\(name.escapedSwiftKeyword).rawValue)" : ".\(tn)(\(name.escapedSwiftKeyword)?.rawValue)"
             } else {
-              ".\(tn)(\(name))"
+              ".\(tn)(\(name.escapedSwiftKeyword))"
             }
           DictionaryElementSyntax(
             key: StringLiteralExprSyntax(content: name),
@@ -227,7 +227,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         name: .identifier("ResponseBody"),
         initializer: TypeInitializerClauseSyntax(
           equal: .equalToken(),
-          value: IdentifierTypeSyntax(name: output(ts: ts, fname: name, defMap: defMap, prefix: Lex.structNameFor(prefix: ts.prefix)))
+          value: output(ts: ts, fname: name, defMap: defMap, prefix: Lex.structNameFor(prefix: ts.prefix))
         )
       )
       genQueryInput(ts: ts, name: name, type: type, prefix: ts.prefix, defMap: defMap, generate: generate)

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -64,7 +64,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       }
       queries.append(
         PatternBindingSyntax(
-          pattern: IdentifierPatternSyntax(identifier: .identifier(name)),
+          pattern: IdentifierPatternSyntax(identifier: .lexIdentifier(name)),
           typeAnnotation: TypeAnnotationSyntax(
             colon: .colonToken(),
             type: type
@@ -149,7 +149,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       }
       arguments.append(
         .init(
-          firstName: .identifier(name),
+          firstName: .lexIdentifier(name),
           type: isRequired
             ? type
             : TypeSyntax(OptionalTypeSyntax(wrappedType: type)), defaultValue: defaultValue))
@@ -195,7 +195,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       modifiers: [
         declModifierSyntax
       ],
-      name: .identifier(ts.typeName),
+      name: .lexIdentifier(ts.typeName),
       inheritanceClause: InheritanceClauseSyntax {
         InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCQuery")))
       }
@@ -283,10 +283,10 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
               MemberAccessExprSyntax(
                 base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
                 period: .periodToken(),
-                declName: DeclReferenceExprSyntax(baseName: .identifier(key))
+                declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
               )
               AssignmentExprSyntax(equal: .equalToken())
-              DeclReferenceExprSyntax(baseName: .identifier(key))
+              DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
             }
           }
         }

--- a/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
@@ -55,7 +55,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
           declModifierSyntax,
           DeclModifierSyntax(name: .keyword(.indirect)),
         ],
-        name: .identifier(name),
+        name: .lexIdentifier(name),
         inheritanceClause: InheritanceClauseSyntax(typeNames: ["String", "Codable", "Hashable"])
       ) {
         for value in cases {
@@ -228,7 +228,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
         declModifierSyntax,
         DeclModifierSyntax(name: .keyword(.indirect)),
       ],
-      name: .identifier(name),
+      name: .lexIdentifier(name),
       inheritanceClause: InheritanceClauseSyntax(typeNames: ["RawRepresentable", "Codable", "Hashable", "Sendable"])
     ) {
       for value in knownValues {
@@ -341,7 +341,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
                                       pattern: ExpressionPatternSyntax(
                                         expression: MemberAccessExprSyntax(
                                           period: .periodToken(),
-                                          declName: DeclReferenceExprSyntax(baseName: .identifier(value.camelCased()))
+                                          declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(value.camelCased()))
                                         ))
                                     )
                                   ],

--- a/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
@@ -44,18 +44,14 @@ struct UnionTypeDefinition: Codable, SwiftCodeGeneratable {
     ) {
       for cts in tss {
         let id = cts.defName == "main" ? cts.id : #"\#(cts.id)#\#(cts.defName)"#
-        let tn: TypeSyntaxProtocol =
+        let tn: TypeSyntax =
           cts.prefix == ts.prefix
-          ? IdentifierTypeSyntax(name: .identifier(cts.typeName.escapedSwiftKeyword))
-          : MemberTypeSyntax(
-            baseType: IdentifierTypeSyntax(name: .identifier(Lex.structNameFor(prefix: cts.prefix))),
-            period: .periodToken(),
-            name: .identifier(cts.typeName.escapedSwiftKeyword)
-          )
+          ? Lex.typeSyntax(cts.typeName)
+          : Lex.typeSyntax("\(Lex.structNameFor(prefix: cts.prefix)).\(cts.typeName)")
 
         EnumCaseDeclSyntax {
           EnumCaseElementSyntax(
-            name: .identifier(Lex.caseNameFromId(id: id, prefix: ts.prefix)),
+            name: .lexIdentifier(Lex.caseNameFromId(id: id, prefix: ts.prefix)),
             parameterClause: EnumCaseParameterClauseSyntax(
               parameters: [EnumCaseParameterSyntax(type: tn)]
             )
@@ -155,7 +151,7 @@ struct UnionTypeDefinition: Codable, SwiftCodeGeneratable {
                 TryExprSyntax(
                   expression: FunctionCallExprSyntax(
                     callee: MemberAccessExprSyntax(
-                      name: .identifier(Lex.caseNameFromId(id: id, prefix: ts.prefix))
+                      name: .lexIdentifier(Lex.caseNameFromId(id: id, prefix: ts.prefix))
                     )
                   ) {
                     LabeledExprSyntax(
@@ -224,7 +220,7 @@ struct UnionTypeDefinition: Codable, SwiftCodeGeneratable {
                   .init(
                     pattern: ExpressionPatternSyntax(
                       expression: FunctionCallExprSyntax(
-                        callee: MemberAccessExprSyntax(name: .identifier(Lex.caseNameFromId(id: id, prefix: ts.prefix)))
+                        callee: MemberAccessExprSyntax(name: .lexIdentifier(Lex.caseNameFromId(id: id, prefix: ts.prefix)))
                       ) {
                         LabeledExprSyntax(
                           expression: PatternExprSyntax(

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -143,7 +143,7 @@ extension Lex {
               colon: .colonToken(),
               type: MemberTypeSyntax(
                 baseType: MemberTypeSyntax(
-                  baseType: IdentifierTypeSyntax(name: .identifier(prefix)),
+                  baseType: Lex.typeSyntax(prefix),
                   period: .periodToken(),
                   name: .identifier(key)
                 ),
@@ -162,7 +162,7 @@ extension Lex {
           arrow: .arrowToken(),
           type: MemberTypeSyntax(
             baseType: MemberTypeSyntax(
-              baseType: IdentifierTypeSyntax(name: .identifier(prefix)),
+              baseType: Lex.typeSyntax(prefix),
               period: .periodToken(),
               name: .identifier(key)
             ),
@@ -189,7 +189,7 @@ extension Lex {
               colon: .colonToken(),
               type: MemberTypeSyntax(
                 baseType: MemberTypeSyntax(
-                  baseType: IdentifierTypeSyntax(name: .identifier(prefix)),
+                  baseType: Lex.typeSyntax(prefix),
                   period: .periodToken(),
                   name: .identifier(key)
                 ),
@@ -208,7 +208,7 @@ extension Lex {
           arrow: .arrowToken(),
           type: MemberTypeSyntax(
             baseType: MemberTypeSyntax(
-              baseType: IdentifierTypeSyntax(name: .identifier(prefix)),
+              baseType: Lex.typeSyntax(prefix),
               period: .periodToken(),
               name: .identifier(key)
             ),
@@ -504,7 +504,7 @@ extension Lex {
             LabeledExprSyntax(
               label: .identifier("forOperation", leadingTrivia: .newline),
               colon: .colonToken(),
-              expression: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("id")])
+              expression: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("id")])
             )
             LabeledExprSyntax(
               label: .identifier("using", leadingTrivia: .newline),
@@ -566,7 +566,7 @@ extension Lex {
           pattern: IdentifierPatternSyntax(identifier: .identifier("headers")),
           typeAnnotation: TypeAnnotationSyntax(
             colon: .colonToken(),
-            type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Headers")])
+            type: MemberTypeSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Headers")])
           ),
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
@@ -623,7 +623,7 @@ extension Lex {
               pattern: IdentifierPatternSyntax(identifier: .identifier("body")),
               typeAnnotation: TypeAnnotationSyntax(
                 colon: .colonToken(),
-                type: MemberTypeSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Body")])
+                type: MemberTypeSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Body")])
               )
             )
           ])
@@ -634,7 +634,7 @@ extension Lex {
       ReturnStmtSyntax(
         leadingTrivia: .newline,
         expression: FunctionCallExprSyntax(
-          callee: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input")])
+          callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input")])
         ) {
           LabeledExprSyntax(
             leadingTrivia: .newline,
@@ -727,7 +727,7 @@ extension Lex {
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
             value: FunctionCallExprSyntax(
-              callee: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Query")])
+              callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Query")])
             ) {
               for (i, (key, _)) in (def.parameters?.sortedProperties ?? []).enumerated() {
                 LabeledExprSyntax(
@@ -748,7 +748,7 @@ extension Lex {
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
             value: FunctionCallExprSyntax(
-              callee: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input"), .identifier("Headers")])
+              callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Headers")])
             ) {
               LabeledExprSyntax(
                 label: .identifier("accept"),
@@ -772,7 +772,7 @@ extension Lex {
       ReturnStmtSyntax(
         returnKeyword: .keyword(.return, leadingTrivia: .newline),
         expression: FunctionCallExprSyntax(
-          callee: MemberAccessExprSyntax(parts: [.identifier(prefix), .identifier(key), .identifier("Input")])
+          callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input")])
         ) {
           LabeledExprSyntax(
             label: .identifier("query", leadingTrivia: .newline),

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -85,7 +85,7 @@ extension Lex {
   }
 
   private static func makeXRPCMethodStub(leadingTrivia: Trivia? = nil, key: String, prefix: String) -> FunctionDeclSyntax {
-    let prefixIdent: [TokenSyntax] = Lex.structNameFor(prefix: prefix).split(separator: ".").map({ .identifier(String($0)) })
+    let prefixIdent: [TokenSyntax] = Lex.structNameFor(prefix: prefix).split(separator: ".").map({ .lexIdentifier(String($0)) })
     return FunctionDeclSyntax(
       modifiers: [DeclModifierSyntax(name: .keyword(.public))],
       name: .identifier("\(Lex.enumNameFor(prefix: prefix))\(key)"),
@@ -95,7 +95,7 @@ extension Lex {
             firstName: .wildcardToken(),
             secondName: .identifier("input"),
             colon: .colonToken(),
-            type: MemberTypeSyntax(parts: prefixIdent + [.identifier(key), .identifier("Input")])
+            type: MemberTypeSyntax(parts: prefixIdent + [.lexIdentifier(key), .identifier("Input")])
           )
         },
         effectSpecifiers: FunctionEffectSpecifiersSyntax(
@@ -103,7 +103,7 @@ extension Lex {
           throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
         ),
         returnClause: ReturnClauseSyntax(
-          type: MemberTypeSyntax(parts: prefixIdent + [.identifier(key), .identifier("Output")])
+          type: MemberTypeSyntax(parts: prefixIdent + [.lexIdentifier(key), .identifier("Output")])
         )
       )
     ) {
@@ -145,7 +145,7 @@ extension Lex {
                 baseType: MemberTypeSyntax(
                   baseType: Lex.typeSyntax(prefix),
                   period: .periodToken(),
-                  name: .identifier(key)
+                  name: .lexIdentifier(key)
                 ),
                 period: .periodToken(),
                 name: .identifier("Input")
@@ -164,7 +164,7 @@ extension Lex {
             baseType: MemberTypeSyntax(
               baseType: Lex.typeSyntax(prefix),
               period: .periodToken(),
-              name: .identifier(key)
+              name: .lexIdentifier(key)
             ),
             period: .periodToken(),
             name: .identifier("Output")
@@ -191,7 +191,7 @@ extension Lex {
                 baseType: MemberTypeSyntax(
                   baseType: Lex.typeSyntax(prefix),
                   period: .periodToken(),
-                  name: .identifier(key)
+                  name: .lexIdentifier(key)
                 ),
                 period: .periodToken(),
                 name: .identifier("Input")
@@ -210,7 +210,7 @@ extension Lex {
             baseType: MemberTypeSyntax(
               baseType: Lex.typeSyntax(prefix),
               period: .periodToken(),
-              name: .identifier(key)
+              name: .lexIdentifier(key)
             ),
             period: .periodToken(),
             name: .identifier("Output")
@@ -221,7 +221,7 @@ extension Lex {
   }
 
   private static func makeHandlerRegistration(leadingTrivia: Trivia? = nil, prefix: String, type: String, method: String) -> TryExprSyntax {
-    let prefixIdent: [TokenSyntax] = Lex.structNameFor(prefix: prefix).split(separator: ".").map({ .identifier(String($0)) })
+    let prefixIdent: [TokenSyntax] = Lex.structNameFor(prefix: prefix).split(separator: ".").map({ .lexIdentifier(String($0)) })
     return TryExprSyntax(
       leadingTrivia: leadingTrivia,
       expression: FunctionCallExprSyntax(
@@ -504,7 +504,7 @@ extension Lex {
             LabeledExprSyntax(
               label: .identifier("forOperation", leadingTrivia: .newline),
               colon: .colonToken(),
-              expression: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("id")])
+              expression: MemberAccessExprSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("id")])
             )
             LabeledExprSyntax(
               label: .identifier("using", leadingTrivia: .newline),
@@ -566,7 +566,7 @@ extension Lex {
           pattern: IdentifierPatternSyntax(identifier: .identifier("headers")),
           typeAnnotation: TypeAnnotationSyntax(
             colon: .colonToken(),
-            type: MemberTypeSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Headers")])
+            type: MemberTypeSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("Input"), .identifier("Headers")])
           ),
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
@@ -623,7 +623,7 @@ extension Lex {
               pattern: IdentifierPatternSyntax(identifier: .identifier("body")),
               typeAnnotation: TypeAnnotationSyntax(
                 colon: .colonToken(),
-                type: MemberTypeSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Body")])
+                type: MemberTypeSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("Input"), .identifier("Body")])
               )
             )
           ])
@@ -634,7 +634,7 @@ extension Lex {
       ReturnStmtSyntax(
         leadingTrivia: .newline,
         expression: FunctionCallExprSyntax(
-          callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input")])
+          callee: MemberAccessExprSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("Input")])
         ) {
           LabeledExprSyntax(
             leadingTrivia: .newline,
@@ -727,11 +727,11 @@ extension Lex {
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
             value: FunctionCallExprSyntax(
-              callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Query")])
+              callee: MemberAccessExprSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("Input"), .identifier("Query")])
             ) {
               for (i, (key, _)) in (def.parameters?.sortedProperties ?? []).enumerated() {
                 LabeledExprSyntax(
-                  label: .identifier(key),
+                  label: .lexIdentifier(key),
                   colon: .colonToken(),
                   expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("query\(i)")))
                 )
@@ -748,7 +748,7 @@ extension Lex {
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
             value: FunctionCallExprSyntax(
-              callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input"), .identifier("Headers")])
+              callee: MemberAccessExprSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("Input"), .identifier("Headers")])
             ) {
               LabeledExprSyntax(
                 label: .identifier("accept"),
@@ -772,7 +772,7 @@ extension Lex {
       ReturnStmtSyntax(
         returnKeyword: .keyword(.return, leadingTrivia: .newline),
         expression: FunctionCallExprSyntax(
-          callee: MemberAccessExprSyntax(parts: prefix.identifierSegments + [.identifier(key), .identifier("Input")])
+          callee: MemberAccessExprSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("Input")])
         ) {
           LabeledExprSyntax(
             label: .identifier("query", leadingTrivia: .newline),

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -199,7 +199,7 @@ class EnumDeclSyntaxNode {
       modifiers: [
         DeclModifierSyntax(name: .keyword(.public))
       ],
-      name: .identifier(name)
+      name: .lexIdentifier(name)
     ) {
       for childKey in children.keys.sorted() {
         children[childKey]!.generateEnums()
@@ -391,7 +391,7 @@ enum Lex {
                     DictionaryElementSyntax(
                       key: StringLiteralExprSyntax(openingQuote: .stringQuoteToken(leadingTrivia: .newline), content: recordType.id),
                       colon: .colonToken(),
-                      value: MemberAccessExprSyntax(parts: Lex.enumIdentifiersFor(prefix: recordType.prefix) + [.identifier(name), .keyword(.self)]),
+                      value: MemberAccessExprSyntax(parts: Lex.enumIdentifiersFor(prefix: recordType.prefix) + [.lexIdentifier(name), .keyword(.self)]),
                       trailingComma: .commaToken()
                     )
                   }
@@ -636,7 +636,7 @@ enum Lex {
   }
 
   static func enumIdentifiersFor(prefix: String) -> [TokenSyntax] {
-    prefix.split(separator: ".").map({ .identifier(String($0).capitalized) })
+    prefix.split(separator: ".").map({ .lexIdentifier(String($0).capitalized) })
   }
 
   static func caseNameFromId(id: String, prefix: String) -> String {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -636,7 +636,7 @@ enum Lex {
   }
 
   static func enumIdentifiersFor(prefix: String) -> [TokenSyntax] {
-    prefix.split(separator: ".").map({ .identifier(.init(String($0).capitalized)) })
+    prefix.split(separator: ".").map({ .identifier(String($0).capitalized) })
   }
 
   static func caseNameFromId(id: String, prefix: String) -> String {

--- a/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
@@ -2,9 +2,15 @@ import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+extension TokenSyntax {
+  static func lexIdentifier(_ name: String) -> TokenSyntax {
+    .identifier(name.escapedSwiftKeyword)
+  }
+}
+
 extension String {
-  var identifierSegments: [TokenSyntax] {
-    split(separator: ".", omittingEmptySubsequences: false).map { .identifier(String($0)) }
+  var lexIdentifierSegments: [TokenSyntax] {
+    split(separator: ".", omittingEmptySubsequences: false).map { .lexIdentifier(String($0)) }
   }
 }
 
@@ -13,17 +19,17 @@ extension Lex {
     if name.hasPrefix("["), name.hasSuffix("]") {
       return TypeSyntax(ArrayTypeSyntax(element: typeSyntax(String(name.dropFirst().dropLast()))))
     }
-    let segments = name.identifierSegments
+    let segments = name.lexIdentifierSegments
     if segments.count <= 1 {
-      return TypeSyntax(IdentifierTypeSyntax(name: .identifier(name)))
+      return TypeSyntax(IdentifierTypeSyntax(name: .lexIdentifier(name)))
     }
     return TypeSyntax(MemberTypeSyntax(parts: segments))
   }
 
   static func refExpr(_ name: String) -> ExprSyntax {
-    let segments = name.identifierSegments
+    let segments = name.lexIdentifierSegments
     if segments.count <= 1 {
-      return ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(name)))
+      return ExprSyntax(DeclReferenceExprSyntax(baseName: .lexIdentifier(name)))
     }
     return ExprSyntax(MemberAccessExprSyntax(parts: segments))
   }

--- a/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
@@ -2,6 +2,33 @@ import Foundation
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+extension String {
+  var identifierSegments: [TokenSyntax] {
+    split(separator: ".", omittingEmptySubsequences: false).map { .identifier(String($0)) }
+  }
+}
+
+extension Lex {
+  static func typeSyntax(_ name: String) -> TypeSyntax {
+    if name.hasPrefix("["), name.hasSuffix("]") {
+      return TypeSyntax(ArrayTypeSyntax(element: typeSyntax(String(name.dropFirst().dropLast()))))
+    }
+    let segments = name.identifierSegments
+    if segments.count <= 1 {
+      return TypeSyntax(IdentifierTypeSyntax(name: .identifier(name)))
+    }
+    return TypeSyntax(MemberTypeSyntax(parts: segments))
+  }
+
+  static func refExpr(_ name: String) -> ExprSyntax {
+    let segments = name.identifierSegments
+    if segments.count <= 1 {
+      return ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier(name)))
+    }
+    return ExprSyntax(MemberAccessExprSyntax(parts: segments))
+  }
+}
+
 extension MemberAccessExprSyntax {
   init(leadingTrivia: Trivia? = nil, parts: [TokenSyntax], isRoot: Bool = true) {
     precondition(!parts.isEmpty, "MemberAccessExprSyntax.init(parts:) requires at least one token.")

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -436,11 +436,11 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
     let type: TypeSyntax
     if case .string(let def) = property, def.enum != nil || def.knownValues != nil {
       let tn = "\(name)_\(key.titleCased())"
-      type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(!dropPrefix ? "\(Lex.structNameFor(prefix: prefix)).\(tn)" : tn)))
+      type = Lex.typeSyntax(!dropPrefix ? "\(Lex.structNameFor(prefix: prefix)).\(tn)" : tn)
     } else {
       let ts = TypeSchema(id: id, prefix: prefix, defName: key, type: property)
       let tn = Self.typeNameForField(name: name, k: key, v: ts, defMap: defMap, dropPrefix: dropPrefix)
-      type = TypeSyntax(IdentifierTypeSyntax(name: .identifier(tn)))
+      type = Lex.typeSyntax(tn)
     }
     if isRequired {
       return type

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -415,9 +415,9 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
                           if let properties = def.parameters?.sortedProperties {
                             for (name, _) in properties {
                               LabeledExprSyntax(
-                                label: .identifier(name),
+                                label: .lexIdentifier(name),
                                 colon: .colonToken(),
-                                expression: DeclReferenceExprSyntax(baseName: .identifier(name))
+                                expression: DeclReferenceExprSyntax(baseName: .lexIdentifier(name))
                               )
                             }
                           }

--- a/Tests/SwiftAtprotoLexTests/KeywordEscapingTests.swift
+++ b/Tests/SwiftAtprotoLexTests/KeywordEscapingTests.swift
@@ -1,0 +1,32 @@
+import SwiftSyntax
+import XCTest
+
+@testable import SwiftAtprotoLex
+
+final class KeywordEscapingTests: XCTestCase {
+  func testEscapedSwiftKeyword() {
+    XCTAssertEqual("default".escapedSwiftKeyword, "`default`")
+    XCTAssertEqual("in".escapedSwiftKeyword, "`in`")
+    XCTAssertEqual("Type".escapedSwiftKeyword, "`Type`")
+    XCTAssertEqual("foo".escapedSwiftKeyword, "foo")
+    XCTAssertEqual("async".escapedSwiftKeyword, "async")
+  }
+
+  func testLexIdentifier() {
+    XCTAssertEqual(TokenSyntax.lexIdentifier("default").text, "`default`")
+    XCTAssertEqual(TokenSyntax.lexIdentifier("foo").text, "foo")
+  }
+
+  func testTypeSyntax() {
+    XCTAssertEqual(Lex.typeSyntax("App.Bsky.Foo").description, "App.Bsky.Foo")
+    XCTAssertEqual(Lex.typeSyntax("App.Type.Foo").description, "App.`Type`.Foo")
+    XCTAssertEqual(Lex.typeSyntax("[App.Type]").description, "[App.`Type`]")
+    XCTAssertEqual(Lex.typeSyntax("default").description, "`default`")
+    XCTAssertEqual(Lex.typeSyntax("String").description, "String")
+  }
+
+  func testRefExpr() {
+    XCTAssertEqual(Lex.refExpr("App.Type").description, "App.`Type`")
+    XCTAssertEqual(Lex.refExpr("default").description, "`default`")
+  }
+}


### PR DESCRIPTION
This PR fixes generated code failing to compile when a lexicon uses Swift reserved words (e.g. `default`, `in`, `type`) as property names, enum/union/error case names, or type/namespace names. 