### PR TITLE
Project AT Protocol language fields to a type-safe FormatString<Language>

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/Language.swift
+++ b/Sources/SwiftAtproto/StringFormats/Language.swift
@@ -8,7 +8,20 @@ import Foundation
 // whitelist, in strict mode. The parser only validates grammar — it does not consult any subtag
 // registry. A lenient mode (`_` separators, etc.) and canonicalization are intentionally NOT
 // supported.
-public struct Language: Hashable, Sendable {}
+public struct Language: LexiconStringFormat {
+  // The original wire string, kept verbatim (no normalization).
+  public let rawValue: String
+  // The BCP-47 parsed components (or grandfathered match).
+  public let components: Components
+
+  public init(string: String) throws {
+    guard let components = Language.parse(string) else {
+      throw LexiconStringFormatError.invalid(format: "language", value: string)
+    }
+    rawValue = string
+    self.components = components
+  }
+}
 
 extension Language {
   // BCP-47 primary language subtag: 2-3 ALPHA, or 4 ALPHA (reserved), or 5-8 ALPHA (registered).
@@ -55,6 +68,13 @@ extension Language {
     // The primary language subtag. nil when the wire string is a grandfathered/irregular tag
     // or a private-use-only tag (`x-…`).
     public let languageCode: LanguageCode?
+    // BCP-47 §2.2.2 extended language subtags. Up to 3 `3ALPHA` subtags, only present when
+    // the primary language is 2-3 ALPHA. Empty for tags without extlang. RFC 5646 discourages
+    // the extlang form (`zh-cmn`) in favor of the primary subtag directly (`cmn`); the parser
+    // accepts both forms verbatim and leaves canonicalization to the consumer.
+    // The 3-ALPHA constraint is enforced by the parser (`isExtendedLanguageSubtag`), not by
+    // the element type, which reuses `LanguageCode` (2-8 ALPHA) for shape parity.
+    public let extendedLanguageSubtags: [LanguageCode]
     public let script: Script?
     public let region: Region?
     public let variants: [Variant]
@@ -104,5 +124,192 @@ extension Language {
     case zhMin = "zh-min"
     case zhMinNan = "zh-min-nan"
     case zhXiang = "zh-xiang"
+  }
+}
+
+extension Language {
+  // Maximum byte length we accept for a single language identifier. BCP-47 itself has no upper
+  // bound but ≤64 is a generous practical cap (real-world tags are ≤16 chars).
+  private static let maxLength = 64
+
+  // Precomputed lowercase rawValue → enum case map for O(1) grandfathered lookup.
+  private static let grandfatheredLowercasedMap: [String: Grandfathered] =
+    Dictionary(uniqueKeysWithValues: Grandfathered.allCases.map { ($0.rawValue.lowercased(), $0) })
+
+  // Strict parser. Returns nil on any grammar violation; the caller wraps that in
+  // `LexiconStringFormatError.invalid(format: "language", …)`.
+  static func parse(_ input: String) -> Components? {
+    guard !input.isEmpty, input.utf8.count <= maxLength else { return nil }
+    for byte in input.utf8 where !isAllowedByte(byte) { return nil }
+
+    // 1. Grandfathered/irregular: case-insensitive exact match.
+    let lowered = input.lowercased()
+    if let g = grandfatheredLowercasedMap[lowered] {
+      return Components(
+        languageCode: nil, extendedLanguageSubtags: [], script: nil, region: nil, variants: [],
+        extensions: [], privateUse: [], grandfathered: g
+      )
+    }
+
+    // 2. Split into subtags. Empty subtags (leading/trailing/duplicate `-`) → reject.
+    let subtags = input.split(separator: "-", omittingEmptySubsequences: false)
+    for tag in subtags where tag.isEmpty { return nil }
+
+    // 3. Private-use-only tag (`x-…` / `X-…`).
+    if subtags[0] == "x" || subtags[0] == "X" {
+      let rest = subtags.dropFirst()
+      guard !rest.isEmpty, rest.allSatisfy(isPrivateuseSubtag) else { return nil }
+      return Components(
+        languageCode: nil, extendedLanguageSubtags: [], script: nil, region: nil, variants: [],
+        extensions: [], privateUse: rest.map(String.init), grandfathered: nil
+      )
+    }
+
+    // 4. Langtag: language [-extlang] [-script] [-region] *[-variant] *[-extension] [-privateuse]
+    var i = 0
+    let n = subtags.count
+
+    guard isLanguageSubtag(subtags[i]) else { return nil }
+    let primary = subtags[i]
+    let languageCode = LanguageCode(rawValue: String(primary))
+    i += 1
+
+    // RFC 5646 §2.2.2: extlang follows a 2-3 ALPHA primary subtag; up to 3 `3ALPHA` subtags.
+    // Unlike variants and extension singletons, RFC 5646 §4.1's MUST-NOT duplicate rule does
+    // not apply to extlang subtags; duplicates are accepted at the grammar level.
+    var extendedLanguageSubtags: [LanguageCode] = []
+    if primary.count <= 3 {
+      while extendedLanguageSubtags.count < 3, i < n, isExtendedLanguageSubtag(subtags[i]) {
+        extendedLanguageSubtags.append(LanguageCode(rawValue: String(subtags[i])))
+        i += 1
+      }
+    }
+
+    var script: Script?
+    if i < n, isScriptSubtag(subtags[i]) {
+      script = Script(rawValue: String(subtags[i]))
+      i += 1
+    }
+
+    var region: Region?
+    if i < n, isRegionSubtag(subtags[i]) {
+      region = Region(rawValue: String(subtags[i]))
+      i += 1
+    }
+
+    // RFC 5646 §4.1: "The same variant subtag MUST NOT be used more than once."
+    // Comparison per §2.1.1 is case-insensitive.
+    var variants: [Variant] = []
+    var seenVariants: Set<String> = []
+    while i < n, isVariantSubtag(subtags[i]) {
+      let key = subtags[i].lowercased()
+      guard seenVariants.insert(key).inserted else { return nil }
+      variants.append(Variant(rawValue: String(subtags[i])))
+      i += 1
+    }
+
+    // RFC 5646 §4.1: "The same singleton MUST NOT be used more than once."
+    var extensions: [Extension] = []
+    var seenSingletons: Set<Character> = []
+    while i < n, isExtensionSingleton(subtags[i]) {
+      guard let singleton = subtags[i].first else { return nil }
+      let key = Character(singleton.lowercased())
+      guard seenSingletons.insert(key).inserted else { return nil }
+      i += 1
+      var extSubtags: [String] = []
+      while i < n, isExtensionSubtag(subtags[i]) {
+        extSubtags.append(String(subtags[i]))
+        i += 1
+      }
+      guard !extSubtags.isEmpty else { return nil }
+      extensions.append(Extension(singleton: singleton, subtags: extSubtags))
+    }
+
+    var privateUse: [String] = []
+    if i < n, subtags[i] == "x" || subtags[i] == "X" {
+      i += 1
+      while i < n, isPrivateuseSubtag(subtags[i]) {
+        privateUse.append(String(subtags[i]))
+        i += 1
+      }
+      guard !privateUse.isEmpty else { return nil }
+    }
+
+    guard i == n else { return nil }
+
+    return Components(
+      languageCode: languageCode, extendedLanguageSubtags: extendedLanguageSubtags,
+      script: script, region: region,
+      variants: variants, extensions: extensions, privateUse: privateUse,
+      grandfathered: nil
+    )
+  }
+
+  // Allowed bytes: ASCII letters, digits, and `-`.
+  private static func isAllowedByte(_ byte: UInt8) -> Bool {
+    switch byte {
+    case 0x30...0x39, 0x41...0x5A, 0x61...0x7A, 0x2D: true
+    default: false
+    }
+  }
+
+  private static func isAlpha(_ s: Substring) -> Bool {
+    !s.isEmpty
+      && s.utf8.allSatisfy { (0x41...0x5A).contains($0) || (0x61...0x7A).contains($0) }
+  }
+
+  private static func isDigit(_ s: Substring) -> Bool {
+    !s.isEmpty && s.utf8.allSatisfy { (0x30...0x39).contains($0) }
+  }
+
+  private static func isAlphanum(_ s: Substring) -> Bool {
+    !s.isEmpty
+      && s.utf8.allSatisfy {
+        (0x30...0x39).contains($0) || (0x41...0x5A).contains($0) || (0x61...0x7A).contains($0)
+      }
+  }
+
+  // language: 2-3 ALPHA, 4 ALPHA reserved, or 5-8 ALPHA registered.
+  private static func isLanguageSubtag(_ s: Substring) -> Bool {
+    (2...8).contains(s.count) && isAlpha(s)
+  }
+
+  // extlang: exactly 3 ALPHA (follows a 2-3 ALPHA primary subtag).
+  private static func isExtendedLanguageSubtag(_ s: Substring) -> Bool {
+    s.count == 3 && isAlpha(s)
+  }
+
+  // script: 4 ALPHA.
+  private static func isScriptSubtag(_ s: Substring) -> Bool {
+    s.count == 4 && isAlpha(s)
+  }
+
+  // region: 2 ALPHA or 3 DIGIT.
+  private static func isRegionSubtag(_ s: Substring) -> Bool {
+    (s.count == 2 && isAlpha(s)) || (s.count == 3 && isDigit(s))
+  }
+
+  // variant: 5-8 alphanum, or DIGIT + 3 alphanum.
+  private static func isVariantSubtag(_ s: Substring) -> Bool {
+    if (5...8).contains(s.count), isAlphanum(s) { return true }
+    if s.count == 4, let f = s.utf8.first, (0x30...0x39).contains(f), isAlphanum(s.dropFirst()) {
+      return true
+    }
+    return false
+  }
+
+  // extension singleton: 1 alphanum, except `x` / `X` (reserved for privateuse).
+  private static func isExtensionSingleton(_ s: Substring) -> Bool {
+    s.count == 1 && isAlphanum(s) && s != "x" && s != "X"
+  }
+
+  // extension subtag: 2-8 alphanum.
+  private static func isExtensionSubtag(_ s: Substring) -> Bool {
+    (2...8).contains(s.count) && isAlphanum(s)
+  }
+
+  // privateuse subtag: 1-8 alphanum.
+  private static func isPrivateuseSubtag(_ s: Substring) -> Bool {
+    (1...8).contains(s.count) && isAlphanum(s)
   }
 }

--- a/Sources/SwiftAtproto/StringFormats/Language.swift
+++ b/Sources/SwiftAtproto/StringFormats/Language.swift
@@ -43,3 +43,66 @@ extension Language {
     public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
   }
 }
