### PR TITLE
Project AT Protocol uri fields to a type-safe FormatString<URI>

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/URI.swift
+++ b/Sources/SwiftAtproto/StringFormats/URI.swift
@@ -14,10 +14,14 @@ import Foundation
 // Non-ASCII bytes in the body are accepted verbatim (per the spec's "any scheme" stance);
 // canonicalization is left to the consumer.
 //
-// `URL` is intentionally NOT used as the conformance: `URL(string:)` rejects valid atproto
-// URIs like `at://did:plc:…`, normalizes spaces to `%20`, and converts IDN to punycode — all
-// of which break wire-faithful projection. `URL` is offered as a best-effort derived accessor
-// instead.
+// `URL` is intentionally NOT used as the conformance: `URL(string:)` silently re-encodes
+// wire characters (spaces → `%20`, IDN → punycode, etc.), and even
+// `URL(string:encodingInvalidCharacters: false)` is too strict for our lenient wire
+// admission (rejects inputs the lexicon `uri` format may carry, e.g. raw non-ASCII bytes)
+// while still rejecting `at://did:plc:…` (the DID authority's embedded colon collides with
+// port grammar). `URL` is offered as a best-effort derived accessor instead, exposing the
+// `encodingInvalidCharacters:` toggle so callers choose between best-effort (silent
+// re-encoding) and strict wire-faithful (nil for inputs needing encoding).
 public struct URI: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
@@ -32,13 +36,22 @@ public struct URI: LexiconStringFormat {
     scheme = parsedScheme
   }
 
-  // Best-effort `URL` projection. Returns nil for inputs `URL(string:)` cannot parse — notably
-  // any URI whose authority contains a colon followed by non-numeric bytes (port grammar
-  // violation), e.g. `at://did:plc:abc` or `at://example.com:notaport/path`. When non-nil,
-  // the URL may be canonicalized (percent-encoding, IDN punycode); compare against `rawValue`
-  // for wire fidelity. Non-nil does NOT imply the URL is semantically loadable (e.g.
-  // `https:///x` parses but has no host).
-  public var url: URL? { URL(string: rawValue) }
+  // Best-effort `URL` projection. The `encodingInvalidCharacters` parameter is forwarded to
+  // `URL(string:encodingInvalidCharacters:)`:
+  //   - `true` (default, matching Foundation's historical `URL(string:)` behavior): silently
+  //     re-encodes wire characters that need encoding (spaces → `%20`, IDN → punycode, etc.)
+  //     and converts the result to a usable URL when possible. `absoluteString` may diverge
+  //     from `rawValue`.
+  //   - `false`: returns nil for wire forms that would require any re-encoding. When
+  //     non-nil, the URL's `absoluteString` matches `rawValue` byte-for-byte (wire-faithful).
+  //
+  // Returns nil in either mode for inputs `URL` cannot parse — notably any URI whose
+  // authority contains a colon followed by non-numeric bytes (port grammar violation, e.g.
+  // `at://did:plc:abc` or `at://example.com:notaport/path`). Non-nil does NOT imply the URL
+  // is semantically loadable (e.g. `https:///x` parses but has no host).
+  public func url(encodingInvalidCharacters: Bool = true) -> URL? {
+    URL(string: rawValue, encodingInvalidCharacters: encodingInvalidCharacters)
+  }
 
   // Best-effort AT-URI projection. Non-nil only when the wire string is a valid restricted-form
   // AT URI (scheme=at, authority=DID/handle, …).

