### PR TITLE
feat: add lexicon constraint validation to generated Swift code

### DIFF
--- a/Sources/SwiftAtproto/LexiconConstraintError.swift
+++ b/Sources/SwiftAtproto/LexiconConstraintError.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum LexiconConstraintError: Error {
+  case stringTooLong(_ field: String, limit: Int)
+  case stringTooShort(_ field: String, minimum: Int)
+  case tooManyGraphemes(_ field: String, limit: Int)
+  case tooFewGraphemes(_ field: String, minimum: Int)
+  case integerBelowMinimum(_ field: String, minimum: Int)
+  case integerAboveMaximum(_ field: String, maximum: Int)
+  case arrayTooLong(_ field: String, limit: Int)
+  case arrayTooShort(_ field: String, minimum: Int)
+  case bytesTooLong(_ field: String, limit: Int)
+  case bytesTooShort(_ field: String, minimum: Int)
+  case blobTooLarge(_ field: String, limit: Int)
+}

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -5,7 +5,7 @@ extension FieldTypeDefinition {
   var hasConstraints: Bool {
     switch self {
     case .string(let def) where def.enum == nil:
-      def.maxLength != nil
+      def.maxLength != nil || def.minLength != nil
     default:
       false
     }
@@ -96,6 +96,17 @@ extension FieldTypeDefinition {
             argLabel: "limit"
           ))
       }
+      if let n = def.minLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("utf8"), .identifier("count")]),
+            op: ">=",
+            rhs: n,
+            errorCase: "stringTooShort",
+            field: field,
+            argLabel: "minimum"
+          ))
+      }
       return items
     case .string(let def) where def.enum == nil && def.knownValues != nil:
       var items = [CodeBlockItemSyntax]()
@@ -109,6 +120,18 @@ extension FieldTypeDefinition {
             errorCase: "stringTooLong",
             field: field,
             argLabel: "limit"
+          ))
+      }
+      if let n = def.minLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(
+              parts: [.identifier(ref), .identifier("rawValue"), .identifier("utf8"), .identifier("count")]),
+            op: ">=",
+            rhs: n,
+            errorCase: "stringTooShort",
+            field: field,
+            argLabel: "minimum"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -7,7 +7,7 @@ extension FieldTypeDefinition {
     case .string(let def) where def.enum == nil:
       def.maxLength != nil || def.minLength != nil || def.maxGraphemes != nil || def.minGraphemes != nil
     case .integer(let def):
-      def.minimum != nil
+      def.minimum != nil || def.maximum != nil
     default:
       false
     }
@@ -194,6 +194,17 @@ extension FieldTypeDefinition {
             errorCase: "integerBelowMinimum",
             field: field,
             argLabel: "minimum"
+          ))
+      }
+      if let n = def.maximum {
+        items.append(
+          constraintGuardItem(
+            lhs: DeclReferenceExprSyntax(baseName: .lexIdentifier(ref)),
+            op: "<=",
+            rhs: n,
+            errorCase: "integerAboveMaximum",
+            field: field,
+            argLabel: "maximum"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -4,6 +4,8 @@ import SwiftSyntaxBuilder
 extension FieldTypeDefinition {
   var hasConstraints: Bool {
     switch self {
+    case .string(let def) where def.enum == nil:
+      def.maxLength != nil
     default:
       false
     }
@@ -81,6 +83,35 @@ extension FieldTypeDefinition {
 
   private func constraintGuardStmts(ref: String, field: String) -> [CodeBlockItemSyntax] {
     switch self {
+    case .string(let def) where def.enum == nil && def.knownValues == nil:
+      var items = [CodeBlockItemSyntax]()
+      if let n = def.maxLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("utf8"), .identifier("count")]),
+            op: "<=",
+            rhs: n,
+            errorCase: "stringTooLong",
+            field: field,
+            argLabel: "limit"
+          ))
+      }
+      return items
+    case .string(let def) where def.enum == nil && def.knownValues != nil:
+      var items = [CodeBlockItemSyntax]()
+      if let n = def.maxLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(
+              parts: [.identifier(ref), .identifier("rawValue"), .identifier("utf8"), .identifier("count")]),
+            op: "<=",
+            rhs: n,
+            errorCase: "stringTooLong",
+            field: field,
+            argLabel: "limit"
+          ))
+      }
+      return items
     default:
       return []
     }

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -10,6 +10,8 @@ extension FieldTypeDefinition {
       def.minimum != nil || def.maximum != nil
     case .array(let def):
       def.minLength != nil || def.maxLength != nil
+    case .bytes(let def):
+      def.maxLength != nil
     default:
       false
     }
@@ -232,6 +234,20 @@ extension FieldTypeDefinition {
             errorCase: "arrayTooShort",
             field: field,
             argLabel: "minimum"
+          ))
+      }
+      return items
+    case .bytes(let def):
+      var items = [CodeBlockItemSyntax]()
+      if let n = def.maxLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("count")]),
+            op: "<=",
+            rhs: n,
+            errorCase: "bytesTooLong",
+            field: field,
+            argLabel: "limit"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -5,7 +5,7 @@ extension FieldTypeDefinition {
   var hasConstraints: Bool {
     switch self {
     case .string(let def) where def.enum == nil:
-      def.maxLength != nil || def.minLength != nil
+      def.maxLength != nil || def.minLength != nil || def.maxGraphemes != nil
     default:
       false
     }
@@ -107,6 +107,17 @@ extension FieldTypeDefinition {
             argLabel: "minimum"
           ))
       }
+      if let n = def.maxGraphemes {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("count")]),
+            op: "<=",
+            rhs: n,
+            errorCase: "tooManyGraphemes",
+            field: field,
+            argLabel: "limit"
+          ))
+      }
       return items
     case .string(let def) where def.enum == nil && def.knownValues != nil:
       var items = [CodeBlockItemSyntax]()
@@ -132,6 +143,18 @@ extension FieldTypeDefinition {
             errorCase: "stringTooShort",
             field: field,
             argLabel: "minimum"
+          ))
+      }
+      if let n = def.maxGraphemes {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(
+              parts: [.identifier(ref), .identifier("rawValue"), .identifier("count")]),
+            op: "<=",
+            rhs: n,
+            errorCase: "tooManyGraphemes",
+            field: field,
+            argLabel: "limit"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -11,7 +11,7 @@ extension FieldTypeDefinition {
     case .array(let def):
       def.minLength != nil || def.maxLength != nil
     case .bytes(let def):
-      def.maxLength != nil
+      def.minLength != nil || def.maxLength != nil
     default:
       false
     }
@@ -248,6 +248,17 @@ extension FieldTypeDefinition {
             errorCase: "bytesTooLong",
             field: field,
             argLabel: "limit"
+          ))
+      }
+      if let n = def.minLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("count")]),
+            op: ">=",
+            rhs: n,
+            errorCase: "bytesTooShort",
+            field: field,
+            argLabel: "minimum"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -12,6 +12,8 @@ extension FieldTypeDefinition {
       def.minLength != nil || def.maxLength != nil
     case .bytes(let def):
       def.minLength != nil || def.maxLength != nil
+    case .blob(let def):
+      def.maxSize != nil
     default:
       false
     }