+
+extension Language {
+  // The parsed BCP-47 components: languageCode / script / region, plus the langtag fields the
+  // lexicon needs to model verbatim (variants, extensions, privateUse) and the §2.2.8
+  // grandfathered match.
+  //
+  // `Components` is created by the `Language.init(string:)` parser; callers do not construct it
+  // directly. Sub-tag fields preserve the wire case verbatim (no normalization).
+  public struct Components: Hashable, Sendable {
+    // The primary language subtag. nil when the wire string is a grandfathered/irregular tag
+    // or a private-use-only tag (`x-…`).
+    public let languageCode: LanguageCode?
+    public let script: Script?
+    public let region: Region?
+    public let variants: [Variant]
+    public let extensions: [Extension]
+    public let privateUse: [String]
+    // Per RFC 5646 §2.2.8, grandfathered tags are atomic: only inputs that match a registered
+    // tag exactly (case-insensitive) populate this field. Adding any suffix (e.g.,
+    // `zh-min-nan-x-foo`) demotes the tag to a normal langtag parse where this is nil.
+    public let grandfathered: Grandfathered?
+  }
+
+  // A BCP-47 extension: a singleton (ALPHA / DIGIT except `x`) followed by 1+ subtags of
+  // length 2-8 alphanumeric, e.g. `u-co-phonebk`. Subtags preserve the wire case verbatim.
+  public struct Extension: Hashable, Sendable {
+    public let singleton: Character
+    public let subtags: [String]
+  }
+
+  // RFC 5646 §2.2.8 grandfathered/irregular language tags. The parser matches these
+  // case-insensitively but the canonical wire form (as listed below) is the `rawValue`.
+  public enum Grandfathered: String, Hashable, Sendable, Codable, CaseIterable {
+    // Irregular
+    case enGBOed = "en-GB-oed"
+    case iAmi = "i-ami"
+    case iBnn = "i-bnn"
+    case iDefault = "i-default"
+    case iEnochian = "i-enochian"
+    case iHak = "i-hak"
+    case iKlingon = "i-klingon"
+    case iLux = "i-lux"
+    case iMingo = "i-mingo"
+    case iNavajo = "i-navajo"
+    case iPwn = "i-pwn"
+    case iTao = "i-tao"
+    case iTay = "i-tay"
+    case iTsu = "i-tsu"
+    case sgnBEFR = "sgn-BE-FR"
+    case sgnBENL = "sgn-BE-NL"
+    case sgnCHDE = "sgn-CH-DE"
+    // Regular
+    case artLojban = "art-lojban"
+    case celGaulish = "cel-gaulish"
+    case noBok = "no-bok"
+    case noNyn = "no-nyn"
+    case zhGuoyu = "zh-guoyu"
+    case zhHakka = "zh-hakka"
+    case zhMin = "zh-min"
+    case zhMinNan = "zh-min-nan"
+    case zhXiang = "zh-xiang"
+  }
+}