--- a/Sources/SwiftAtproto/StringFormats/URI.swift
+++ b/Sources/SwiftAtproto/StringFormats/URI.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+// Type for the lexicon `uri` string format: a lenient parser that keeps the wire string
+// verbatim and exposes best-effort typed accessors for known schemes (`url: URL?` and
+// `atUri: ATURI?`).
+//
+// Scope: atproto lexicon `uri` is "flexible to any URI schema" per RFC 3986
+// (https://atproto.com/specs/lexicon). This parser only enforces the wire-level shape:
+//   - RFC 3986 §3.1 scheme grammar (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )) followed by ":"
+//   - optional "//"
+//   - non-empty body whose first byte is neither "/" nor ASCII whitespace, and whose remaining
+//     bytes contain no ASCII whitespace / control characters
+//   - total length <= 8 KiB (per spec)
+// Non-ASCII bytes in the body are accepted verbatim (per the spec's "any scheme" stance);
+// canonicalization is left to the consumer.
+//
+// `URL` is intentionally NOT used as the conformance: `URL(string:)` rejects valid atproto
+// URIs like `at://did:plc:…`, normalizes spaces to `%20`, and converts IDN to punycode — all
+// of which break wire-faithful projection. `URL` is offered as a best-effort derived accessor
+// instead.
+public struct URI: LexiconStringFormat {
+  // The original wire string, kept verbatim (no normalization).
+  public let rawValue: String
+  // The URI scheme (before the colon), preserved verbatim (no lowercase canonicalization).
+  public let scheme: String
+
+  public init(string: String) throws {
+    guard let parsedScheme = URI.parse(string) else {
+      throw LexiconStringFormatError.invalid(format: "uri", value: string)
+    }
+    rawValue = string
+    scheme = parsedScheme
+  }
+
+  // Best-effort `URL` projection. Returns nil for inputs `URL(string:)` cannot parse — notably
+  // any URI whose authority contains a colon followed by non-numeric bytes (port grammar
+  // violation), e.g. `at://did:plc:abc` or `at://example.com:notaport/path`. When non-nil,
+  // the URL may be canonicalized (percent-encoding, IDN punycode); compare against `rawValue`
+  // for wire fidelity. Non-nil does NOT imply the URL is semantically loadable (e.g.
+  // `https:///x` parses but has no host).
+  public var url: URL? { URL(string: rawValue) }
+
+  // Best-effort AT-URI projection. Non-nil only when the wire string is a valid restricted-form
+  // AT URI (scheme=at, authority=DID/handle, …).
+  public var atUri: ATURI? { try? ATURI(string: rawValue) }
+}
+
+extension URI {
+  // 8 KiB per atproto spec.
+  private static let maxLength = 8 * 1024
+
+  static func parse(_ input: String) -> String? {
+    guard !input.isEmpty, input.utf8.count <= maxLength else { return nil }
+    let bytes = Array(input.utf8)
+    var i = 0
+
+    // RFC 3986 §3.1: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+    guard i < bytes.count, isSchemeFirst(bytes[i]) else { return nil }
+    let schemeStart = i
+    i += 1
+    while i < bytes.count, isSchemeRest(bytes[i]) { i += 1 }
+
+    // ":"
+    guard i < bytes.count, bytes[i] == 0x3A else { return nil }
+    let schemeEnd = i
+    i += 1
+
+    // optional "//"
+    if i + 1 < bytes.count, bytes[i] == 0x2F, bytes[i + 1] == 0x2F {
+      i += 2
+    }
+
+    // Body: at least 1 byte; first byte must not be whitespace / control. A leading "/" is
+    // allowed because RFC 3986 §3 lets `hier-part` be `path-absolute` (`scheme:/path`) or
+    // `"//" authority path-abempty` with empty authority + path-abempty (`scheme:///path`).
+    guard i < bytes.count else { return nil }
+    guard isBodyByte(bytes[i]) else { return nil }
+    i += 1
+
+    // Body remainder: no whitespace / control bytes.
+    while i < bytes.count {
+      guard isBodyByte(bytes[i]) else { return nil }
+      i += 1
+    }
+
+    // Scheme is pure ASCII by grammar, so direct byte slice is safe.
+    return String(bytes: bytes[schemeStart..<schemeEnd], encoding: .ascii)
+  }
+
+  // RFC 3986 §3.1: scheme starts with ALPHA (A-Z / a-z).
+  private static func isSchemeFirst(_ b: UInt8) -> Bool {
+    (0x41...0x5A).contains(b) || (0x61...0x7A).contains(b)
+  }
+
+  // RFC 3986 §3.1: subsequent scheme chars are ALPHA / DIGIT / "+" / "-" / ".".
+  private static func isSchemeRest(_ b: UInt8) -> Bool {
+    isSchemeFirst(b)
+      || (0x30...0x39).contains(b)  // DIGIT
+      || b == 0x2B  // +
+      || b == 0x2D  // -
+      || b == 0x2E  // .
+  }
+
+  // Body byte: anything that is not an ASCII control character (0x00-0x1F) or space (0x20) or
+  // DEL (0x7F). Non-ASCII bytes (>= 0x80) are accepted verbatim; the consumer may percent-encode.
+  private static func isBodyByte(_ b: UInt8) -> Bool {
+    b > 0x20 && b != 0x7F
+  }
+}

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -564,6 +564,7 @@ struct StringFormat: Codable, RawRepresentable {
     case "cid": "LexLink"
     case "at-uri": "ATURI"
     case "language": "Language"
+    case "uri": "URI"
     default: nil
     }
   }