@@ -259,6 +261,28 @@ extension FieldTypeDefinition {
             errorCase: "bytesTooShort",
             field: field,
             argLabel: "minimum"
+          ))
+      }
+      return items
+    case .blob(let def):
+      var items = [CodeBlockItemSyntax]()
+      if let n = def.maxSize {
+        items.append(
+          constraintGuardItem(
+            lhs: FunctionCallExprSyntax(
+              callee: DeclReferenceExprSyntax(baseName: .identifier("Int"))
+            ) {
+              LabeledExprSyntax(
+                expression: MemberAccessExprSyntax(
+                  parts: [.lexIdentifier(ref), .identifier("size")]
+                )
+              )
+            },
+            op: "<=",
+            rhs: n,
+            errorCase: "blobTooLarge",
+            field: field,
+            argLabel: "limit"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -6,6 +6,8 @@ extension FieldTypeDefinition {
     switch self {
     case .string(let def) where def.enum == nil:
       def.maxLength != nil || def.minLength != nil || def.maxGraphemes != nil || def.minGraphemes != nil
+    case .integer(let def):
+      def.minimum != nil
     default:
       false
     }
@@ -176,6 +178,20 @@ extension FieldTypeDefinition {
             op: ">=",
             rhs: n,
             errorCase: "tooFewGraphemes",
+            field: field,
+            argLabel: "minimum"
+          ))
+      }
+      return items
+    case .integer(let def):
+      var items = [CodeBlockItemSyntax]()
+      if let n = def.minimum {
+        items.append(
+          constraintGuardItem(
+            lhs: DeclReferenceExprSyntax(baseName: .lexIdentifier(ref)),
+            op: ">=",
+            rhs: n,
+            errorCase: "integerBelowMinimum",
             field: field,
             argLabel: "minimum"
           ))

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -1,0 +1,88 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension FieldTypeDefinition {
+  var hasConstraints: Bool {
+    switch self {
+    default:
+      false
+    }
+  }
+
+  func constraintGuardItems(for key: String, optional: Bool) -> CodeBlockItemListSyntax {
+    let ref = key.escapedSwiftKeyword
+    let stmts = constraintGuardStmts(ref: ref, field: key)
+    guard !stmts.isEmpty else { return [] }
+    if optional {
+      return CodeBlockItemListSyntax([
+        CodeBlockItemSyntax(
+          item: .expr(
+            ExprSyntax(
+              IfExprSyntax(
+                conditions: ConditionElementListSyntax {
+                  OptionalBindingConditionSyntax(
+                    bindingSpecifier: .keyword(.let),
+                    pattern: IdentifierPatternSyntax(identifier: .lexIdentifier(ref))
+                  )
+                }
+              ) {
+                for stmt in stmts { stmt }
+              }
+            )
+          )
+        )
+      ])
+    } else {
+      return CodeBlockItemListSyntax(stmts)
+    }
+  }
+
+  private func constraintGuardItem(
+    lhs: some ExprSyntaxProtocol,
+    op: String,
+    rhs: Int,
+    errorCase: String,
+    field: String,
+    argLabel: String
+  ) -> CodeBlockItemSyntax {
+    CodeBlockItemSyntax(
+      item: .stmt(
+        StmtSyntax(
+          GuardStmtSyntax(
+            conditions: ConditionElementListSyntax {
+              SequenceExprSyntax {
+                lhs
+                BinaryOperatorExprSyntax(operator: .binaryOperator(op))
+                IntegerLiteralExprSyntax(literal: .integerLiteral("\(rhs)"))
+              }
+            }
+          ) {
+            ThrowStmtSyntax(
+              expression: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(
+                  base: DeclReferenceExprSyntax(baseName: .identifier("LexiconConstraintError")),
+                  period: .periodToken(),
+                  declName: DeclReferenceExprSyntax(baseName: .identifier(errorCase))
+                )
+              ) {
+                LabeledExprSyntax(expression: StringLiteralExprSyntax(content: field))
+                LabeledExprSyntax(
+                  label: .identifier(argLabel),
+                  colon: .colonToken(),
+                  expression: IntegerLiteralExprSyntax(literal: .integerLiteral("\(rhs)"))
+                )
+              }
+            )
+          }
+        )
+      )
+    )
+  }
+
+  private func constraintGuardStmts(ref: String, field: String) -> [CodeBlockItemSyntax] {
+    switch self {
+    default:
+      return []
+    }
+  }
+}

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -8,6 +8,8 @@ extension FieldTypeDefinition {
       def.maxLength != nil || def.minLength != nil || def.maxGraphemes != nil || def.minGraphemes != nil
     case .integer(let def):
       def.minimum != nil || def.maximum != nil
+    case .array(let def):
+      def.maxLength != nil
     default:
       false
     }
@@ -205,6 +207,20 @@ extension FieldTypeDefinition {
             errorCase: "integerAboveMaximum",
             field: field,
             argLabel: "maximum"
+          ))
+      }
+      return items
+    case .array(let def):
+      var items = [CodeBlockItemSyntax]()
+      if let n = def.maxLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("count")]),
+            op: "<=",
+            rhs: n,
+            errorCase: "arrayTooLong",
+            field: field,
+            argLabel: "limit"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -5,7 +5,7 @@ extension FieldTypeDefinition {
   var hasConstraints: Bool {
     switch self {
     case .string(let def) where def.enum == nil:
-      def.maxLength != nil || def.minLength != nil || def.maxGraphemes != nil
+      def.maxLength != nil || def.minLength != nil || def.maxGraphemes != nil || def.minGraphemes != nil
     default:
       false
     }
@@ -118,6 +118,17 @@ extension FieldTypeDefinition {
             argLabel: "limit"
           ))
       }
+      if let n = def.minGraphemes {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("count")]),
+            op: ">=",
+            rhs: n,
+            errorCase: "tooFewGraphemes",
+            field: field,
+            argLabel: "minimum"
+          ))
+      }
       return items
     case .string(let def) where def.enum == nil && def.knownValues != nil:
       var items = [CodeBlockItemSyntax]()
@@ -155,6 +166,18 @@ extension FieldTypeDefinition {
             errorCase: "tooManyGraphemes",
             field: field,
             argLabel: "limit"
+          ))
+      }
+      if let n = def.minGraphemes {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(
+              parts: [.identifier(ref), .identifier("rawValue"), .identifier("count")]),
+            op: ">=",
+            rhs: n,
+            errorCase: "tooFewGraphemes",
+            field: field,
+            argLabel: "minimum"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -9,7 +9,7 @@ extension FieldTypeDefinition {
     case .integer(let def):
       def.minimum != nil || def.maximum != nil
     case .array(let def):
-      def.maxLength != nil
+      def.minLength != nil || def.maxLength != nil
     default:
       false
     }
@@ -221,6 +221,17 @@ extension FieldTypeDefinition {
             errorCase: "arrayTooLong",
             field: field,
             argLabel: "limit"
+          ))
+      }
+      if let n = def.minLength {
+        items.append(
+          constraintGuardItem(
+            lhs: MemberAccessExprSyntax(parts: [.identifier(ref), .identifier("count")]),
+            op: ">=",
+            rhs: n,
+            errorCase: "arrayTooShort",
+            field: field,
+            argLabel: "minimum"
           ))
       }
       return items

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -60,6 +60,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     for key in nullable ?? [] {
       required[key] = false
     }
+    let hasConstraints = sortedProperties.contains { $0.1.hasConstraints }
     return StructDeclSyntax(
       leadingTrivia: leadingTrivia,
       modifiers: [declModifierSyntax],
@@ -144,52 +145,11 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
           )
         ]
       )
-      InitializerDeclSyntax(
-        leadingTrivia: .newlines(2),
-        modifiers: [
-          DeclModifierSyntax(name: .keyword(.public))
-        ],
-        signature: FunctionSignatureSyntax(
-          parameterClause: FunctionParameterClauseSyntax {
-            for (key, property) in sortedProperties {
-              let isRequired = required[key] ?? false
-              let defaultValue: InitializerClauseSyntax? =
-                isRequired
-                ? nil
-                : InitializerClauseSyntax(
-                  equal: .equalToken(),
-                  value: NilLiteralExprSyntax()
-                )
-              let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: true)
-              FunctionParameterSyntax(firstName: .lexIdentifier(key), type: type, defaultValue: defaultValue)
-            }
-          }
-        )
-      ) {
-        for (key, _) in sortedProperties {
-          SequenceExprSyntax {
-            MemberAccessExprSyntax(
-              base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
-              period: .periodToken(),
-              declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
-            )
-            AssignmentExprSyntax(equal: .equalToken())
-            DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
-          }
-        }
-        SequenceExprSyntax {
-          MemberAccessExprSyntax(
-            base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
-            period: .periodToken(),
-            declName: DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
-          )
-          AssignmentExprSyntax(equal: .equalToken())
-          DictionaryExprSyntax(
-            leftSquare: .leftSquareToken(),
-            content: DictionaryExprSyntax.Content(.colonToken()),
-            rightSquare: .rightSquareToken()
-          )
-        }
+      memberwiseInitDecl(ts: ts, name: name, defMap: defMap, required: required)
+        .with(\.leadingTrivia, .newlines(2))
+      if hasConstraints {
+        staticMakeDecl(ts: ts, name: name, defMap: defMap, required: required)
+          .with(\.leadingTrivia, .newlines(2))
       }
       if !enumCaseIsEmpty {
         EnumDeclSyntax(
@@ -213,19 +173,101 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
           }
         }
       }