--- a/Sources/SwiftAtproto/StringFormats/Language.swift
+++ b/Sources/SwiftAtproto/StringFormats/Language.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+// Type for the lexicon `language` string format: a range-based BCP-47 (RFC 5646) parser whose
+// `rawValue` keeps the wire string verbatim and acts as the single source of truth — parsed
+// `Components` are never re-serialized back to an identifier.
+//
+// Scope: the canonical BCP-47 langtag grammar plus the RFC 5646 §2.2.8 grandfathered/irregular
+// whitelist, in strict mode. The parser only validates grammar — it does not consult any subtag
+// registry. A lenient mode (`_` separators, etc.) and canonicalization are intentionally NOT
+// supported.
+public struct Language: Hashable, Sendable {}
+
+extension Language {
+  // BCP-47 primary language subtag: 2-3 ALPHA, or 4 ALPHA (reserved), or 5-8 ALPHA (registered).
+  public struct LanguageCode: Hashable, Sendable, Codable, RawRepresentable {
+    public let rawValue: String
+    public init(rawValue: String) { self.rawValue = rawValue }
+    public init(from decoder: any Decoder) throws { rawValue = try String(from: decoder) }
+    public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
+  }
+
+  // BCP-47 script subtag: 4 ALPHA, e.g. `Latn`, `Hant`.
+  public struct Script: Hashable, Sendable, Codable, RawRepresentable {
+    public let rawValue: String
+    public init(rawValue: String) { self.rawValue = rawValue }
+    public init(from decoder: any Decoder) throws { rawValue = try String(from: decoder) }
+    public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
+  }
+
+  // BCP-47 region subtag: 2 ALPHA (e.g. `US`) or 3 DIGIT (e.g. `419`).
+  public struct Region: Hashable, Sendable, Codable, RawRepresentable {
+    public let rawValue: String
+    public init(rawValue: String) { self.rawValue = rawValue }
+    public init(from decoder: any Decoder) throws { rawValue = try String(from: decoder) }
+    public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
+  }
+
+  // BCP-47 variant subtag: 5-8 alphanum, or DIGIT + 3 alphanum (e.g. `1901`, `rozaj`).
+  public struct Variant: Hashable, Sendable, Codable, RawRepresentable {
+    public let rawValue: String
+    public init(rawValue: String) { self.rawValue = rawValue }
+    public init(from decoder: any Decoder) throws { rawValue = try String(from: decoder) }
+    public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
+  }
+}

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -563,6 +563,7 @@ struct StringFormat: Codable, RawRepresentable {
     case "datetime": "Date"
     case "cid": "LexLink"
     case "at-uri": "ATURI"
+    case "language": "Language"
     default: nil
     }
   }