--- a/Tests/SwiftAtprotoTests/FormatStringURITests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringURITests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringURITests {
+  static let wire = "https://example.com/path?q=1#frag"
+
+  @Test func decodePreservesWireStringAndTypedYieldsURI() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<URI>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+    #expect(value.typed?.scheme == "https")
+  }
+
+  @Test func invalidURIDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\"not a uri\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<URI>.self, from: data)
+    #expect(value.rawValue == "not a uri")
+    #expect(value.typed == nil)
+  }
+
+  @Test func atURIDecodesAsValidURI() throws {
+    // `uri` is the broader format and should accept AT URIs alongside other schemes.
+    let wire = "at://did:plc:abc/com.example.foo/rkey"
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<URI>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed?.scheme == "at")
+    #expect(value.typed?.atUri != nil)
+    #expect(value.typed?.url == nil)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<URI>(rawValue: Self.wire)
+    let encoder = JSONEncoder()
+    // The wire string contains "/", which JSONEncoder escapes to "\/" by default.
+    encoder.outputFormatting = [.withoutEscapingSlashes]
+    let data = try encoder.encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+
+  @Test func initFromURIPreservesWireString() throws {
+    let uri = try URI(string: Self.wire)
+    let value = FormatString(uri)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func decodesURIFieldInRecord() throws {
+    struct Record: Codable {
+      var link: FormatString<URI>
+    }
+    let json = Data("{\"link\":\"\(Self.wire)\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.link.rawValue == Self.wire)
+    #expect(record.link.typed?.scheme == "https")
+  }
+
+  @Test func decodesURIArrayFieldInRecord() throws {
+    struct Record: Codable {
+      var links: [FormatString<URI>]
+    }
+    let json = Data("{\"links\":[\"https://a.example\",\"at://did:plc:abc\",\"did:web:x\"]}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.links.count == 3)
+    #expect(record.links.map(\.rawValue) == ["https://a.example", "at://did:plc:abc", "did:web:x"])
+    #expect(record.links.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func decodesOversizedURIWithNilTyped() throws {
+    // Over the 8 KiB cap → strict parser rejects, lenient decode preserves rawValue.
+    let body = String(repeating: "a", count: 8 * 1024)
+    let wire = "https:" + body
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<URI>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<URI>(rawValue: Self.wire)
+    #expect(value.description == Self.wire)
+    #expect("\(value)" == Self.wire)
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringURITests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringURITests.swift
@@ -29,7 +29,7 @@ struct FormatStringURITests {
     #expect(value.rawValue == wire)
     #expect(value.typed?.scheme == "at")
     #expect(value.typed?.atUri != nil)
-    #expect(value.typed?.url == nil)
+    #expect(value.typed?.url() == nil)
   }
 
   @Test func encodeEmitsWireString() throws {

--- a/Tests/SwiftAtprotoTests/URIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/URIInteropTests.swift
@@ -87,4 +87,49 @@ struct URIInteropTests {
     let u = try URI(string: "git+ssh://git@example.com/repo.git")
     #expect(u.scheme == "git+ssh")
   }
+
+  static let invalidURIs: [String] = [
+    // Empty / colon-only / scheme-only.
+    "", ":", "https:", "at:", "at://",
+    // Scheme missing (no colon).
+    "example.com", "/path", "/", "//host/path",
+    // Scheme starts with non-ALPHA (digit, +, -, .).
+    "1http://example.com", "+http://example.com", "-http://example.com", ".http://example.com",
+    // Scheme contains underscore (RFC 3986 §3.1 disallows).
+    "ht_tp://example.com",
+    // Whitespace anywhere in body.
+    "https://example.com/ space", "https://example.com\twith\ttab",
+    // ASCII control characters in body.
+    "https://example.com\u{0001}body", "https://example.com\nbody",
+    // CR/LF/NUL.
+    "https://example.com\r", "https://example.com\u{0000}",
+    // DEL (0x7F).
+    "https://example.com\u{007F}",
+    // Empty body after "//".
+    "https://", "wss://",
+    // Pure whitespace.
+    " ", "\t",
+  ]
+
+  @Test(arguments: invalidURIs)
+  func invalidThrows(_ uri: String) {
+    #expect(throws: (any Error).self) { try URI(string: uri) }
+  }
+
+  @Test func acceptsExactly8KiBInput() throws {
+    // scheme(5 byte "https") + ":" + body of 8186 byte → total 8 * 1024 = 8192 byte (cap).
+    let body = String(repeating: "a", count: 8 * 1024 - 6)
+    let uri = "https:" + body
+    let u = try URI(string: uri)
+    #expect(u.rawValue.utf8.count == 8 * 1024)
+    #expect(u.scheme == "https")
+  }
+
+  @Test func rejectsOver8KiBInput() {
+    // Just past the cap.
+    let body = String(repeating: "a", count: 8 * 1024 - 5)
+    let uri = "https:" + body
+    #expect(uri.utf8.count == 8 * 1024 + 1)
+    #expect(throws: (any Error).self) { try URI(string: uri) }
+  }
 }

--- a/Tests/SwiftAtprotoTests/URIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/URIInteropTests.swift
@@ -137,9 +137,11 @@ struct URIInteropTests {
 
   @Test func urlAccessorReturnsNilForAtURIWithDID() throws {
     // `URL(string:)` returns nil for `at://did:plc:*` (the embedded `:` in the authority
-    // interacts with port grammar). The wire string is preserved in `rawValue`.
+    // interacts with port grammar). The wire string is preserved in `rawValue`. The result
+    // is nil in either `encodingInvalidCharacters` mode.
     let u = try URI(string: "at://did:plc:abc")
-    #expect(u.url == nil)
+    #expect(u.url() == nil)
+    #expect(u.url(encodingInvalidCharacters: false) == nil)
     #expect(u.rawValue == "at://did:plc:abc")
   }
 
@@ -147,8 +149,8 @@ struct URIInteropTests {
     // Assert non-nil + scheme match rather than full `absoluteString` equality so the test
     // survives any URL canonicalization changes across OS versions.
     let u = try URI(string: "https://example.com/path")
-    #expect(u.url != nil)
-    #expect(u.url?.scheme == "https")
+    #expect(u.url() != nil)
+    #expect(u.url()?.scheme == "https")
   }
 
   @Test func urlAccessorReturnsNonNilForEmptyAuthority() throws {
@@ -156,36 +158,40 @@ struct URIInteropTests {
     // returns a non-nil URL. The contract is wire-shape correctness — non-nil here does NOT
     // imply the URL is loadable: `URLSession` would fail because there is no host.
     let u = try URI(string: "https:///x")
-    #expect(u.url != nil)
-    #expect((u.url?.host ?? "").isEmpty)
+    #expect(u.url() != nil)
+    #expect(u.url()?.host(percentEncoded: false) == nil)
   }
 
-  @Test func urlAccessorCanonicalizesIDN() throws {
-    // IDN host is punycoded by URL canonicalization, so `.url?.absoluteString` diverges from
-    // `.rawValue`. The wire string is preserved in `.rawValue` (verbatim contract).
+  @Test func urlAccessorIDNBehaviorByEncodingMode() throws {
+    // Default (`encodingInvalidCharacters: true`): Foundation silently re-encodes IDN to
+    // punycode, so `.url()` is non-nil and `absoluteString` diverges from `rawValue`.
+    // Strict (`encodingInvalidCharacters: false`): wire-faithful — nil because the wire form
+    // would require canonicalization. The wire string is preserved in `.rawValue` either way.
     let u = try URI(string: "https://例え.テスト/foo")
     #expect(u.rawValue == "https://例え.テスト/foo")
-    #expect(u.url != nil)
-    #expect(u.url?.absoluteString != u.rawValue)
-    #expect(u.url?.absoluteString.contains("xn--") == true)
+    // Default mode: punycode-canonicalized URL.
+    #expect(u.url() != nil)
+    #expect(u.url()?.absoluteString.contains("xn--") == true)
+    // Strict mode: nil.
+    #expect(u.url(encodingInvalidCharacters: false) == nil)
   }
 
   @Test func urlAccessorAcceptsDIDColonScheme() throws {
-    // `URL(string:)` accepts `did:plc:abc` as an opaque, no-authority URI; `.url` is non-nil.
+    // `URL(string:)` accepts `did:plc:abc` as an opaque, no-authority URI; `.url()` is non-nil.
     // Asserting non-nil (rather than full `absoluteString` equality) survives canonicalization
     // changes in `URL`. Note: if `URL(string:)` ever rejects `did:` URIs outright, this test
     // will fail — intentionally, since we want to be notified of that behavior change.
     let u = try URI(string: "did:plc:abc")
-    #expect(u.url != nil)
+    #expect(u.url() != nil)
   }
 
   @Test func urlAccessorAcceptsFileSchemeForms() throws {
     // Both `path-absolute` (`file:/etc/hosts`) and empty-authority (`file:///etc/hosts`)
     // forms yield a non-nil URL. Pin this so a future tightening of `URL(string:)` is caught.
     let u1 = try URI(string: "file:/etc/hosts")
-    #expect(u1.url != nil)
+    #expect(u1.url() != nil)
     let u2 = try URI(string: "file:///etc/hosts")
-    #expect(u2.url != nil)
+    #expect(u2.url() != nil)
   }
 
   @Test func atUriAccessorReturnsValueForValidATURI() throws {

--- a/Tests/SwiftAtprotoTests/URIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/URIInteropTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Valid/invalid wire-shape vectors for the lenient `uri` string format parser. The `rawValue`
+// is always preserved verbatim; the parsed `scheme` keeps its wire case.
+struct URIInteropTests {
+  static let validURIs: [String] = [
+    // AT Protocol URIs.
+    "at://did:plc:abc",
+    "at://did:plc:abc/com.example.foo",
+    "at://did:plc:abc/com.example.foo/rkey",
+    "at://example.com",
+    // HTTP / HTTPS.
+    "https://example.com",
+    "http://example.com",
+    "https://example.com/path/to/resource",
+    "https://example.com/path?query=value&other=1",
+    "https://example.com/path#fragment",
+    "https://example.com:8443/path",
+    // WebSocket schemes.
+    "wss://relay.example.com",
+    "ws://localhost:9000/feed",
+    // Schemes without authority (no `//`).
+    "did:plc:abc123",
+    "did:web:example.com",
+    "data:text/plain,Hello",
+    "tel:+1-555-0100",
+    "mailto:user@example.com",
+    // RFC 3986 §3 `path-absolute` hier-part (scheme followed by absolute path, no authority).
+    "file:/etc/hosts", "at:/", "at:/x", "https:/x",
+    // RFC 3986 §3.2 empty authority + path-abempty (`scheme://` followed by absolute path).
+    "file:///etc/hosts", "https:///x", "at:///x/y",
+    // `//` after the authority delimiter is consumed only once; the remaining bytes form the
+    // body and are accepted verbatim (no further interpretation by this parser).
+    "https:////host",
+    // IPFS / DNS / other examples cited by the atproto spec.
+    "ipfs://QmHash123",
+    "dns://_atproto.example.com",
+    // Scheme case preserved (uppercase scheme is grammar-legal per RFC 3986).
+    "HTTPS://Example.Com",
+    "AT://Did:Plc:ABC",
+    // Scheme characters: ALPHA / DIGIT / "+" / "-" / "."
+    "x-custom:body",
+    "git+ssh://git@example.com/repo.git",
+    "z39.50r://library.example.com",
+    "h2://example.com",
+    // Non-ASCII bytes are accepted verbatim in the body (verbatim wire preservation).
+    "https://例え.テスト/foo",
+    // Very short minimal forms.
+    "a:b",
+    "ab://c",
+  ]
+
+  @Test(arguments: validURIs)
+  func validParses(_ uri: String) throws {
+    let value = try URI(string: uri)
+    #expect(value.rawValue == uri)
+    #expect(!value.scheme.isEmpty)
+  }
+
+  @Test func parsesSchemeForAtUri() throws {
+    let u = try URI(string: "at://did:plc:abc/com.example.foo/rkey")
+    #expect(u.scheme == "at")
+    #expect(u.rawValue == "at://did:plc:abc/com.example.foo/rkey")
+  }
+
+  @Test func parsesSchemeForHttps() throws {
+    let u = try URI(string: "https://example.com/path?q=1#frag")
+    #expect(u.scheme == "https")
+  }
+
+  @Test func parsesSchemeWithoutAuthority() throws {
+    let u = try URI(string: "did:plc:abc")
+    #expect(u.scheme == "did")
+    #expect(u.rawValue == "did:plc:abc")
+  }
+
+  @Test func preservesSchemeCaseVerbatim() throws {
+    let u = try URI(string: "HTTPS://Example.Com")
+    #expect(u.scheme == "HTTPS")
+    #expect(u.rawValue == "HTTPS://Example.Com")
+  }
+
+  @Test func parsesSchemeWithSpecialCharacters() throws {
+    let u = try URI(string: "git+ssh://git@example.com/repo.git")
+    #expect(u.scheme == "git+ssh")
+  }
+}

--- a/Tests/SwiftAtprotoTests/URIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/URIInteropTests.swift
@@ -132,4 +132,96 @@ struct URIInteropTests {
     #expect(uri.utf8.count == 8 * 1024 + 1)
     #expect(throws: (any Error).self) { try URI(string: uri) }
   }
+
+  // MARK: derived accessors
+
+  @Test func urlAccessorReturnsNilForAtURIWithDID() throws {
+    // `URL(string:)` returns nil for `at://did:plc:*` (the embedded `:` in the authority
+    // interacts with port grammar). The wire string is preserved in `rawValue`.
+    let u = try URI(string: "at://did:plc:abc")
+    #expect(u.url == nil)
+    #expect(u.rawValue == "at://did:plc:abc")
+  }
+
+  @Test func urlAccessorReturnsValueForHttpsScheme() throws {
+    // Assert non-nil + scheme match rather than full `absoluteString` equality so the test
+    // survives any URL canonicalization changes across OS versions.
+    let u = try URI(string: "https://example.com/path")
+    #expect(u.url != nil)
+    #expect(u.url?.scheme == "https")
+  }
+
+  @Test func urlAccessorReturnsNonNilForEmptyAuthority() throws {
+    // `https:///x` is RFC 3986 valid (empty authority + path-abempty) and `URL(string:)`
+    // returns a non-nil URL. The contract is wire-shape correctness — non-nil here does NOT
+    // imply the URL is loadable: `URLSession` would fail because there is no host.
+    let u = try URI(string: "https:///x")
+    #expect(u.url != nil)
+    #expect((u.url?.host ?? "").isEmpty)
+  }
+
+  @Test func urlAccessorCanonicalizesIDN() throws {
+    // IDN host is punycoded by URL canonicalization, so `.url?.absoluteString` diverges from
+    // `.rawValue`. The wire string is preserved in `.rawValue` (verbatim contract).
+    let u = try URI(string: "https://例え.テスト/foo")
+    #expect(u.rawValue == "https://例え.テスト/foo")
+    #expect(u.url != nil)
+    #expect(u.url?.absoluteString != u.rawValue)
+    #expect(u.url?.absoluteString.contains("xn--") == true)
+  }
+
+  @Test func urlAccessorAcceptsDIDColonScheme() throws {
+    // `URL(string:)` accepts `did:plc:abc` as an opaque, no-authority URI; `.url` is non-nil.
+    // Asserting non-nil (rather than full `absoluteString` equality) survives canonicalization
+    // changes in `URL`. Note: if `URL(string:)` ever rejects `did:` URIs outright, this test
+    // will fail — intentionally, since we want to be notified of that behavior change.
+    let u = try URI(string: "did:plc:abc")
+    #expect(u.url != nil)
+  }
+
+  @Test func urlAccessorAcceptsFileSchemeForms() throws {
+    // Both `path-absolute` (`file:/etc/hosts`) and empty-authority (`file:///etc/hosts`)
+    // forms yield a non-nil URL. Pin this so a future tightening of `URL(string:)` is caught.
+    let u1 = try URI(string: "file:/etc/hosts")
+    #expect(u1.url != nil)
+    let u2 = try URI(string: "file:///etc/hosts")
+    #expect(u2.url != nil)
+  }
+
+  @Test func atUriAccessorReturnsValueForValidATURI() throws {
+    let u = try URI(string: "at://did:plc:abc/com.example.foo/rkey")
+    #expect(u.atUri != nil)
+    #expect(u.atUri?.rawValue == "at://did:plc:abc/com.example.foo/rkey")
+    #expect(u.atUri?.collection == "com.example.foo")
+    #expect(u.atUri?.rkey == "rkey")
+  }
+
+  @Test func atUriAccessorReturnsValueForHandleOnlyAuthority() throws {
+    // ATURI's restricted form permits authority alone (collection/rkey optional).
+    let u = try URI(string: "at://example.com")
+    #expect(u.atUri != nil)
+    #expect(u.atUri?.authority == "example.com")
+    #expect(u.atUri?.collection == nil)
+    #expect(u.atUri?.rkey == nil)
+  }
+
+  @Test func atUriAccessorReturnsNilForNonATScheme() throws {
+    let u = try URI(string: "https://example.com")
+    #expect(u.atUri == nil)
+  }
+
+  @Test func atUriAccessorReturnsNilForAtSchemeWithoutDoubleSlash() throws {
+    // `at:/` and `at:/x` are valid `uri` (path-absolute) but the strict AT URI parser
+    // requires the `at://` prefix, so `.atUri` is nil.
+    let u1 = try URI(string: "at:/")
+    #expect(u1.atUri == nil)
+    let u2 = try URI(string: "at:/x")
+    #expect(u2.atUri == nil)
+  }
+
+  @Test func atUriAccessorReturnsNilForMalformedATURI() throws {
+    // Wire-shape valid for `uri` but not a valid restricted-form AT URI (path lacks NSID).
+    let u = try URI(string: "at://example.com/not-an-nsid")
+    #expect(u.atUri == nil)
+  }
 }


### PR DESCRIPTION
This PR projects AT Protocol `uri` string fields to a type-safe `FormatString<URI>`, a lenient wrapper that keeps the original wire string in `rawValue` and exposes the parsed value via `typed`. `URI` is a new lenient RFC 3986 parser conforming to `LexiconStringFormat`, with best-effort `url(encodingInvalidCharacters:)` and `atUri: ATURI?` derived accessors for known schemes. The `url(...)` method exposes Foundation's URL parsing toggle directly, letting callers choose between best-effort canonicalization (default) and strict wire-faithful projection.