-      decodableInitializerDeclSyntax(leadingTrivia: .newlines(2)) {
-        if !enumCaseIsEmpty {
+      if hasConstraints {
+        constraintDecodableInitDecl(ts: ts, name: name, defMap: defMap, required: required)
+          .with(\.leadingTrivia, .newlines(2))
+      } else {
+        decodableInitializerDeclSyntax(leadingTrivia: .newlines(2)) {
+          if !enumCaseIsEmpty {
+            VariableDeclSyntax(
+              bindingSpecifier: .keyword(.let),
+              bindings: PatternBindingListSyntax([
+                PatternBindingSyntax(
+                  pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("keyedContainer"))),
+                  initializer: InitializerClauseSyntax(
+                    equal: .equalToken(),
+                    value: TryExprSyntax(
+                      expression: FunctionCallExprSyntax(
+                        callee: MemberAccessExprSyntax(
+                          base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("decoder"))),
+                          period: .periodToken(),
+                          declName: DeclReferenceExprSyntax(baseName: .identifier("container"))
+                        )
+                      ) {
+                        LabeledExprSyntax(
+                          label: .identifier("keyedBy"),
+                          colon: .colonToken(),
+                          expression: ExprSyntax(
+                            MemberAccessExprSyntax(
+                              base: DeclReferenceExprSyntax(baseName: .identifier("CodingKeys")),
+                              period: .periodToken(),
+                              declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                            ))
+                        )
+                      }
+                    )
+                  )
+                )
+              ])
+            )
+          }
+          for (key, property) in sortedProperties {
+            let isRequired = required[key] ?? false
+            let tname: String = {
+              if case .string(let def) = property, def.enum != nil || def.knownValues != nil {
+                let tname = "\(name)_\(key.titleCased())"
+                return "\(Lex.structNameFor(prefix: ts.prefix)).\(tname)"
+              } else {
+                let cts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: key, type: property)
+                return TypeSchema.typeNameForField(name: name, k: key, v: cts, defMap: defMap, dropPrefix: true)
+              }
+            }()
+            SequenceExprSyntax {
+              MemberAccessExprSyntax(
+                base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self))),
+                period: .periodToken(),
+                declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+              )
+              AssignmentExprSyntax(equal: .equalToken())
+              TryExprSyntax(
+                expression: FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: .identifier("keyedContainer")),
+                    period: .periodToken(),
+                    declName: DeclReferenceExprSyntax(baseName: .identifier(isRequired ? "decode" : "decodeIfPresent"))
+                  )
+                ) {
+                  LabeledExprSyntax(
+                    expression: MemberAccessExprSyntax(
+                      base: Lex.refExpr(tname),
+                      period: .periodToken(),
+                      declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                    ),
+                    trailingComma: .commaToken()
+                  )
+                  LabeledExprSyntax(
+                    label: .identifier("forKey"),
+                    colon: .colonToken(),
+                    expression: MemberAccessExprSyntax(
+                      period: .periodToken(),
+                      declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+                    )
+                  )
+                }
+              )
+            }
+          }
           VariableDeclSyntax(
             bindingSpecifier: .keyword(.let),
-            bindings: PatternBindingListSyntax([
+            bindings: [
               PatternBindingSyntax(
-                pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("keyedContainer"))),
+                pattern: IdentifierPatternSyntax(identifier: .identifier("unknownContainer")),
                 initializer: InitializerClauseSyntax(
                   equal: .equalToken(),
                   value: TryExprSyntax(
                     expression: FunctionCallExprSyntax(
                       callee: MemberAccessExprSyntax(
-                        base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("decoder"))),
+                        base: DeclReferenceExprSyntax(baseName: .identifier("decoder")),
                         period: .periodToken(),
                         declName: DeclReferenceExprSyntax(baseName: .identifier("container"))
                       )
@@ -235,7 +277,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                         colon: .colonToken(),
                         expression: ExprSyntax(
                           MemberAccessExprSyntax(
-                            base: DeclReferenceExprSyntax(baseName: .identifier("CodingKeys")),
+                            base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodingKeys"))),
                             period: .periodToken(),
                             declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
                           ))
@@ -244,183 +286,106 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                   )
                 )
               )
-            ])
+            ]
           )
-        }
-        for (key, property) in sortedProperties {
-          let isRequired = required[key] ?? false
-          let tname: String = {
-            if case .string(let def) = property, def.enum != nil || def.knownValues != nil {
-              let tname = "\(name)_\(key.titleCased())"
-              return "\(Lex.structNameFor(prefix: ts.prefix)).\(tname)"
-            } else {
-              let cts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: key, type: property)
-              return TypeSchema.typeNameForField(name: name, k: key, v: cts, defMap: defMap, dropPrefix: true)
+          VariableDeclSyntax(
+            bindingSpecifier: .keyword(.var),
+            bindings: [
+              PatternBindingSyntax(
+                pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("_unknownValues"))),
+                initializer: InitializerClauseSyntax(
+                  equal: .equalToken(),
+                  value: FunctionCallExprSyntax(
+                    callee: DictionaryExprSyntax(
+                      leftSquare: .leftSquareToken(),
+                      content: DictionaryExprSyntax.Content(
+                        DictionaryElementListSyntax([
+                          DictionaryElementSyntax(
+                            key: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("String"))),
+                            colon: .colonToken(),
+                            value: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")))
+                          )
+                        ])),
+                      rightSquare: .rightSquareToken()
+                    ))
+                )
+              )
+            ]
+          )
+          ForStmtSyntax(
+            pattern: IdentifierPatternSyntax(identifier: .identifier("key")),
+            sequence: MemberAccessExprSyntax(
+              base: DeclReferenceExprSyntax(baseName: .identifier("unknownContainer")),
+              period: .periodToken(),
+              declName: DeclReferenceExprSyntax(baseName: .identifier("allKeys"))
+            )
+          ) {
+            if !sortedKeys.isEmpty || ts.isRecord {
+              GuardStmtSyntax(
+                conditions: ConditionElementListSyntax {
+                  SequenceExprSyntax {
+                    FunctionCallExprSyntax(
+                      callee: DeclReferenceExprSyntax(baseName: .identifier("CodingKeys"))
+                    ) {
+                      LabeledExprSyntax(
+                        label: .identifier("rawValue"),
+                        colon: .colonToken(),
+                        expression: MemberAccessExprSyntax(
+                          base: DeclReferenceExprSyntax(baseName: .identifier("key")),
+                          period: .periodToken(),
+                          declName: DeclReferenceExprSyntax(baseName: .identifier("stringValue"))
+                        )
+                      )
+                    }
+                    BinaryOperatorExprSyntax(operator: .binaryOperator("=="))
+                    NilLiteralExprSyntax()
+                  }
+                }
+              ) {
+                ContinueStmtSyntax(continueKeyword: .keyword(.continue))
+              }
             }
-          }()
+            SequenceExprSyntax {
+              SubscriptCallExprSyntax(
+                calledExpression: DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
+              ) {
+                LabeledExprSyntax(
+                  expression: MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: .identifier("key")),
+                    period: .periodToken(),
+                    declName: DeclReferenceExprSyntax(baseName: .identifier("stringValue"))
+                  ))
+              }
+              AssignmentExprSyntax(equal: .equalToken())
+              TryExprSyntax(
+                expression: FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(parts: [.identifier("unknownContainer"), .identifier("decode")])
+                ) {
+                  LabeledExprSyntax(
+                    expression: MemberAccessExprSyntax(
+                      base: DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")),
+                      period: .periodToken(),
+                      declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                    )
+                  )
+                  LabeledExprSyntax(
+                    label: .identifier("forKey"),
+                    colon: .colonToken(),
+                    expression: DeclReferenceExprSyntax(baseName: .identifier("key"))
+                  )
+                }
+              )
+            }
+          }
           SequenceExprSyntax {
             MemberAccessExprSyntax(
-              base: ExprSyntax(DeclReferenceExprSyntax(baseName: .keyword(.self))),
+              base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
               period: .periodToken(),
-              declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+              declName: DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
             )
             AssignmentExprSyntax(equal: .equalToken())
-            TryExprSyntax(
-              expression: FunctionCallExprSyntax(
-                callee: MemberAccessExprSyntax(
-                  base: DeclReferenceExprSyntax(baseName: .identifier("keyedContainer")),
-                  period: .periodToken(),
-                  declName: DeclReferenceExprSyntax(baseName: .identifier(isRequired ? "decode" : "decodeIfPresent"))
-                )
-              ) {
-                LabeledExprSyntax(
-                  expression: MemberAccessExprSyntax(
-                    base: Lex.refExpr(tname),
-                    period: .periodToken(),
-                    declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
-                  ),
-                  trailingComma: .commaToken()
-                )
-                LabeledExprSyntax(
-                  label: .identifier("forKey"),
-                  colon: .colonToken(),
-                  expression: MemberAccessExprSyntax(
-                    period: .periodToken(),
-                    declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
-                  )
-                )
-              }
-            )
+            DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
           }