--- a/Tests/SwiftAtprotoTests/FormatStringLanguageTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringLanguageTests.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringLanguageTests {
+  static let wire = "en-US"
+
+  @Test func decodePreservesWireStringAndTypedYieldsLanguage() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Language>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+    #expect(value.typed?.components.languageCode?.rawValue == "en")
+    #expect(value.typed?.components.region?.rawValue == "US")
+  }
+
+  @Test func invalidLanguageDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\"not a language tag\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Language>.self, from: data)
+    #expect(value.rawValue == "not a language tag")
+    #expect(value.typed == nil)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<Language>(rawValue: Self.wire)
+    let data = try JSONEncoder().encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+
+  @Test func initFromLanguagePreservesWireString() throws {
+    let lang = try Language(string: "zh-Hant-TW")
+    let value = FormatString(lang)
+    #expect(value.rawValue == "zh-Hant-TW")
+    #expect(value.typed?.components.languageCode?.rawValue == "zh")
+    #expect(value.typed?.components.script?.rawValue == "Hant")
+    #expect(value.typed?.components.region?.rawValue == "TW")
+  }
+
+  @Test func decodesArrayOfLanguageFieldsInRecord() throws {
+    struct Post: Codable {
+      var langs: [FormatString<Language>]
+    }
+    let json = Data("{\"langs\":[\"en\",\"es-419\",\"x-pig-latin\"]}".utf8)
+    let post = try JSONDecoder().decode(Post.self, from: json)
+    #expect(post.langs.map(\.rawValue) == ["en", "es-419", "x-pig-latin"])
+    #expect(post.langs.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func decodesGrandfatheredFieldInRecord() throws {
+    struct Record: Codable {
+      var lang: FormatString<Language>
+    }
+    let json = Data("{\"lang\":\"i-klingon\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.lang.rawValue == "i-klingon")
+    #expect(record.lang.typed?.components.grandfathered == .iKlingon)
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<Language>(rawValue: Self.wire)
+    #expect(value.description == Self.wire)
+    #expect("\(value)" == Self.wire)
+  }
+}