-        }
-        VariableDeclSyntax(
-          bindingSpecifier: .keyword(.let),
-          bindings: [
-            PatternBindingSyntax(
-              pattern: IdentifierPatternSyntax(identifier: .identifier("unknownContainer")),
-              initializer: InitializerClauseSyntax(
-                equal: .equalToken(),
-                value: TryExprSyntax(
-                  expression: FunctionCallExprSyntax(
-                    callee: MemberAccessExprSyntax(
-                      base: DeclReferenceExprSyntax(baseName: .identifier("decoder")),
-                      period: .periodToken(),
-                      declName: DeclReferenceExprSyntax(baseName: .identifier("container"))
-                    )
-                  ) {
-                    LabeledExprSyntax(
-                      label: .identifier("keyedBy"),
-                      colon: .colonToken(),
-                      expression: ExprSyntax(
-                        MemberAccessExprSyntax(
-                          base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodingKeys"))),
-                          period: .periodToken(),
-                          declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
-                        ))
-                    )
-                  }
-                )
-              )
-            )
-          ]
-        )
-        VariableDeclSyntax(
-          bindingSpecifier: .keyword(.var),
-          bindings: [
-            PatternBindingSyntax(
-              pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("_unknownValues"))),
-              initializer: InitializerClauseSyntax(
-                equal: .equalToken(),
-                value: FunctionCallExprSyntax(
-                  callee: DictionaryExprSyntax(
-                    leftSquare: .leftSquareToken(),
-                    content: DictionaryExprSyntax.Content(
-                      DictionaryElementListSyntax([
-                        DictionaryElementSyntax(
-                          key: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("String"))),
-                          colon: .colonToken(),
-                          value: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")))
-                        )
-                      ])),
-                    rightSquare: .rightSquareToken()
-                  ))
-              )
-            )
-          ]
-        )
-        ForStmtSyntax(
-          pattern: IdentifierPatternSyntax(identifier: .identifier("key")),
-          sequence: MemberAccessExprSyntax(
-            base: DeclReferenceExprSyntax(baseName: .identifier("unknownContainer")),
-            period: .periodToken(),
-            declName: DeclReferenceExprSyntax(baseName: .identifier("allKeys"))
-          )
-        ) {
-          if !sortedKeys.isEmpty || ts.isRecord {
-            GuardStmtSyntax(
-              conditions: ConditionElementListSyntax {
-                SequenceExprSyntax {
-                  FunctionCallExprSyntax(
-                    callee: DeclReferenceExprSyntax(baseName: .identifier("CodingKeys"))
-                  ) {
-                    LabeledExprSyntax(
-                      label: .identifier("rawValue"),
-                      colon: .colonToken(),
-                      expression: MemberAccessExprSyntax(
-                        base: DeclReferenceExprSyntax(baseName: .identifier("key")),
-                        period: .periodToken(),
-                        declName: DeclReferenceExprSyntax(baseName: .identifier("stringValue"))
-                      )
-                    )
-                  }
-                  BinaryOperatorExprSyntax(operator: .binaryOperator("=="))
-                  NilLiteralExprSyntax()
-                }
-              }
-            ) {
-              ContinueStmtSyntax(continueKeyword: .keyword(.continue))
-            }
-          }
-          SequenceExprSyntax {
-            SubscriptCallExprSyntax(
-              calledExpression: DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
-            ) {
-              LabeledExprSyntax(
-                expression: MemberAccessExprSyntax(
-                  base: DeclReferenceExprSyntax(baseName: .identifier("key")),
-                  period: .periodToken(),
-                  declName: DeclReferenceExprSyntax(baseName: .identifier("stringValue"))
-                ))
-            }
-            AssignmentExprSyntax(equal: .equalToken())
-            TryExprSyntax(
-              expression: FunctionCallExprSyntax(
-                callee: MemberAccessExprSyntax(parts: [.identifier("unknownContainer"), .identifier("decode")])
-              ) {
-                LabeledExprSyntax(
-                  expression: MemberAccessExprSyntax(
-                    base: DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")),
-                    period: .periodToken(),
-                    declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
-                  )
-                )
-                LabeledExprSyntax(
-                  label: .identifier("forKey"),
-                  colon: .colonToken(),
-                  expression: DeclReferenceExprSyntax(baseName: .identifier("key"))
-                )
-              }
-            )
-          }
-        }
-        SequenceExprSyntax {
-          MemberAccessExprSyntax(
-            base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
-            period: .periodToken(),
-            declName: DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
-          )
-          AssignmentExprSyntax(equal: .equalToken())
-          DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
         }
       }
       encodableFunctionDeclSyntax(leadingTrivia: .newlines(2)) {
@@ -499,6 +464,408 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
           }
         )
       }