--- a/Tests/SwiftAtprotoTests/LanguageAdversarialTests.swift
+++ b/Tests/SwiftAtprotoTests/LanguageAdversarialTests.swift
@@ -1,0 +1,298 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Attack-oriented coverage: Unicode confusables, control bytes, length boundaries, every
+// permitted singleton, RFC 5646 §4.1 MUST-NOT cases (duplicate variants / singletons), and
+// `FormatString<Language>` lenient decoding paths.
+struct LanguageAdversarialTests {
+  // MARK: - Unicode confusables and non-ASCII bytes
+
+  static let confusables: [String] = [
+    "\u{0435}n-US",  // Cyrillic small e + n
+    "\u{0410}-US",  // Cyrillic capital A as single-letter "language" (invalid even shaped right)
+    "en-U\u{0405}",  // Cyrillic capital dze where 'S' should be
+    "ja-\u{65E5}\u{672C}",  // CJK "Japan" as a region
+    "en\u{2010}US",  // U+2010 HYPHEN (NOT ASCII `-`)
+    "en\u{2013}US",  // EN DASH
+    "en-US\u{200B}",  // ZERO WIDTH SPACE
+    "\u{FEFF}en-US",  // BOM
+    "e\u{0301}n-US",  // combining acute on e
+  ]
+
+  @Test(arguments: confusables)
+  func nonAsciiBytesAreRejected(_ tag: String) {
+    #expect(throws: (any Error).self) { try Language(string: tag) }
+  }
+
+  // MARK: - ASCII control bytes and separator look-alikes
+
+  static let controlChars: [String] = [
+    "en\u{00}US",  // NUL
+    "en\u{09}US",  // TAB
+    "en\u{0A}US",  // LF
+    "en\u{0D}US",  // CR
+    "en\u{1F}US",  // unit separator
+    "en\u{7F}US",  // DEL
+    "en US",  // SPACE
+    "en\tUS",  // TAB literal
+    "en/US",  // slash
+    "en.US",  // dot
+    "en_US",  // underscore (BCP-47 uses `-`)
+  ]
+
+  @Test(arguments: controlChars)
+  func nonHyphenSeparatorsAreRejected(_ tag: String) {
+    #expect(throws: (any Error).self) { try Language(string: tag) }
+  }
+
+  // MARK: - Length boundaries
+
+  @Test func acceptsLanguageAtLengthBoundary() throws {
+    // Exactly 64 bytes: "en-x-" (5) + 6 × ("aaaaaaaa-" = 9 bytes) + "ggggg" (5) = 64.
+    let tag =
+      "en-x-" + String(repeating: "a", count: 8) + "-"
+      + String(repeating: "b", count: 8) + "-" + String(repeating: "c", count: 8)
+      + "-" + String(repeating: "d", count: 8) + "-"
+      + String(repeating: "e", count: 8) + "-"
+      + String(repeating: "f", count: 8) + "-" + String(repeating: "g", count: 5)
+    #expect(tag.utf8.count == 64)
+    let l = try Language(string: tag)
+    #expect(l.rawValue == tag)
+  }
+
+  @Test func rejectsLanguageOneOverLengthCap() {
+    let tag =
+      "en-x-" + String(repeating: "a", count: 8) + "-"
+      + String(repeating: "b", count: 8) + "-" + String(repeating: "c", count: 8)
+      + "-" + String(repeating: "d", count: 8) + "-"
+      + String(repeating: "e", count: 8) + "-"
+      + String(repeating: "f", count: 8) + "-" + String(repeating: "g", count: 6)
+    #expect(tag.utf8.count == 65)
+    #expect(throws: (any Error).self) { try Language(string: tag) }
+  }
+
+  // MARK: - Every permitted singleton (BCP-47 §2.2.6)
+
+  static let validSingletons: [Character] = {
+    var chars: [Character] = []
+    for byte: UInt8 in 0x30...0x39 { chars.append(Character(UnicodeScalar(byte))) }
+    for byte: UInt8 in 0x41...0x5A where byte != 0x58 {
+      chars.append(Character(UnicodeScalar(byte)))
+    }
+    for byte: UInt8 in 0x61...0x7A where byte != 0x78 {
+      chars.append(Character(UnicodeScalar(byte)))
+    }
+    return chars
+  }()
+
+  @Test(arguments: validSingletons)
+  func acceptsEverySingletonExceptX(_ singleton: Character) throws {
+    let l = try Language(string: "en-\(singleton)-ab")
+    #expect(l.components.extensions.count == 1)
+    #expect(l.components.extensions[0].singleton == singleton)
+    #expect(l.components.extensions[0].subtags == ["ab"])
+  }
+
+  @Test(arguments: ["x", "X"])
+  func xCannotBeAnExtensionSingleton(_ tag: String) throws {
+    // `en-x-ab`: `x` opens privateuse, not extension.
+    let l = try Language(string: "en-\(tag)-ab")
+    #expect(l.components.extensions.isEmpty)
+    #expect(l.components.privateUse == ["ab"])
+  }
+
+  // MARK: - RFC 5646 §4.1 MUST-NOT: subtag uniqueness
+
+  @Test func rejectsDuplicateVariantSubtags() {
+    // §4.1: "The same variant subtag MUST NOT be used more than once within a language tag."
+    #expect(throws: (any Error).self) { try Language(string: "de-1996-1996") }
+  }
+
+  @Test func rejectsDuplicateVariantSubtagsCaseInsensitively() {
+    // §2.1.1 subtag comparison is case-insensitive.
+    #expect(throws: (any Error).self) { try Language(string: "sl-rozaj-ROZAJ") }
+  }
+
+  @Test func rejectsDuplicateExtensionSingletons() {
+    // §4.1: "The same singleton MUST NOT be used more than once in a language tag."
+    #expect(throws: (any Error).self) { try Language(string: "en-u-co-phonebk-u-other") }
+  }
+
+  @Test func rejectsDuplicateExtensionSingletonsCaseInsensitively() {
+    #expect(throws: (any Error).self) { try Language(string: "en-U-co-u-other") }
+  }
+
+  // MARK: - Hashable identity
+
+  @Test func equalRawValueImpliesEqualValueAndHash() throws {
+    let a = try Language(string: "en-US")
+    let b = try Language(string: "en-US")
+    #expect(a == b)
+    #expect(a.hashValue == b.hashValue)
+  }
+
+  @Test func differentWireCaseProducesDifferentValues() throws {
+    let lower = try Language(string: "en-us")
+    let mixed = try Language(string: "EN-us")
+    #expect(lower != mixed)
+    #expect(lower.rawValue != mixed.rawValue)
+  }
+
+  // MARK: - Components invariants
+
+  @Test(arguments: ["en", "en-US", "zh-Hant-TW", "x-foo", "i-klingon"])
+  func languageCodeNilImpliesPrivateuseOrGrandfathered(_ tag: String) throws {
+    let l = try Language(string: tag)
+    if l.components.languageCode == nil {
+      #expect(!l.components.privateUse.isEmpty || l.components.grandfathered != nil)
+    }
+  }
+
+  // MARK: - FormatString<Language> attacks
+
+  @Test func formatStringDecodesNullThrows() {
+    let data = Data("null".utf8)
+    #expect(throws: (any Error).self) {
+      try JSONDecoder().decode(FormatString<Language>.self, from: data)
+    }
+  }
+
+  @Test func formatStringDecodesNumberThrows() {
+    let data = Data("42".utf8)
+    #expect(throws: (any Error).self) {
+      try JSONDecoder().decode(FormatString<Language>.self, from: data)
+    }
+  }
+
+  @Test func formatStringDecodesEmptyStringWithNilTyped() throws {
+    let data = Data("\"\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Language>.self, from: data)
+    #expect(value.rawValue == "")
+    #expect(value.typed == nil)
+  }
+
+  @Test func formatStringDecodesOversizedStringWithNilTyped() throws {
+    let oversized = String(repeating: "a", count: 100)
+    let data = Data("\"\(oversized)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Language>.self, from: data)
+    #expect(value.rawValue == oversized)
+    #expect(value.typed == nil)
+  }
+
+  @Test func formatStringRoundTripPreservesWireString() throws {
+    let wire = "EN-Latn-us-1901-u-co-phonebk-x-twain"
+    let value = try JSONDecoder().decode(
+      FormatString<Language>.self, from: Data("\"\(wire)\"".utf8))
+    let encoded = try JSONEncoder().encode(value)
+    #expect(String(decoding: encoded, as: UTF8.self) == "\"\(wire)\"")
+  }
+
+  // MARK: - Public API surface lockdown
+
+  // Locks the public-facing API of `Language` and its nested types so future refactors that
+  // drop a property, rename a case, or remove a conformance fail to compile or fail the test.
+
+  @Test func languageConformsToLexiconStringFormat() throws {
+    let l: any LexiconStringFormat = try Language(string: "en")
+    #expect(l.rawValue == "en")
+  }
+
+  @Test func subtagNewtypesAreRawRepresentableWithPublicInit() {
+    // The newtypes are public RawRepresentable so callers can model their own JSON; the
+    // resulting Language is still gated by the throwing parser.
+    let lc: Language.LanguageCode = Language.LanguageCode(rawValue: "en")
+    let sc: Language.Script = Language.Script(rawValue: "Latn")
+    let rg: Language.Region = Language.Region(rawValue: "US")
+    let vr: Language.Variant = Language.Variant(rawValue: "1901")
+    #expect(lc.rawValue == "en")
+    #expect(sc.rawValue == "Latn")
+    #expect(rg.rawValue == "US")
+    #expect(vr.rawValue == "1901")
+  }
+
+  @Test func grandfatheredEnumHasExactlyTwentySixCases() {
+    // RFC 5646 §2.2.8: 17 irregular + 9 regular.
+    #expect(Language.Grandfathered.allCases.count == 26)
+  }
+
+  @Test func languageStoredPropertiesAreImmutable() throws {
+    // `let` stored properties surface as non-mutable children; this is a smoke check that
+    // refactors don't switch to `var`.
+    let l = try Language(string: "en-US")
+    let mirror = Mirror(reflecting: l)
+    let labels = mirror.children.compactMap(\.label)
+    #expect(labels.contains("rawValue"))
+    #expect(labels.contains("components"))
+  }
+
+  // MARK: - Subtag order preservation (RFC 5646 SHOULD)
+
+  @Test func variantOrderIsPreservedInWire() throws {
+    let a = try Language(string: "de-CH-1901-1996")
+    let b = try Language(string: "de-CH-1996-1901")
+    #expect(a.components.variants.map(\.rawValue) == ["1901", "1996"])
+    #expect(b.components.variants.map(\.rawValue) == ["1996", "1901"])
+    #expect(a != b)
+    #expect(a.rawValue != b.rawValue)
+  }
+
+  @Test func extensionOrderIsPreservedInWire() throws {
+    let a = try Language(string: "en-a-bb-b-cc")
+    let b = try Language(string: "en-b-cc-a-bb")
+    #expect(a.components.extensions.map(\.singleton) == ["a", "b"])
+    #expect(b.components.extensions.map(\.singleton) == ["b", "a"])
+    #expect(a != b)
+  }
+
+  // MARK: - Subtag length boundaries
+
+  @Test func variantAtFiveCharBoundary() throws {
+    let l = try Language(string: "sl-rozaj")
+    #expect(l.components.variants.first?.rawValue == "rozaj")
+  }
+
+  @Test func variantAtEightCharBoundary() throws {
+    let l = try Language(string: "en-12345abc")
+    #expect(l.components.variants.first?.rawValue == "12345abc")
+  }
+
+  @Test func extensionSubtagAtTwoAndEightCharBoundaries() throws {
+    let l = try Language(string: "en-u-ab-abcdefgh-12345678")
+    #expect(l.components.extensions.count == 1)
+    #expect(l.components.extensions[0].subtags == ["ab", "abcdefgh", "12345678"])
+  }
+
+  @Test func privateuseSubtagAtOneAndEightCharBoundaries() throws {
+    let l = try Language(string: "x-a-abcdefgh-12345678")
+    #expect(l.components.privateUse == ["a", "abcdefgh", "12345678"])
+  }
+
+  // MARK: - Invariants over the full positive test corpus
+
+  @Test func componentsInvariantsHoldAcrossAllValidLanguages() throws {
+    // Run the structural invariants over every entry in the positive test corpus so a future
+    // parser change that violates them in some obscure tag fails loudly.
+    for tag in LanguageInteropTests.validLanguages {
+      let l = try Language(string: tag)
+      #expect(l.rawValue == tag, "rawValue must be verbatim for \(tag)")
+
+      let c = l.components
+      if c.languageCode == nil {
+        #expect(
+          !c.privateUse.isEmpty || c.grandfathered != nil,
+          "languageCode==nil but no privateUse and no grandfathered for \(tag)")
+      }
+      if c.grandfathered != nil {
+        // Grandfathered match consumes the entire wire; other slots stay empty.
+        #expect(c.languageCode == nil, "grandfathered tag has language for \(tag)")
+        #expect(c.script == nil, "grandfathered tag has script for \(tag)")
+        #expect(c.region == nil, "grandfathered tag has region for \(tag)")
+        #expect(c.variants.isEmpty, "grandfathered tag has variants for \(tag)")
+        #expect(c.extensions.isEmpty, "grandfathered tag has extensions for \(tag)")
+        #expect(c.privateUse.isEmpty, "grandfathered tag has privateUse for \(tag)")
+      }
+    }
+  }
+}