+    }
+  }
+
+  private func decodeTypeName(ts: TypeSchema, name: String, key: String, property: FieldTypeDefinition, defMap: ExtDefMap) -> String {
+    if case .string(let def) = property, def.enum != nil || def.knownValues != nil {
+      let tname = "\(name)_\(key.titleCased())"
+      return "\(Lex.structNameFor(prefix: ts.prefix)).\(tname)"
+    } else {
+      let cts = TypeSchema(id: ts.id, prefix: ts.prefix, defName: key, type: property)
+      return TypeSchema.typeNameForField(name: name, k: key, v: cts, defMap: defMap, dropPrefix: true)
+    }
+  }
+
+  private func memberwiseInitDecl(ts: TypeSchema, name: String, defMap: ExtDefMap, required: [String: Bool]) -> InitializerDeclSyntax {
+    InitializerDeclSyntax(
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      signature: FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax {
+          for (key, property) in sortedProperties {
+            let isRequired = required[key] ?? false
+            let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: true)
+            let defaultValue: InitializerClauseSyntax? =
+              isRequired
+              ? nil
+              : InitializerClauseSyntax(equal: .equalToken(), value: NilLiteralExprSyntax())
+            FunctionParameterSyntax(firstName: .lexIdentifier(key), type: type, defaultValue: defaultValue)
+          }
+        }
+      )
+    ) {
+      for (key, _) in sortedProperties {
+        SequenceExprSyntax {
+          MemberAccessExprSyntax(
+            base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+            period: .periodToken(),
+            declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+          )
+          AssignmentExprSyntax(equal: .equalToken())
+          DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+        }
+      }
+      SequenceExprSyntax {
+        MemberAccessExprSyntax(
+          base: DeclReferenceExprSyntax(baseName: .keyword(.self)),
+          period: .periodToken(),
+          declName: DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
+        )
+        AssignmentExprSyntax(equal: .equalToken())
+        DictionaryExprSyntax(
+          leftSquare: .leftSquareToken(),
+          content: DictionaryExprSyntax.Content(.colonToken()),
+          rightSquare: .rightSquareToken()
+        )
+      }
+    }
+  }
+
+  private func staticMakeDecl(ts: TypeSchema, name: String, defMap: ExtDefMap, required: [String: Bool]) -> FunctionDeclSyntax {
+    FunctionDeclSyntax(
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public)),
+        DeclModifierSyntax(name: .keyword(.static)),
+      ],
+      name: .identifier("make"),
+      signature: FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax {
+          for (key, property) in sortedProperties {
+            let isRequired = required[key] ?? false
+            let type = ts.typeIdentifier(name: name, property: property, defMap: defMap, key: key, isRequired: isRequired, dropPrefix: true)
+            let defaultValue: InitializerClauseSyntax? =
+              isRequired
+              ? nil
+              : InitializerClauseSyntax(equal: .equalToken(), value: NilLiteralExprSyntax())
+            FunctionParameterSyntax(firstName: .lexIdentifier(key), type: type, defaultValue: defaultValue)
+          }
+        },
+        effectSpecifiers: FunctionEffectSpecifiersSyntax(
+          throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+        ),
+        returnClause: ReturnClauseSyntax(
+          type: TypeSyntax(IdentifierTypeSyntax(name: .keyword(.Self)))
+        )
+      )
+    ) {
+      for (key, property) in sortedProperties {
+        let isRequired = required[key] ?? false
+        for item in property.constraintGuardItems(for: key, optional: !isRequired) {
+          item
+        }
+      }
+      ReturnStmtSyntax(
+        expression: FunctionCallExprSyntax(
+          callee: MemberAccessExprSyntax(
+            base: DeclReferenceExprSyntax(baseName: .keyword(.Self)),
+            period: .periodToken(),
+            declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+          )
+        ) {
+          for (key, _) in sortedProperties {
+            LabeledExprSyntax(
+              label: .lexIdentifier(key),
+              colon: .colonToken(),
+              expression: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+            )
+          }
+        }
+      )
+    }
+  }
+
+  private func constraintDecodableInitDecl(ts: TypeSchema, name: String, defMap: ExtDefMap, required: [String: Bool]) -> InitializerDeclSyntax {
+    decodableInitializerDeclSyntax {
+      VariableDeclSyntax(
+        bindingSpecifier: .keyword(.let),
+        bindings: PatternBindingListSyntax([
+          PatternBindingSyntax(
+            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("keyedContainer"))),
+            initializer: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: TryExprSyntax(
+                expression: FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(
+                    base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("decoder"))),
+                    period: .periodToken(),
+                    declName: DeclReferenceExprSyntax(baseName: .identifier("container"))
+                  )
+                ) {
+                  LabeledExprSyntax(
+                    label: .identifier("keyedBy"),
+                    colon: .colonToken(),
+                    expression: ExprSyntax(
+                      MemberAccessExprSyntax(
+                        base: DeclReferenceExprSyntax(baseName: .identifier("CodingKeys")),
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                      ))
+                  )
+                }
+              )
+            )
+          )
+        ])
+      )
+      for (key, property) in sortedProperties {
+        let isRequired = required[key] ?? false
+        let tname = decodeTypeName(ts: ts, name: name, key: key, property: property, defMap: defMap)
+        VariableDeclSyntax(
+          bindingSpecifier: .keyword(.let),
+          bindings: PatternBindingListSyntax([
+            PatternBindingSyntax(
+              pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .lexIdentifier(key))),
+              initializer: InitializerClauseSyntax(
+                equal: .equalToken(),
+                value: TryExprSyntax(
+                  expression: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(
+                      base: DeclReferenceExprSyntax(baseName: .identifier("keyedContainer")),
+                      period: .periodToken(),
+                      declName: DeclReferenceExprSyntax(baseName: .identifier(isRequired ? "decode" : "decodeIfPresent"))
+                    )
+                  ) {
+                    LabeledExprSyntax(
+                      expression: MemberAccessExprSyntax(
+                        base: Lex.refExpr(tname),
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                      ),
+                      trailingComma: .commaToken()
+                    )
+                    LabeledExprSyntax(
+                      label: .identifier("forKey"),
+                      colon: .colonToken(),
+                      expression: MemberAccessExprSyntax(
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+                      )
+                    )
+                  }
+                )
+              )
+            )
+          ])
+        )
+      }
+      VariableDeclSyntax(
+        bindingSpecifier: .keyword(.let),
+        bindings: [
+          PatternBindingSyntax(
+            pattern: IdentifierPatternSyntax(identifier: .identifier("unknownContainer")),
+            initializer: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: TryExprSyntax(
+                expression: FunctionCallExprSyntax(
+                  callee: MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: .identifier("decoder")),
+                    period: .periodToken(),
+                    declName: DeclReferenceExprSyntax(baseName: .identifier("container"))
+                  )
+                ) {
+                  LabeledExprSyntax(
+                    label: .identifier("keyedBy"),
+                    colon: .colonToken(),
+                    expression: ExprSyntax(
+                      MemberAccessExprSyntax(
+                        base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodingKeys"))),
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                      ))
+                  )
+                }
+              )
+            )
+          )
+        ]
+      )
+      VariableDeclSyntax(
+        bindingSpecifier: .keyword(.var),
+        bindings: [
+          PatternBindingSyntax(
+            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("_unknownValues"))),
+            initializer: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: FunctionCallExprSyntax(
+                callee: DictionaryExprSyntax(
+                  leftSquare: .leftSquareToken(),
+                  content: DictionaryExprSyntax.Content(
+                    DictionaryElementListSyntax([
+                      DictionaryElementSyntax(
+                        key: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("String"))),
+                        colon: .colonToken(),
+                        value: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")))
+                      )
+                    ])),
+                  rightSquare: .rightSquareToken()
+                ))
+            )
+          )
+        ]
+      )
+      ForStmtSyntax(
+        pattern: IdentifierPatternSyntax(identifier: .identifier("key")),
+        sequence: MemberAccessExprSyntax(
+          base: DeclReferenceExprSyntax(baseName: .identifier("unknownContainer")),
+          period: .periodToken(),
+          declName: DeclReferenceExprSyntax(baseName: .identifier("allKeys"))
+        )
+      ) {
+        GuardStmtSyntax(
+          conditions: ConditionElementListSyntax {
+            SequenceExprSyntax {
+              FunctionCallExprSyntax(
+                callee: DeclReferenceExprSyntax(baseName: .identifier("CodingKeys"))
+              ) {
+                LabeledExprSyntax(
+                  label: .identifier("rawValue"),
+                  colon: .colonToken(),
+                  expression: MemberAccessExprSyntax(
+                    base: DeclReferenceExprSyntax(baseName: .identifier("key")),
+                    period: .periodToken(),
+                    declName: DeclReferenceExprSyntax(baseName: .identifier("stringValue"))
+                  )
+                )
+              }
+              BinaryOperatorExprSyntax(operator: .binaryOperator("=="))
+              NilLiteralExprSyntax()
+            }
+          }
+        ) {
+          ContinueStmtSyntax(continueKeyword: .keyword(.continue))
+        }
+        SequenceExprSyntax {
+          SubscriptCallExprSyntax(
+            calledExpression: DeclReferenceExprSyntax(baseName: .identifier("_unknownValues"))
+          ) {
+            LabeledExprSyntax(
+              expression: MemberAccessExprSyntax(
+                base: DeclReferenceExprSyntax(baseName: .identifier("key")),
+                period: .periodToken(),
+                declName: DeclReferenceExprSyntax(baseName: .identifier("stringValue"))
+              ))
+          }
+          AssignmentExprSyntax(equal: .equalToken())
+          TryExprSyntax(
+            expression: FunctionCallExprSyntax(
+              callee: MemberAccessExprSyntax(parts: [.identifier("unknownContainer"), .identifier("decode")])
+            ) {
+              LabeledExprSyntax(
+                expression: MemberAccessExprSyntax(
+                  base: DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")),
+                  period: .periodToken(),
+                  declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
+                )
+              )
+              LabeledExprSyntax(
+                label: .identifier("forKey"),
+                colon: .colonToken(),
+                expression: DeclReferenceExprSyntax(baseName: .identifier("key"))
+              )
+            }
+          )
+        }
+      }
+      DoStmtSyntax(
+        body: CodeBlockSyntax {
+          SequenceExprSyntax {
+            DeclReferenceExprSyntax(baseName: .keyword(.self))
+            AssignmentExprSyntax(equal: .equalToken())
+            TryExprSyntax(
+              expression: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(
+                  base: DeclReferenceExprSyntax(baseName: .keyword(.Self)),
+                  period: .periodToken(),
+                  declName: DeclReferenceExprSyntax(baseName: .identifier("make"))
+                )
+              ) {
+                for (key, _) in sortedProperties {
+                  LabeledExprSyntax(
+                    label: .lexIdentifier(key),
+                    colon: .colonToken(),
+                    expression: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+                  )
+                }
+              }
+            )
+          }
+        },
+        catchClauses: CatchClauseListSyntax {
+          CatchClauseSyntax(
+            catchItems: CatchItemListSyntax {
+              CatchItemSyntax(
+                pattern: PatternSyntax(
+                  ValueBindingPatternSyntax(
+                    bindingSpecifier: .keyword(.let),
+                    pattern: PatternSyntax(
+                      ExpressionPatternSyntax(
+                        expression: SequenceExprSyntax {
+                          PatternExprSyntax(
+                            pattern: IdentifierPatternSyntax(identifier: .identifier("error"))
+                          )
+                          UnresolvedAsExprSyntax()
+                          TypeExprSyntax(type: IdentifierTypeSyntax(name: .identifier("LexiconConstraintError")))
+                        }
+                      )
+                    )
+                  )
+                )
+              )
+            }
+          ) {
+            ThrowStmtSyntax(
+              expression: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(
+                  base: DeclReferenceExprSyntax(baseName: .identifier("DecodingError")),
+                  period: .periodToken(),
+                  declName: DeclReferenceExprSyntax(baseName: .identifier("dataCorrupted"))
+                )
+              ) {
+                LabeledExprSyntax(
+                  expression: FunctionCallExprSyntax(
+                    callee: MemberAccessExprSyntax(
+                      period: .periodToken(),
+                      declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+                    )
+                  ) {
+                    LabeledExprSyntax(
+                      label: .identifier("codingPath"),
+                      colon: .colonToken(),
+                      expression: MemberAccessExprSyntax(
+                        base: DeclReferenceExprSyntax(baseName: .identifier("decoder")),
+                        period: .periodToken(),
+                        declName: DeclReferenceExprSyntax(baseName: .identifier("codingPath"))
+                      )
+                    )
+                    LabeledExprSyntax(
+                      label: .identifier("debugDescription"),
+                      colon: .colonToken(),
+                      expression: StringLiteralExprSyntax(
+                        openingQuote: .stringQuoteToken(),
+                        segments: StringLiteralSegmentListSyntax {
+                          ExpressionSegmentSyntax(
+                            expressions: LabeledExprListSyntax {
+                              LabeledExprSyntax(
+                                expression: DeclReferenceExprSyntax(baseName: .identifier("error"))
+                              )
+                            }
+                          )
+                        },
+                        closingQuote: .stringQuoteToken()
+                      )
+                    )
+                    LabeledExprSyntax(
+                      label: .identifier("underlyingError"),
+                      colon: .colonToken(),
+                      expression: DeclReferenceExprSyntax(baseName: .identifier("error"))
+                    )
+                  }
+                )
+              }
+            )
+          }
+        }
+      )
     }
   }
 }

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -270,13 +270,16 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
             bindings: [query]
           )
         }