--- a/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
@@ -122,6 +122,29 @@ struct LanguageInteropTests {
     #expect(l.components.region?.rawValue == "us")
   }
 
+  @Test(arguments: Language.Grandfathered.allCases)
+  func grandfatheredCanonicalFormParses(_ g: Language.Grandfathered) throws {
+    let l = try Language(string: g.rawValue)
+    #expect(l.rawValue == g.rawValue)
+    #expect(l.components.grandfathered == g)
+    #expect(l.components.languageCode == nil)
+    #expect(l.components.script == nil)
+    #expect(l.components.region == nil)
+    #expect(l.components.variants.isEmpty)
+    #expect(l.components.extensions.isEmpty)
+    #expect(l.components.privateUse.isEmpty)
+  }
+
+  @Test func grandfatheredMatchIsCaseInsensitive() throws {
+    let l = try Language(string: "I-Klingon")
+    #expect(l.rawValue == "I-Klingon")
+    #expect(l.components.grandfathered == .iKlingon)
+
+    let l2 = try Language(string: "EN-gb-OED")
+    #expect(l2.rawValue == "EN-gb-OED")
+    #expect(l2.components.grandfathered == .enGBOed)
+  }
+
   @Test func multipleExtensionsAndVariants() throws {
     let l = try Language(string: "sl-rozaj-biske-u-co-standard-t-en-US")
     #expect(l.components.languageCode?.rawValue == "sl")

--- a/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Valid/invalid BCP-47 (RFC 5646) vectors for the strict language parser. The `rawValue` is
+// always preserved verbatim; sub-tags inside `Components` likewise keep the wire case.
+struct LanguageInteropTests {
+  static let validLanguages: [String] = [
+    // 2-3 ALPHA primary language.
+    "en", "EN", "en-US", "fr", "de", "ja", "zh", "cmn",
+    // 4 ALPHA reserved + 5-8 ALPHA registered.
+    "abcd", "abcde", "abcdefgh",
+    // With script.
+    "zh-Hant", "zh-Hans", "en-Latn", "sr-Cyrl",
+    // With script and region.
+    "zh-Hant-TW", "zh-Hans-CN", "en-Latn-US", "sr-Cyrl-RS",
+    // With 3-digit UN M.49 region.
+    "es-419", "en-001",
+    // With variant subtags.
+    "de-CH-1901", "sl-rozaj", "sl-rozaj-biske", "de-1996",
+    // Variant of DIGIT + 3 alphanum.
+    "en-1abc",
+    // With Unicode/Locale extension (`u-…`).
+    "en-US-u-islamcal", "de-DE-u-co-phonebk", "en-u-ca-buddhist-nu-thai",
+    // Single-letter extension singletons other than `x`.
+    "de-a-value", "en-r-extended-sequence",
+    // Privateuse-only.
+    "x-pig-latin", "X-Foo", "x-a-b-c", "x-1", "x-12345678",
+    // With privateuse suffix on a langtag.
+    "en-x-private", "de-CH-x-phonebk", "en-Latn-US-u-co-phonebk-x-twain",
+    // Case preservation (wire form kept verbatim regardless of canonical case).
+    "EN-us", "zh-hant", "DE-ch-1901",
+    // Grandfathered / irregular (RFC 5646 §2.2.8) and their case variations.
+    "i-klingon", "I-Klingon", "en-GB-oed", "EN-gb-OED", "sgn-BE-FR", "art-lojban",
+    "no-bok", "zh-min-nan",
+    // Extended language subtags (BCP-47 §2.2.2): up to 3 `3ALPHA` after a 2-3 ALPHA primary.
+    "zh-cmn", "zh-yue-HK", "zh-cmn-Hans-CN", "ar-aao-Latn-DZ", "en-USA", "ab-bbb-cccc",
+    "zh-cmn-cmn-cmn",
+  ]
+
+  @Test(arguments: validLanguages)
+  func validParses(_ tag: String) throws {
+    let language = try Language(string: tag)
+    #expect(language.rawValue == tag)
+  }
+}

--- a/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
@@ -39,9 +39,45 @@ struct LanguageInteropTests {
     "zh-cmn-cmn-cmn",
   ]
 
+  static let invalidLanguages: [String] = [
+    // Empty / pure hyphens.
+    "", "-", "--", "---",
+    // Empty subtags at edges or interior.
+    "en-", "-en", "en--US", "en-US-",
+    // No ALPHA in primary language.
+    "1234", "12-US",
+    // 1-char primary language (must be 2-8 ALPHA).
+    "a", "1",
+    // Wrong separator (BCP-47 uses `-`, not `_`).
+    "en_US", "EN_us",
+    // Trailing space / leading space / spurious whitespace.
+    " en", "en ", "en US",
+    // Non-ASCII bytes (Unicode letter, emoji).
+    "ja-日本", "en-😀",
+    // Privateuse degenerate forms (`x-` with no subtag, bare `x`).
+    "x-", "x", "X",
+    // Privateuse with overlong subtag (>8 alphanum) or empty subtag.
+    "x-123456789", "x--foo",
+    // Extension singleton without subtags.
+    "en-a", "en-u", "en-u-", "en-u-x",
+    // Extlang requires a 2-3 ALPHA primary subtag; reserved/registered primaries reject it.
+    "abcd-xyz", "english-abc",
+    // Extlang grammar caps at 3 subtags.
+    "zh-cmn-cmn-cmn-cmn",
+    // Region-shape only if 2 ALPHA or 3 DIGIT; 2-digit subtag is neither region nor variant.
+    "en-12",
+    // Length cap.
+    String(repeating: "a", count: 65), "en-" + String(repeating: "a", count: 62),
+  ]
+
   @Test(arguments: validLanguages)
   func validParses(_ tag: String) throws {
     let language = try Language(string: tag)
     #expect(language.rawValue == tag)
+  }
+
+  @Test(arguments: invalidLanguages)
+  func invalidThrows(_ tag: String) {
+    #expect(throws: (any Error).self) { try Language(string: tag) }
   }
 }

--- a/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/LanguageInteropTests.swift
@@ -80,4 +80,79 @@ struct LanguageInteropTests {
   func invalidThrows(_ tag: String) {
     #expect(throws: (any Error).self) { try Language(string: tag) }
   }
+
+  @Test func parsesVariantExtensionAndPrivateuse() throws {
+    let l = try Language(string: "de-CH-1901-u-co-phonebk-x-private")
+    #expect(l.rawValue == "de-CH-1901-u-co-phonebk-x-private")
+    #expect(l.components.languageCode?.rawValue == "de")
+    #expect(l.components.script == nil)
+    #expect(l.components.region?.rawValue == "CH")
+    #expect(l.components.variants.map(\.rawValue) == ["1901"])
+    #expect(l.components.extensions.count == 1)
+    #expect(l.components.extensions[0].singleton == "u")
+    #expect(l.components.extensions[0].subtags == ["co", "phonebk"])
+    #expect(l.components.privateUse == ["private"])
+    #expect(l.components.grandfathered == nil)
+  }
+
+  @Test func parsesScriptRegionExtensionAndPrivateuse() throws {
+    let l = try Language(string: "en-Latn-US-u-co-phonebk-x-twain")
+    #expect(l.components.languageCode?.rawValue == "en")
+    #expect(l.components.script?.rawValue == "Latn")
+    #expect(l.components.region?.rawValue == "US")
+    #expect(l.components.variants.isEmpty)
+    #expect(l.components.extensions.count == 1)
+    #expect(l.components.privateUse == ["twain"])
+  }
+
+  @Test func parsesPrivateuseOnly() throws {
+    let l = try Language(string: "x-pig-latin")
+    #expect(l.rawValue == "x-pig-latin")
+    #expect(l.components.languageCode == nil)
+    #expect(l.components.script == nil)
+    #expect(l.components.region == nil)
+    #expect(l.components.privateUse == ["pig", "latin"])
+    #expect(l.components.grandfathered == nil)
+  }
+
+  @Test func preservesWireCaseInRawValueAndSubtags() throws {
+    let l = try Language(string: "EN-us")
+    #expect(l.rawValue == "EN-us")
+    #expect(l.components.languageCode?.rawValue == "EN")
+    #expect(l.components.region?.rawValue == "us")
+  }
+
+  @Test func multipleExtensionsAndVariants() throws {
+    let l = try Language(string: "sl-rozaj-biske-u-co-standard-t-en-US")
+    #expect(l.components.languageCode?.rawValue == "sl")
+    #expect(l.components.variants.map(\.rawValue) == ["rozaj", "biske"])
+    #expect(l.components.extensions.count == 2)
+    #expect(l.components.extensions[0].singleton == "u")
+    #expect(l.components.extensions[0].subtags == ["co", "standard"])
+    #expect(l.components.extensions[1].singleton == "t")
+    #expect(l.components.extensions[1].subtags == ["en", "US"])
+  }
+
+  @Test func parsesExtendedLanguageSubtag() throws {
+    let l = try Language(string: "zh-cmn-Hans-CN")
+    #expect(l.rawValue == "zh-cmn-Hans-CN")
+    #expect(l.components.languageCode?.rawValue == "zh")
+    #expect(l.components.extendedLanguageSubtags.map(\.rawValue) == ["cmn"])
+    #expect(l.components.script?.rawValue == "Hans")
+    #expect(l.components.region?.rawValue == "CN")
+  }
+
+  @Test func parsesMultipleExtendedLanguageSubtags() throws {
+    let l = try Language(string: "zh-cmn-cmn-cmn")
+    #expect(l.components.languageCode?.rawValue == "zh")
+    #expect(l.components.extendedLanguageSubtags.map(\.rawValue) == ["cmn", "cmn", "cmn"])
+    #expect(l.components.script == nil)
+  }
+
+  @Test func tagWithoutExtlangHasEmptySubtags() throws {
+    let l = try Language(string: "zh-Hans-CN")
+    #expect(l.components.languageCode?.rawValue == "zh")
+    #expect(l.components.extendedLanguageSubtags.isEmpty)
+    #expect(l.components.script?.rawValue == "Hans")
+  }
 }


### PR DESCRIPTION
This PR projects AT Protocol `language` string fields to a type-safe `FormatString<Language>`, a lenient wrapper that keeps the original wire string in `rawValue` and exposes the parsed value via `typed`. `Language` is a new strict BCP-47 (RFC 5646) parser conforming to `LexiconStringFormat`, with support for grandfathered/irregular tags and extended language subtags.