+        let requiredParams = Set(parameters?.required ?? [])
+        let paramsHaveConstraints = (parameters?.sortedProperties ?? []).contains { $0.1.hasConstraints }
         InitializerDeclSyntax(
           leadingTrivia: [.newlines(2)],
           modifiers: [DeclModifierSyntax(name: .keyword(.public))],
           signature: FunctionSignatureSyntax(
             parameterClause: FunctionParameterClauseSyntax {
               rpcArguments(ts: ts, fname: name, defMap: defMap, prefix: prefix, protocolRequirement: false)
-            })
+            }
+          )
         ) {
           for (key, _) in parameters?.sortedProperties ?? [] {
             SequenceExprSyntax(leadingTrivia: .newline) {
@@ -288,6 +291,51 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
               AssignmentExprSyntax(equal: .equalToken())
               DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
             }
+          }
+        }
+        if paramsHaveConstraints {
+          FunctionDeclSyntax(
+            leadingTrivia: .newlines(2),
+            modifiers: [
+              DeclModifierSyntax(name: .keyword(.public)),
+              DeclModifierSyntax(name: .keyword(.static)),
+            ],
+            name: .identifier("make"),
+            signature: FunctionSignatureSyntax(
+              parameterClause: FunctionParameterClauseSyntax {
+                rpcArguments(ts: ts, fname: name, defMap: defMap, prefix: prefix, protocolRequirement: false)
+              },
+              effectSpecifiers: FunctionEffectSpecifiersSyntax(
+                throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+              ),
+              returnClause: ReturnClauseSyntax(
+                type: TypeSyntax(IdentifierTypeSyntax(name: .keyword(.Self)))
+              )
+            )
+          ) {
+            for (key, property) in parameters?.sortedProperties ?? [] {
+              for item in property.constraintGuardItems(for: key, optional: !requiredParams.contains(key)) {
+                item.with(\.leadingTrivia, .newline)
+              }
+            }
+            ReturnStmtSyntax(
+              leadingTrivia: .newline,
+              expression: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(
+                  base: DeclReferenceExprSyntax(baseName: .keyword(.Self)),
+                  period: .periodToken(),
+                  declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+                )
+              ) {
+                for (key, _) in parameters?.sortedProperties ?? [] {
+                  LabeledExprSyntax(
+                    label: .lexIdentifier(key),
+                    colon: .colonToken(),
+                    expression: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+                  )
+                }
+              }
+            )
           }
         }
         VariableDeclSyntax(

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -726,17 +726,35 @@ extension Lex {
           pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("query"))),
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
-            value: FunctionCallExprSyntax(
-              callee: MemberAccessExprSyntax(parts: prefix.lexIdentifierSegments + [.lexIdentifier(key), .identifier("Input"), .identifier("Query")])
-            ) {
-              for (i, (key, _)) in (def.parameters?.sortedProperties ?? []).enumerated() {
-                LabeledExprSyntax(
-                  label: .lexIdentifier(key),
-                  colon: .colonToken(),
-                  expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("query\(i)")))
+            value: {
+              let paramsHaveConstraints = (def.parameters?.sortedProperties ?? []).contains { $0.1.hasConstraints }
+              let callee: ExprSyntax =
+                paramsHaveConstraints
+                ? ExprSyntax(
+                  MemberAccessExprSyntax(
+                    parts: prefix.lexIdentifierSegments + [
+                      .lexIdentifier(key), .identifier("Input"), .identifier("Query"), .identifier("make"),
+                    ]
+                  )
                 )
+                : ExprSyntax(
+                  MemberAccessExprSyntax(
+                    parts: prefix.lexIdentifierSegments + [
+                      .lexIdentifier(key), .identifier("Input"), .identifier("Query"),
+                    ]
+                  )
+                )
+              let call = FunctionCallExprSyntax(callee: callee) {
+                for (i, (key, _)) in (def.parameters?.sortedProperties ?? []).enumerated() {
+                  LabeledExprSyntax(
+                    label: .lexIdentifier(key),
+                    colon: .colonToken(),
+                    expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("query\(i)")))
+                  )
+                }
               }
-            }
+              return paramsHaveConstraints ? ExprSyntax(TryExprSyntax(expression: call)) : ExprSyntax(call)
+            }()
           )
         )
       }

--- a/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
@@ -6,15 +6,17 @@ import XCTest
 private struct ConstrainedRecord: Codable, Hashable, Sendable {
   let text: String
   let limit: Int?
+  let tags: [String]?
   let _unknownValues: [String: AnyCodable]
 
-  public init(text: String, limit: Int? = nil) {
+  public init(text: String, limit: Int? = nil, tags: [String]? = nil) {
     self.text = text
     self.limit = limit
+    self.tags = tags
     self._unknownValues = [:]
   }
 
-  public static func make(text: String, limit: Int? = nil) throws -> Self {
+  public static func make(text: String, limit: Int? = nil, tags: [String]? = nil) throws -> Self {
     guard text.utf8.count <= 3000 else {
       throw LexiconConstraintError.stringTooLong("text", limit: 3000)
     }
@@ -29,20 +31,27 @@ private struct ConstrainedRecord: Codable, Hashable, Sendable {
         throw LexiconConstraintError.integerAboveMaximum("limit", maximum: 100)
       }
     }
-    return Self(text: text, limit: limit)
+    if let tags {
+      guard tags.count <= 8 else {
+        throw LexiconConstraintError.arrayTooLong("tags", limit: 8)
+      }
+    }
+    return Self(text: text, limit: limit, tags: tags)
   }
 
   enum CodingKeys: String, CodingKey {
     case text
     case limit
+    case tags
   }
 
   init(from decoder: any Decoder) throws {
     let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
     let text = try keyedContainer.decode(String.self, forKey: .text)
     let limit = try keyedContainer.decodeIfPresent(Int.self, forKey: .limit)
+    let tags = try keyedContainer.decodeIfPresent([String].self, forKey: .tags)
     do {
-      self = try Self.make(text: text, limit: limit)
+      self = try Self.make(text: text, limit: limit, tags: tags)
     } catch let error as LexiconConstraintError {
       throw DecodingError.dataCorrupted(
         .init(codingPath: decoder.codingPath, debugDescription: "\(error)", underlyingError: error))
@@ -89,9 +98,19 @@ private struct KnownValuesRecord: Sendable {
 
 final class LexiconConstraintTests: XCTestCase {
   func testValidValuesSucceed() throws {
-    let record = try ConstrainedRecord.make(text: "hello", limit: 50)
+    let record = try ConstrainedRecord.make(text: "hello", limit: 50, tags: ["a", "b"])
     XCTAssertEqual(record.text, "hello")
     XCTAssertEqual(record.limit, 50)
+  }
+
+  func testArrayTooLongThrows() throws {
+    let tags = (0..<9).map { "tag\($0)" }
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: "ok", tags: tags)) { error in
+      guard case LexiconConstraintError.arrayTooLong("tags", let limit) = error else {
+        return XCTFail("expected arrayTooLong, got \(error)")
+      }
+      XCTAssertEqual(limit, 8)
+    }
   }
 
   func testIntegerOutOfRangeThrows() throws {

--- a/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
@@ -5,32 +5,41 @@ import XCTest
 
 private struct ConstrainedRecord: Codable, Hashable, Sendable {
   let text: String
+  let limit: Int?
   let _unknownValues: [String: AnyCodable]
 
-  public init(text: String) {
+  public init(text: String, limit: Int? = nil) {
     self.text = text
+    self.limit = limit
     self._unknownValues = [:]
   }
 
-  public static func make(text: String) throws -> Self {
+  public static func make(text: String, limit: Int? = nil) throws -> Self {
     guard text.utf8.count <= 3000 else {
       throw LexiconConstraintError.stringTooLong("text", limit: 3000)
     }
     guard text.count <= 300 else {
       throw LexiconConstraintError.tooManyGraphemes("text", limit: 300)
     }
-    return Self(text: text)
+    if let limit {
+      guard limit >= 1 else {
+        throw LexiconConstraintError.integerBelowMinimum("limit", minimum: 1)
+      }
+    }
+    return Self(text: text, limit: limit)
   }
 
   enum CodingKeys: String, CodingKey {
     case text
+    case limit
   }
 
   init(from decoder: any Decoder) throws {
     let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
     let text = try keyedContainer.decode(String.self, forKey: .text)
+    let limit = try keyedContainer.decodeIfPresent(Int.self, forKey: .limit)
     do {
-      self = try Self.make(text: text)
+      self = try Self.make(text: text, limit: limit)
     } catch let error as LexiconConstraintError {
       throw DecodingError.dataCorrupted(
         .init(codingPath: decoder.codingPath, debugDescription: "\(error)", underlyingError: error))
@@ -77,8 +86,18 @@ private struct KnownValuesRecord: Sendable {
 
 final class LexiconConstraintTests: XCTestCase {
   func testValidValuesSucceed() throws {
-    let record = try ConstrainedRecord.make(text: "hello")
+    let record = try ConstrainedRecord.make(text: "hello", limit: 50)
     XCTAssertEqual(record.text, "hello")
+    XCTAssertEqual(record.limit, 50)
+  }
+
+  func testIntegerOutOfRangeThrows() throws {
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: "ok", limit: 0)) { error in
+      guard case LexiconConstraintError.integerBelowMinimum("limit", let minimum) = error else {
+        return XCTFail("expected integerBelowMinimum, got \(error)")
+      }
+      XCTAssertEqual(minimum, 1)
+    }
   }
 
   func testTooManyGraphemesThrows() throws {

--- a/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
@@ -103,13 +103,26 @@ final class LexiconConstraintTests: XCTestCase {
     XCTAssertEqual(record.limit, 50)
   }
 
-  func testArrayTooLongThrows() throws {
-    let tags = (0..<9).map { "tag\($0)" }
-    XCTAssertThrowsError(try ConstrainedRecord.make(text: "ok", tags: tags)) { error in
-      guard case LexiconConstraintError.arrayTooLong("tags", let limit) = error else {
-        return XCTFail("expected arrayTooLong, got \(error)")
+  func testStringTooLongThrows() throws {
+    let tooLong = String(repeating: "a", count: 3001)
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: tooLong)) { error in
+      guard case LexiconConstraintError.stringTooLong(let field, let limit) = error else {
+        return XCTFail("expected stringTooLong, got \(error)")
       }
-      XCTAssertEqual(limit, 8)
+      XCTAssertEqual(field, "text")
+      XCTAssertEqual(limit, 3000)
+    }
+  }
+
+  func testTooManyGraphemesThrows() throws {
+    // stays under the UTF-8 byte limit while exceeding the grapheme limit
+    let manyGraphemes = String(repeating: "a", count: 301)
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: manyGraphemes)) { error in
+      guard case LexiconConstraintError.tooManyGraphemes(let field, let limit) = error else {
+        return XCTFail("expected tooManyGraphemes, got \(error)")
+      }
+      XCTAssertEqual(field, "text")
+      XCTAssertEqual(limit, 300)
     }
   }
 
@@ -128,26 +141,13 @@ final class LexiconConstraintTests: XCTestCase {
     }
   }
 
-  func testTooManyGraphemesThrows() throws {
-    // stays under the UTF-8 byte limit while exceeding the grapheme limit
-    let manyGraphemes = String(repeating: "a", count: 301)
-    XCTAssertThrowsError(try ConstrainedRecord.make(text: manyGraphemes)) { error in
-      guard case LexiconConstraintError.tooManyGraphemes(let field, let limit) = error else {
-        return XCTFail("expected tooManyGraphemes, got \(error)")
+  func testArrayTooLongThrows() throws {
+    let tags = (0..<9).map { "tag\($0)" }
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: "ok", tags: tags)) { error in
+      guard case LexiconConstraintError.arrayTooLong("tags", let limit) = error else {
+        return XCTFail("expected arrayTooLong, got \(error)")
       }
-      XCTAssertEqual(field, "text")
-      XCTAssertEqual(limit, 300)
-    }
-  }
-
-  func testStringTooLongThrows() throws {
-    let tooLong = String(repeating: "a", count: 3001)
-    XCTAssertThrowsError(try ConstrainedRecord.make(text: tooLong)) { error in
-      guard case LexiconConstraintError.stringTooLong(let field, let limit) = error else {
-        return XCTFail("expected stringTooLong, got \(error)")
-      }
-      XCTAssertEqual(field, "text")
-      XCTAssertEqual(limit, 3000)
+      XCTAssertEqual(limit, 8)
     }
   }
 

--- a/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
@@ -25,6 +25,9 @@ private struct ConstrainedRecord: Codable, Hashable, Sendable {
       guard limit >= 1 else {
         throw LexiconConstraintError.integerBelowMinimum("limit", minimum: 1)
       }
+      guard limit <= 100 else {
+        throw LexiconConstraintError.integerAboveMaximum("limit", maximum: 100)
+      }
     }
     return Self(text: text, limit: limit)
   }
@@ -97,6 +100,12 @@ final class LexiconConstraintTests: XCTestCase {
         return XCTFail("expected integerBelowMinimum, got \(error)")
       }
       XCTAssertEqual(minimum, 1)
+    }
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: "ok", limit: 101)) { error in
+      guard case LexiconConstraintError.integerAboveMaximum("limit", let maximum) = error else {
+        return XCTFail("expected integerAboveMaximum, got \(error)")
+      }
+      XCTAssertEqual(maximum, 100)
     }
   }
 

--- a/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
@@ -16,6 +16,9 @@ private struct ConstrainedRecord: Codable, Hashable, Sendable {
     guard text.utf8.count <= 3000 else {
       throw LexiconConstraintError.stringTooLong("text", limit: 3000)
     }
+    guard text.count <= 300 else {
+      throw LexiconConstraintError.tooManyGraphemes("text", limit: 300)
+    }
     return Self(text: text)
   }
 
@@ -76,6 +79,18 @@ final class LexiconConstraintTests: XCTestCase {
   func testValidValuesSucceed() throws {
     let record = try ConstrainedRecord.make(text: "hello")
     XCTAssertEqual(record.text, "hello")
+  }
+
+  func testTooManyGraphemesThrows() throws {
+    // stays under the UTF-8 byte limit while exceeding the grapheme limit
+    let manyGraphemes = String(repeating: "a", count: 301)
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: manyGraphemes)) { error in
+      guard case LexiconConstraintError.tooManyGraphemes(let field, let limit) = error else {
+        return XCTFail("expected tooManyGraphemes, got \(error)")
+      }
+      XCTAssertEqual(field, "text")
+      XCTAssertEqual(limit, 300)
+    }
   }
 
   func testStringTooLongThrows() throws {

--- a/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
@@ -1,0 +1,130 @@
+import Foundation
+import XCTest
+
+@testable import SwiftAtproto
+
+private struct ConstrainedRecord: Codable, Hashable, Sendable {
+  let text: String
+  let _unknownValues: [String: AnyCodable]
+
+  public init(text: String) {
+    self.text = text
+    self._unknownValues = [:]
+  }
+
+  public static func make(text: String) throws -> Self {
+    guard text.utf8.count <= 3000 else {
+      throw LexiconConstraintError.stringTooLong("text", limit: 3000)
+    }
+    return Self(text: text)
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case text
+  }
+
+  init(from decoder: any Decoder) throws {
+    let keyedContainer = try decoder.container(keyedBy: CodingKeys.self)
+    let text = try keyedContainer.decode(String.self, forKey: .text)
+    do {
+      self = try Self.make(text: text)
+    } catch let error as LexiconConstraintError {
+      throw DecodingError.dataCorrupted(
+        .init(codingPath: decoder.codingPath, debugDescription: "\(error)", underlyingError: error))
+    }
+  }
+}
+
+private enum KnownLang: RawRepresentable, Codable, Hashable, Sendable {
+  case en
+  case ja
+  case _other(String)
+
+  init(rawValue: String) {
+    switch rawValue {
+    case "en": self = .en
+    case "ja": self = .ja
+    default: self = ._other(rawValue)
+    }
+  }
+
+  var rawValue: String {
+    switch self {
+    case .en: return "en"
+    case .ja: return "ja"
+    case ._other(let s): return s
+    }
+  }
+}
+
+private struct KnownValuesRecord: Sendable {
+  let lang: KnownLang
+
+  public init(lang: KnownLang) {
+    self.lang = lang
+  }
+
+  public static func make(lang: KnownLang) throws -> Self {
+    guard lang.rawValue.utf8.count <= 5 else {
+      throw LexiconConstraintError.stringTooLong("lang", limit: 5)
+    }
+    return Self(lang: lang)
+  }
+}
+
+final class LexiconConstraintTests: XCTestCase {
+  func testValidValuesSucceed() throws {
+    let record = try ConstrainedRecord.make(text: "hello")
+    XCTAssertEqual(record.text, "hello")
+  }
+
+  func testStringTooLongThrows() throws {
+    let tooLong = String(repeating: "a", count: 3001)
+    XCTAssertThrowsError(try ConstrainedRecord.make(text: tooLong)) { error in
+      guard case LexiconConstraintError.stringTooLong(let field, let limit) = error else {
+        return XCTFail("expected stringTooLong, got \(error)")
+      }
+      XCTAssertEqual(field, "text")
+      XCTAssertEqual(limit, 3000)
+    }
+  }
+
+  func testDecodeViolationConvertedToDecodingError() throws {
+    let tooLong = String(repeating: "a", count: 3001)
+    let json = try JSONEncoder().encode(["text": tooLong])
+    XCTAssertThrowsError(try JSONDecoder().decode(ConstrainedRecord.self, from: json)) { error in
+      guard case DecodingError.dataCorrupted(let context) = error else {
+        return XCTFail("expected DecodingError.dataCorrupted, got \(error)")
+      }
+      guard let underlying = context.underlyingError, underlying is LexiconConstraintError else {
+        return XCTFail("expected underlyingError to be LexiconConstraintError, got \(String(describing: context.underlyingError))")
+      }
+    }
+  }
+
+  func testDecodeValidSucceeds() throws {
+    let json = try JSONEncoder().encode(["text": "hello world"])
+    let record = try JSONDecoder().decode(ConstrainedRecord.self, from: json)
+    XCTAssertEqual(record.text, "hello world")
+  }
+
+  func testKnownValuesOtherWithinLimitSucceeds() throws {
+    let record = try KnownValuesRecord.make(lang: ._other("en-US"))
+    XCTAssertEqual(record.lang.rawValue, "en-US")
+  }
+
+  func testKnownValuesOtherTooLongThrows() throws {
+    XCTAssertThrowsError(try KnownValuesRecord.make(lang: ._other("en-USABC"))) { error in
+      guard case LexiconConstraintError.stringTooLong(let field, let limit) = error else {
+        return XCTFail("expected stringTooLong, got \(error)")
+      }
+      XCTAssertEqual(field, "lang")
+      XCTAssertEqual(limit, 5)
+    }
+  }
+
+  func testKnownValuesNamedCaseNotChecked() throws {
+    let record = try KnownValuesRecord.make(lang: .en)
+    XCTAssertEqual(record.lang.rawValue, "en")
+  }
+}


### PR DESCRIPTION
This PR introduces constraint validation support to the Swift code generator for AT Protocol lexicons.