### PR TITLE
feat: add identifier string format projections with TID generator (DID, Handle, NSID, TID, RecordKey, AtIdentifier)

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -17,8 +17,8 @@ import Foundation
 // type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
 // separate addition if a concrete need arises.
 //
-// The DID/Handle/NSID/record-key validators are kept private here; they may later be promoted to
-// dedicated identifier types and shared.
+// The Handle/NSID/record-key validators are kept private here for now; they may later be promoted
+// to dedicated identifier types and shared.
 public struct ATURI: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
@@ -129,28 +129,10 @@ extension ATURI {
     return Parts(authority: authority, collection: collection, rkey: rkey, fragment: fragment)
   }
 
-  // MARK: - Component validators (DID / Handle / NSID / record key / JSON pointer)
+  // MARK: - Component validators (Handle / NSID / record key / JSON pointer)
 
   private static func isValidAtIdentifier(_ s: Substring) -> Bool {
-    s.hasPrefix("did:") ? isValidDID(s) : isValidHandle(s)
-  }
-
-  // /^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$/ with length <= 2048
-  private static func isValidDID(_ s: Substring) -> Bool {
-    let u = Array(s.utf8)
-    guard u.count <= 2048, u.starts(with: Array("did:".utf8)) else { return false }
-    var i = 4
-    let methodStart = i
-    while i < u.count, isLowerAlpha(u[i]) { i += 1 }
-    guard i > methodStart, i < u.count, u[i] == colon else { return false }
-    i += 1
-    guard i < u.count else { return false }  // identifier needs >= 1 char
-    while i < u.count {
-      guard isDIDIdentifierByte(u[i]) else { return false }
-      i += 1
-    }
-    let last = u[u.count - 1]
-    return last != colon && last != percent
+    s.hasPrefix("did:") ? DID.isValid(s) : isValidHandle(s)
   }
 
   // /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/, <= 253
@@ -205,8 +187,6 @@ extension ATURI {
 
 // MARK: - ASCII byte helpers
 
-private let colon = UInt8(ascii: ":")
-private let percent = UInt8(ascii: "%")
 private let hyphen = UInt8(ascii: "-")
 private let dot = UInt8(ascii: ".")
 private let slash = UInt8(ascii: "/")
@@ -216,6 +196,3 @@ private let recordKeyPunct = Set("_~.:-".utf8)
 private let pointerPunct = Set("._~:@!$&')(*+,;=%[]/-".utf8)
 
 private func isAllowedURIByte(_ b: UInt8) -> Bool { isAlphanumeric(b) || uriAllowedPunct.contains(b) }
-private func isDIDIdentifierByte(_ b: UInt8) -> Bool {
-  isAlphanumeric(b) || b == dot || b == UInt8(ascii: "_") || b == colon || b == percent || b == hyphen
-}

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -215,11 +215,6 @@ private let uriAllowedPunct = Set(#"._~:@!$&'()*+,;=%/\[]#?-"#.utf8)
 private let recordKeyPunct = Set("_~.:-".utf8)
 private let pointerPunct = Set("._~:@!$&')(*+,;=%[]/-".utf8)
 
-private func isDigit(_ b: UInt8) -> Bool { (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(b) }
-private func isLowerAlpha(_ b: UInt8) -> Bool { (UInt8(ascii: "a")...UInt8(ascii: "z")).contains(b) }
-private func isUpperAlpha(_ b: UInt8) -> Bool { (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(b) }
-private func isAlpha(_ b: UInt8) -> Bool { isLowerAlpha(b) || isUpperAlpha(b) }
-private func isAlphanumeric(_ b: UInt8) -> Bool { isAlpha(b) || isDigit(b) }
 private func isAllowedURIByte(_ b: UInt8) -> Bool { isAlphanumeric(b) || uriAllowedPunct.contains(b) }
 private func isDIDIdentifierByte(_ b: UInt8) -> Bool {
   isAlphanumeric(b) || b == dot || b == UInt8(ascii: "_") || b == colon || b == percent || b == hyphen

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -17,8 +17,8 @@ import Foundation
 // type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
 // separate addition if a concrete need arises.
 //
-// The Handle/NSID/record-key validators are kept private here for now; they may later be promoted
-// to dedicated identifier types and shared.
+// The NSID/record-key validators are kept private here for now; they may later be promoted to
+// dedicated identifier types and shared.
 public struct ATURI: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
@@ -129,25 +129,10 @@ extension ATURI {
     return Parts(authority: authority, collection: collection, rkey: rkey, fragment: fragment)
   }
 
-  // MARK: - Component validators (Handle / NSID / record key / JSON pointer)
+  // MARK: - Component validators (NSID / record key / JSON pointer)
 
   private static func isValidAtIdentifier(_ s: Substring) -> Bool {
-    s.hasPrefix("did:") ? DID.isValid(s) : isValidHandle(s)
-  }
-
-  // /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/, <= 253
-  private static func isValidHandle(_ s: Substring) -> Bool {
-    guard s.utf8.count <= 253 else { return false }
-    let labels = s.split(separator: ".", omittingEmptySubsequences: false)
-    guard labels.count >= 2 else { return false }
-    for (index, label) in labels.enumerated() {
-      let u = Array(label.utf8)
-      guard (1...63).contains(u.count) else { return false }
-      for byte in u where !(isAlphanumeric(byte) || byte == hyphen) { return false }
-      guard u.first != hyphen, u.last != hyphen else { return false }
-      if index == labels.count - 1, !isAlpha(u[0]) { return false }  // TLD starts with a letter
-    }
-    return true
+    s.hasPrefix("did:") ? DID.isValid(s) : Handle.isValid(s)
   }
 
   // NSID rules: <= 317, [a-zA-Z0-9.-], >= 3 segments (1..63, no edge hyphen),

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -17,8 +17,8 @@ import Foundation
 // type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
 // separate addition if a concrete need arises.
 //
-// The record-key validator is kept private here for now; it may later be promoted to a dedicated
-// identifier type and shared.
+// DID / Handle / NSID / RecordKey component validators live in their dedicated identifier-type
+// files. Only the JSON Pointer fragment validator remains here.
 public struct ATURI: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
@@ -124,23 +124,15 @@ extension ATURI {
     // Strict-only constraints.
     if trailingSlash { return nil }
     if hasQuery { return nil }
-    if let rkey, !isValidRecordKey(rkey) { return nil }
+    if let rkey, !RecordKey.isValid(rkey) { return nil }
 
     return Parts(authority: authority, collection: collection, rkey: rkey, fragment: fragment)
   }
 
-  // MARK: - Component validators (record key / JSON pointer)
+  // MARK: - Component validators (JSON pointer)
 
   private static func isValidAtIdentifier(_ s: Substring) -> Bool {
     s.hasPrefix("did:") ? DID.isValid(s) : Handle.isValid(s)
-  }
-
-  // /^[a-zA-Z0-9_~.:-]{1,512}$/, excluding "." and ".."
-  private static func isValidRecordKey(_ s: Substring) -> Bool {
-    let u = Array(s.utf8)
-    guard (1...512).contains(u.count) else { return false }
-    for byte in u where !(isAlphanumeric(byte) || recordKeyPunct.contains(byte)) { return false }
-    return s != "." && s != ".."
   }
 
   // JSON Pointer fragment: starts with "/", allowed pointer chars, with valid percent-encoding.
@@ -157,7 +149,6 @@ extension ATURI {
 private let slash = UInt8(ascii: "/")
 
 private let uriAllowedPunct = Set(#"._~:@!$&'()*+,;=%/\[]#?-"#.utf8)
-private let recordKeyPunct = Set("_~.:-".utf8)
 private let pointerPunct = Set("._~:@!$&')(*+,;=%[]/-".utf8)
 
 private func isAllowedURIByte(_ b: UInt8) -> Bool { isAlphanumeric(b) || uriAllowedPunct.contains(b) }

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -17,8 +17,8 @@ import Foundation
 // type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
 // separate addition if a concrete need arises.
 //
-// The NSID/record-key validators are kept private here for now; they may later be promoted to
-// dedicated identifier types and shared.
+// The record-key validator is kept private here for now; it may later be promoted to a dedicated
+// identifier type and shared.
 public struct ATURI: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
@@ -118,7 +118,7 @@ extension ATURI {
 
     // Component validation (applies in both strict and lenient).
     guard isValidAtIdentifier(authority) else { return nil }
-    if let collection, !isValidNSID(collection) { return nil }
+    if let collection, !NSID.isValid(collection) { return nil }
     if let fragment, !isValidJSONPointer(fragment) { return nil }
 
     // Strict-only constraints.
@@ -129,28 +129,10 @@ extension ATURI {
     return Parts(authority: authority, collection: collection, rkey: rkey, fragment: fragment)
   }
 
-  // MARK: - Component validators (NSID / record key / JSON pointer)
+  // MARK: - Component validators (record key / JSON pointer)
 
   private static func isValidAtIdentifier(_ s: Substring) -> Bool {
     s.hasPrefix("did:") ? DID.isValid(s) : Handle.isValid(s)
-  }
-
-  // NSID rules: <= 317, [a-zA-Z0-9.-], >= 3 segments (1..63, no edge hyphen),
-  // first segment not leading-digit, last segment letters/digits only with no leading digit.
-  private static func isValidNSID(_ s: Substring) -> Bool {
-    let all = Array(s.utf8)
-    guard all.count <= 317 else { return false }
-    for byte in all where !(isAlphanumeric(byte) || byte == dot || byte == hyphen) { return false }
-    let segments = s.split(separator: ".", omittingEmptySubsequences: false)
-    guard segments.count >= 3 else { return false }
-    for segment in segments {
-      let u = Array(segment.utf8)
-      guard (1...63).contains(u.count) else { return false }
-      guard u.first != hyphen, u.last != hyphen else { return false }
-    }
-    if isDigit(Array(segments[0].utf8)[0]) { return false }
-    let name = Array(segments[segments.count - 1].utf8)
-    return !isDigit(name[0]) && !name.contains(hyphen)
   }
 
   // /^[a-zA-Z0-9_~.:-]{1,512}$/, excluding "." and ".."
@@ -172,8 +154,6 @@ extension ATURI {
 
 // MARK: - ASCII byte helpers
 
-private let hyphen = UInt8(ascii: "-")
-private let dot = UInt8(ascii: ".")
 private let slash = UInt8(ascii: "/")
 
 private let uriAllowedPunct = Set(#"._~:@!$&'()*+,;=%/\[]#?-"#.utf8)

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -17,8 +17,8 @@ import Foundation
 // type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
 // separate addition if a concrete need arises.
 //
-// DID / Handle / NSID / RecordKey component validators live in their dedicated identifier-type
-// files. Only the JSON Pointer fragment validator remains here.
+// DID / Handle / NSID / RecordKey / AtIdentifier component validators live in their dedicated
+// identifier-type files. Only the JSON Pointer fragment validator remains here.
 public struct ATURI: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
@@ -117,7 +117,7 @@ extension ATURI {
     guard i == end else { return nil }
 
     // Component validation (applies in both strict and lenient).
-    guard isValidAtIdentifier(authority) else { return nil }
+    guard AtIdentifier.isValid(authority) else { return nil }
     if let collection, !NSID.isValid(collection) { return nil }
     if let fragment, !isValidJSONPointer(fragment) { return nil }
 
@@ -129,11 +129,7 @@ extension ATURI {
     return Parts(authority: authority, collection: collection, rkey: rkey, fragment: fragment)
   }
 
-  // MARK: - Component validators (JSON pointer)
-
-  private static func isValidAtIdentifier(_ s: Substring) -> Bool {
-    s.hasPrefix("did:") ? DID.isValid(s) : Handle.isValid(s)
-  }
+  // MARK: - JSON Pointer fragment
 
   // JSON Pointer fragment: starts with "/", allowed pointer chars, with valid percent-encoding.
   private static func isValidJSONPointer(_ s: Substring) -> Bool {

--- a/Sources/SwiftAtproto/StringFormats/AtIdentifier.swift
+++ b/Sources/SwiftAtproto/StringFormats/AtIdentifier.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// Type for the lexicon `at-identifier` string format: either a DID or a Handle. Per the AT
+// Protocol Identifier spec (https://atproto.com/specs/at-identifier), inputs starting with `did:`
+// are validated as DIDs; everything else is validated as a Handle. Wire bytes round-trip via
+// `rawValue` byte-for-byte.
+public enum AtIdentifier: LexiconStringFormat {
+  case did(DID)
+  case handle(Handle)
+
+  public var rawValue: String {
+    switch self {
+    case .did(let d): d.rawValue
+    case .handle(let h): h.rawValue
+    }
+  }
+
+  public init(string: String) throws {
+    if string.hasPrefix("did:") {
+      self = .did(try DID(string: string))
+    } else {
+      self = .handle(try Handle(string: string))
+    }
+  }
+}
+
+extension AtIdentifier {
+  // Strict per the dispatch rule above. Accepts `String` and `Substring` for both top-level use
+  // and as a callable component validator from `ATURI`.
+  static func isValid(_ s: some StringProtocol) -> Bool {
+    s.hasPrefix("did:") ? DID.isValid(s) : Handle.isValid(s)
+  }
+}

--- a/Sources/SwiftAtproto/StringFormats/DID.swift
+++ b/Sources/SwiftAtproto/StringFormats/DID.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+// Type for the lexicon `did` string format: Decentralized Identifier per W3C DID spec
+// (https://www.w3.org/TR/did-core/) with atproto restrictions per the AT Protocol DID spec
+// (https://atproto.com/specs/did).
+//
+// Wire-shape validation only: ASCII grammar `^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$`,
+// total length <= 2048 byte. No `%xx` decoding (verbatim wire preservation). No semantic
+// resolution (registered-method resolvers live elsewhere — e.g. `ATProtoCrypto`).
+public struct DID: LexiconStringFormat {
+  // The original wire string, kept verbatim.
+  public let rawValue: String
+
+  public init(string: String) throws {
+    guard DID.isValid(string) else {
+      throw LexiconStringFormatError.invalid(format: "did", value: string)
+    }
+    rawValue = string
+  }
+
+  // The DID method (the lowercase ASCII segment between the first two colons). For `did:plc:abc`
+  // this is `"plc"`; for `did:web:example.com` this is `"web"`. Always non-empty since `rawValue`
+  // was admitted by the parser.
+  public var method: String {
+    let afterPrefix = rawValue.dropFirst(4)  // drop "did:"
+    let end = afterPrefix.firstIndex(of: ":") ?? afterPrefix.endIndex
+    return String(afterPrefix[..<end])
+  }
+}
+
+extension DID {
+  // Strict per the grammar above. Accepts `String` and `Substring` so it can serve both as the
+  // top-level entry point and as a callable component validator from `ATURI` / `AtIdentifier`.
+  static func isValid(_ s: some StringProtocol) -> Bool {
+    let u = Array(s.utf8)
+    guard u.count <= 2048, u.starts(with: didPrefix) else { return false }
+    var i = 4
+    let methodStart = i
+    while i < u.count, isLowerAlpha(u[i]) { i += 1 }
+    guard i > methodStart, i < u.count, u[i] == colon else { return false }
+    i += 1
+    guard i < u.count else { return false }  // identifier needs >= 1 char
+    while i < u.count {
+      guard DID.isDIDIdentifierByte(u[i]) else { return false }
+      i += 1
+    }
+    let last = u[u.count - 1]
+    return last != colon && last != percent
+  }
+
+  private static func isDIDIdentifierByte(_ b: UInt8) -> Bool {
+    isAlphanumeric(b) || b == dot || b == underscore || b == colon || b == percent || b == hyphen
+  }
+}
+
+private let didPrefix = Array("did:".utf8)
+private let colon = UInt8(ascii: ":")
+private let percent = UInt8(ascii: "%")
+private let dot = UInt8(ascii: ".")
+private let hyphen = UInt8(ascii: "-")
+private let underscore = UInt8(ascii: "_")

--- a/Sources/SwiftAtproto/StringFormats/Handle.swift
+++ b/Sources/SwiftAtproto/StringFormats/Handle.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// Type for the lexicon `handle` string format: a DNS-like atproto handle per the AT Protocol
+// Handle spec (https://atproto.com/specs/handle).
+//
+// Wire-shape validation only: each label is 1–63 byte ASCII alnum / hyphen with no edge hyphen,
+// the trailing TLD starts with a letter, the whole string is dot-separated with at least two
+// labels, and total length is <= 253 byte. Punycode (`xn--…`) labels pass the same byte test —
+// IDN canonicalization is intentionally not performed.
+public struct Handle: LexiconStringFormat {
+  // The original wire string, kept verbatim.
+  public let rawValue: String
+
+  public init(string: String) throws {
+    guard Handle.isValid(string) else {
+      throw LexiconStringFormatError.invalid(format: "handle", value: string)
+    }
+    rawValue = string
+  }
+}
+
+extension Handle {
+  // Strict per the grammar above. Accepts `String` and `Substring` for both top-level use and
+  // as a callable component validator from `ATURI` / `AtIdentifier`.
+  static func isValid(_ s: some StringProtocol) -> Bool {
+    guard s.utf8.count <= 253 else { return false }
+    let labels = s.split(separator: ".", omittingEmptySubsequences: false)
+    guard labels.count >= 2 else { return false }
+    for (index, label) in labels.enumerated() {
+      let u = Array(label.utf8)
+      guard (1...63).contains(u.count) else { return false }
+      for byte in u where !(isAlphanumeric(byte) || byte == hyphen) { return false }
+      guard u.first != hyphen, u.last != hyphen else { return false }
+      if index == labels.count - 1, !isAlpha(u[0]) { return false }  // TLD starts with a letter
+    }
+    return true
+  }
+}
+
+private let hyphen = UInt8(ascii: "-")

--- a/Sources/SwiftAtproto/StringFormats/NSID.swift
+++ b/Sources/SwiftAtproto/StringFormats/NSID.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+// Type for the lexicon `nsid` string format: AT Protocol Namespaced Identifier per the AT Protocol
+// NSID spec (https://atproto.com/specs/nsid).
+//
+// Wire-shape validation only: a reverse-DNS authority followed by a name segment, with at least
+// three dot-separated segments. Each segment is 1–63 byte ASCII alnum / hyphen with no edge
+// hyphen; the first segment cannot start with a digit; the name (last segment) is alnum-only and
+// cannot start with a digit. Total length <= 317 byte.
+public struct NSID: LexiconStringFormat {
+  // The original wire string, kept verbatim.
+  public let rawValue: String
+
+  public init(string: String) throws {
+    guard NSID.isValid(string) else {
+      throw LexiconStringFormatError.invalid(format: "nsid", value: string)
+    }
+    rawValue = string
+  }
+
+  // The reverse-DNS authority portion: all segments except the last one, re-ordered into a
+  // forward domain. For `com.example.foo` this is `"example.com"`; for `org.4chan.lex.getThing`
+  // it is `"lex.4chan.org"`.
+  public var authority: String {
+    rawValue.split(separator: ".").dropLast().reversed().joined(separator: ".")
+  }
+
+  // The name segment (last dot-separated component). For `com.example.foo` this is `"foo"`.
+  public var name: String {
+    String(rawValue.split(separator: ".").last ?? "")
+  }
+}
+
+extension NSID {
+  // Strict per the grammar above. Accepts `String` and `Substring` for both top-level use and
+  // as a callable component validator from `ATURI`.
+  static func isValid(_ s: some StringProtocol) -> Bool {
+    let all = Array(s.utf8)
+    guard all.count <= 317 else { return false }
+    for byte in all where !(isAlphanumeric(byte) || byte == dot || byte == hyphen) { return false }
+    let segments = s.split(separator: ".", omittingEmptySubsequences: false)
+    guard segments.count >= 3 else { return false }
+    for segment in segments {
+      let u = Array(segment.utf8)
+      guard (1...63).contains(u.count) else { return false }
+      guard u.first != hyphen, u.last != hyphen else { return false }
+    }
+    if isDigit(Array(segments[0].utf8)[0]) { return false }
+    let name = Array(segments[segments.count - 1].utf8)
+    return !isDigit(name[0]) && !name.contains(hyphen)
+  }
+}
+
+private let dot = UInt8(ascii: ".")
+private let hyphen = UInt8(ascii: "-")

--- a/Sources/SwiftAtproto/StringFormats/RecordKey.swift
+++ b/Sources/SwiftAtproto/StringFormats/RecordKey.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+// Type for the lexicon `record-key` string format: the opaque trailing segment of an AT URI per
+// the AT Protocol Record Key spec (https://atproto.com/specs/record-key).
+//
+// Wire-shape validation only: 1–512 byte ASCII alnum / `_~.:-`, excluding the special forbidden
+// values `"."` and `".."`.
+public struct RecordKey: LexiconStringFormat {
+  // The original wire string, kept verbatim.
+  public let rawValue: String
+
+  public init(string: String) throws {
+    guard RecordKey.isValid(string) else {
+      throw LexiconStringFormatError.invalid(format: "record-key", value: string)
+    }
+    rawValue = string
+  }
+}
+
+extension RecordKey {
+  // Strict per the grammar above. Accepts `String` and `Substring` for both top-level use and
+  // as a callable component validator from `ATURI`.
+  static func isValid(_ s: some StringProtocol) -> Bool {
+    let u = Array(s.utf8)
+    guard (1...512).contains(u.count) else { return false }
+    for byte in u where !(isAlphanumeric(byte) || recordKeyPunct.contains(byte)) { return false }
+    return s != "." && s != ".."
+  }
+}
+
+private let recordKeyPunct = Set("_~.:-".utf8)

--- a/Sources/SwiftAtproto/StringFormats/TID.swift
+++ b/Sources/SwiftAtproto/StringFormats/TID.swift
@@ -42,7 +42,66 @@ extension TID {
   public var clockId: UInt16 {
     UInt16((decodeBase32Sortable(rawValue) ?? 0) & 0x3FF)
   }
+
+  // Generate a new TID with a monotonic guarantee. Same-millisecond calls receive an
+  // incrementing per-millisecond counter so consecutive TIDs never collide; clock skew
+  // (system clock going backward) is absorbed by taking `max(now, lastTimestamp)`. If `prev`
+  // is supplied and the freshly generated TID is not newer, the timestamp is bumped to
+  // `prev.timestamp + 1` for additional safety across generator instances.
+  //
+  // Wire-shape correctness is guaranteed by construction: the encoded base32-sortable form is
+  // always 13 characters from the allowed alphabet, so the validator inside `init(string:)`
+  // never throws here.
+  public static func next(prev: TID? = nil) -> TID {
+    let nowMs = UInt64(Date().timeIntervalSince1970 * 1_000)
+    let micros = tidClockState.advanceTimestamp(nowMs: nowMs)
+    return TID.next(prev: prev, now: micros, clockId: tidClockState.defaultClockId)
+  }
+
+  // Deterministic generator for tests. Bypasses the global clock + counter and uses caller-
+  // supplied `now` (microseconds since epoch) and `clockId` (0...1023). Still honors the
+  // `prev` bump rule. Caller is responsible for keeping `now` within the spec-defined 53-bit
+  // microsecond range — values exceeding the range may lose top bits when packed into the
+  // 64-bit encoded form.
+  static func next(prev: TID?, now: UInt64, clockId: UInt16) -> TID {
+    var timestamp = now
+    if let prev, timestamp <= prev.timestamp {
+      timestamp = prev.timestamp &+ 1
+    }
+    let value = (timestamp << 10) | UInt64(clockId & 0x3FF)
+    let raw = encodeBase32Sortable(value: value)
+    return try! TID(string: raw)
+  }
 }
+
+private final class TIDClockState: @unchecked Sendable {
+  private let lock = NSLock()
+  private var lastTimestamp: UInt64 = 0  // milliseconds
+  private var timestampCount: UInt32 = 0
+  // Spec-compliant 10-bit clockId range (0...1023). bluesky-social TypeScript narrowed this
+  // to 5 bits (0...31) when adopting a microsecond-counter design
+  // (https://github.com/bluesky-social/atproto/commit/5b0f826) and notes the collision
+  // tradeoff explicitly; we keep the full 10 bits per the AT Protocol TID spec for stronger
+  // collision resistance.
+  let defaultClockId: UInt16 = UInt16.random(in: 0..<1024)
+
+  func advanceTimestamp(nowMs: UInt64) -> UInt64 {
+    lock.lock()
+    defer { lock.unlock() }
+    let timeMs = max(nowMs, lastTimestamp)
+    if timeMs == lastTimestamp {
+      // `&+= 1` wraps after 2^32 same-ms calls; physically unreachable (would require ~4
+      // billion calls within a single millisecond) so the accepted limitation is left as-is.
+      timestampCount &+= 1
+    } else {
+      timestampCount = 0
+    }
+    lastTimestamp = timeMs
+    return timeMs * 1_000 + UInt64(timestampCount)
+  }
+}
+
+private let tidClockState = TIDClockState()
 
 // `[234567abcdefghij]` — first character of a TID (high bit of the timestamp is zero).
 private let tidFirstChars: Set<UInt8> = Set("234567abcdefghij".utf8)

--- a/Sources/SwiftAtproto/StringFormats/TID.swift
+++ b/Sources/SwiftAtproto/StringFormats/TID.swift
@@ -29,6 +29,19 @@ extension TID {
     for i in 1..<13 where !tidRestChars.contains(u[i]) { return false }
     return true
   }
+
+  // Microsecond timestamp since the UNIX epoch. The top 53 bits of the 64-bit encoded value
+  // per the TID spec. Returns 0 if `rawValue` cannot be decoded (unreachable for instances
+  // produced by `init(string:)`, since the parser guarantees a valid base32-sortable form).
+  public var timestamp: UInt64 {
+    (decodeBase32Sortable(rawValue) ?? 0) >> 10
+  }
+
+  // 10-bit clock identifier (0...1023) per the TID spec. Returns 0 on a decode failure
+  // (unreachable in practice — see `timestamp`).
+  public var clockId: UInt16 {
+    UInt16((decodeBase32Sortable(rawValue) ?? 0) & 0x3FF)
+  }
 }
 
 // `[234567abcdefghij]` — first character of a TID (high bit of the timestamp is zero).

--- a/Sources/SwiftAtproto/StringFormats/TID.swift
+++ b/Sources/SwiftAtproto/StringFormats/TID.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+// Type for the lexicon `tid` string format: AT Protocol Timestamp Identifier per the AT Protocol
+// TID spec (https://atproto.com/specs/tid).
+//
+// Wire-shape validation only: a 13-character base32-sortable token. The first character is from
+// `[234567abcdefghij]` (the high bit of the encoded timestamp is always zero in the foreseeable
+// future, restricting the leading character to the lower 16 of the 32-char alphabet). The
+// remaining 12 characters are from the full base32-sortable alphabet
+// `[234567abcdefghijklmnopqrstuvwxyz]`.
+public struct TID: LexiconStringFormat {
+  // The original wire string, kept verbatim.
+  public let rawValue: String
+
+  public init(string: String) throws {
+    guard TID.isValid(string) else {
+      throw LexiconStringFormatError.invalid(format: "tid", value: string)
+    }
+    rawValue = string
+  }
+}
+
+extension TID {
+  // Strict per the grammar above. Accepts `String` and `Substring`.
+  static func isValid(_ s: some StringProtocol) -> Bool {
+    let u = Array(s.utf8)
+    guard u.count == 13 else { return false }
+    guard tidFirstChars.contains(u[0]) else { return false }
+    for i in 1..<13 where !tidRestChars.contains(u[i]) { return false }
+    return true
+  }
+}
+
+// `[234567abcdefghij]` — first character of a TID (high bit of the timestamp is zero).
+private let tidFirstChars: Set<UInt8> = Set("234567abcdefghij".utf8)
+// `[234567abcdefghijklmnopqrstuvwxyz]` — full base32-sortable alphabet for subsequent chars.
+private let tidRestChars: Set<UInt8> = Set("234567abcdefghijklmnopqrstuvwxyz".utf8)

--- a/Sources/SwiftAtproto/StringFormats/_ASCII.swift
+++ b/Sources/SwiftAtproto/StringFormats/_ASCII.swift
@@ -1,0 +1,9 @@
+// Internal ASCII byte-level helpers shared across LexiconStringFormat validators. Only generic
+// byte tests live here; format-specific punctuation sets and predicates stay with their owning
+// format file.
+
+func isDigit(_ b: UInt8) -> Bool { (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(b) }
+func isLowerAlpha(_ b: UInt8) -> Bool { (UInt8(ascii: "a")...UInt8(ascii: "z")).contains(b) }
+func isUpperAlpha(_ b: UInt8) -> Bool { (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(b) }
+func isAlpha(_ b: UInt8) -> Bool { isLowerAlpha(b) || isUpperAlpha(b) }
+func isAlphanumeric(_ b: UInt8) -> Bool { isAlpha(b) || isDigit(b) }

--- a/Sources/SwiftAtproto/StringFormats/_Base32Sortable.swift
+++ b/Sources/SwiftAtproto/StringFormats/_Base32Sortable.swift
@@ -1,0 +1,40 @@
+// Internal base32-sortable encoder/decoder for fixed 13-character TID encoding per the AT
+// Protocol TID spec (https://atproto.com/specs/tid). The alphabet
+// `234567abcdefghijklmnopqrstuvwxyz` preserves lexicographic order for chronological sort.
+//
+// Encoding packs a 64-bit value MSB-first into 13 base32 characters (5 bit × 13 = 65 bit; the
+// top bit is always zero per spec, so it is discarded). Decoding reverses the same mapping.
+
+private let base32SortableAlphabet: [Character] = Array("234567abcdefghijklmnopqrstuvwxyz")
+private let base32SortableIndex: [Character: UInt64] = {
+  var dict: [Character: UInt64] = [:]
+  for (i, c) in base32SortableAlphabet.enumerated() {
+    dict[c] = UInt64(i)
+  }
+  return dict
+}()
+
+// Encode the bottom 65 bits of `value` as a 13-char base32-sortable string. The leading char
+// reflects bits 60..64; the trailing char reflects bits 0..4.
+func encodeBase32Sortable(value: UInt64) -> String {
+  var chars: [Character] = []
+  chars.reserveCapacity(13)
+  for i in 0..<13 {
+    let shift = 5 * (12 - i)
+    let bits = (value >> shift) & 0x1F
+    chars.append(base32SortableAlphabet[Int(bits)])
+  }
+  return String(chars)
+}
+
+// Decode a 13-char base32-sortable string back into its 65-bit value. Returns nil for any
+// length other than 13 or for any character outside the alphabet.
+func decodeBase32Sortable(_ s: some StringProtocol) -> UInt64? {
+  guard s.count == 13 else { return nil }
+  var value: UInt64 = 0
+  for c in s {
+    guard let bits = base32SortableIndex[c] else { return nil }
+    value = (value << 5) | bits
+  }
+  return value
+}

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -565,6 +565,12 @@ struct StringFormat: Codable, RawRepresentable {
     case "at-uri": "ATURI"
     case "language": "Language"
     case "uri": "URI"
+    case "did": "DID"
+    case "handle": "Handle"
+    case "nsid": "NSID"
+    case "tid": "TID"
+    case "record-key": "RecordKey"
+    case "at-identifier": "AtIdentifier"
     default: nil
     }
   }

--- a/Tests/SwiftAtprotoTests/AtIdentifierInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/AtIdentifierInteropTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Wire-shape vectors for the lexicon `at-identifier` string format. Dispatches to DID or Handle
+// based on the `did:` prefix.
+struct AtIdentifierInteropTests {
+  @Test func didPrefixDispatchesToDIDCase() throws {
+    let id = try AtIdentifier(string: "did:plc:7iza6de2dwap2sbkpav7c6c6")
+    switch id {
+    case .did(let d):
+      #expect(d.rawValue == "did:plc:7iza6de2dwap2sbkpav7c6c6")
+    case .handle:
+      Issue.record("expected .did variant")
+    }
+  }
+
+  @Test func nonDidPrefixDispatchesToHandleCase() throws {
+    let id = try AtIdentifier(string: "alice.example.com")
+    switch id {
+    case .did:
+      Issue.record("expected .handle variant")
+    case .handle(let h):
+      #expect(h.rawValue == "alice.example.com")
+    }
+  }
+
+  @Test func rawValuePreservesWireForDID() throws {
+    let input = "did:web:example.com:path"
+    let id = try AtIdentifier(string: input)
+    #expect(id.rawValue == input)
+  }
+
+  @Test func rawValuePreservesWireForHandle() throws {
+    let input = "Alice.Example.Com"
+    let id = try AtIdentifier(string: input)
+    #expect(id.rawValue == input)
+  }
+
+  static let invalidDIDs: [String] = [
+    "did:", "did:METHOD:val", "did:method:", "did:method:val%",
+  ]
+
+  @Test(arguments: invalidDIDs)
+  func invalidDIDThrows(_ input: String) {
+    #expect(throws: (any Error).self) { try AtIdentifier(string: input) }
+  }
+
+  static let invalidHandles: [String] = [
+    "", "alice", "alice.0", "-alice.test", "alice_test",
+  ]
+
+  @Test(arguments: invalidHandles)
+  func invalidHandleThrows(_ input: String) {
+    #expect(throws: (any Error).self) { try AtIdentifier(string: input) }
+  }
+
+  @Test func equalityIsByCaseAndRawValue() throws {
+    let a = try AtIdentifier(string: "did:plc:abc")
+    let b = try AtIdentifier(string: "did:plc:abc")
+    let c = try AtIdentifier(string: "alice.test")
+    #expect(a == b)
+    #expect(a != c)
+  }
+
+  @Test func usableInSetDeduplicatesEqualValues() throws {
+    let s: Set<AtIdentifier> = [
+      try AtIdentifier(string: "did:plc:abc"),
+      try AtIdentifier(string: "alice.test"),
+      try AtIdentifier(string: "did:plc:abc"),
+    ]
+    #expect(s.count == 2)
+  }
+}

--- a/Tests/SwiftAtprotoTests/DIDInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/DIDInteropTests.swift
@@ -31,4 +31,43 @@ struct DIDInteropTests {
     let did = try DID(string: input)
     #expect(did.rawValue == input)
   }
+
+  static let invalidDIDs: [String] = [
+    // Empty / scheme-only / method-only.
+    "", "did:", "did::", "did:method", "did:method:",
+    // Wrong-case scheme or method (grammar is lowercase-only).
+    "DID:method:val", "did:METHOD:val", "did:Method:val",
+    // Method must be `[a-z]+` — no digits, hyphens, dots, or underscores.
+    "did:m3thod:val", "did:1method:val", "did:method-x:val", "did:method.x:val",
+    "did:method_x:val",
+    // Identifier must not end with `:` or `%`.
+    "did:method:val:", "did:method:val%",
+    // Whitespace and control characters anywhere break wire-shape.
+    "did:method:val ", "did:method:val\t", "did:method:val\n", "did:method:val\u{0001}",
+    "did:method:val\u{007F}", " did:method:val",
+    // Disallowed identifier bytes.
+    "did:method:val/path", "did:method:val[x]", "did:method:val#frag", "did:method:val?q",
+    // Missing prefix or out-of-order.
+    "didmethod:val", "1did:method:val", ":did:method:val",
+  ]
+
+  @Test(arguments: invalidDIDs)
+  func invalidThrows(_ input: String) {
+    #expect(throws: (any Error).self) { try DID(string: input) }
+  }
+
+  @Test func acceptsExactly2048ByteInput() throws {
+    // "did:m:" (6 byte) + 2042-byte identifier = 2048 byte total (cap).
+    let identifier = String(repeating: "a", count: 2048 - 6)
+    let input = "did:m:" + identifier
+    let did = try DID(string: input)
+    #expect(did.rawValue.utf8.count == 2048)
+  }
+
+  @Test func rejectsOver2048ByteInput() {
+    let identifier = String(repeating: "a", count: 2048 - 5)
+    let input = "did:m:" + identifier
+    #expect(input.utf8.count == 2049)
+    #expect(throws: (any Error).self) { try DID(string: input) }
+  }
 }

--- a/Tests/SwiftAtprotoTests/DIDInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/DIDInteropTests.swift
@@ -70,4 +70,33 @@ struct DIDInteropTests {
     #expect(input.utf8.count == 2049)
     #expect(throws: (any Error).self) { try DID(string: input) }
   }
+
+  // MARK: method accessor
+
+  @Test func methodReturnsPlcForPlcDid() throws {
+    let did = try DID(string: "did:plc:7iza6de2dwap2sbkpav7c6c6")
+    #expect(did.method == "plc")
+  }
+
+  @Test func methodReturnsWebForWebDid() throws {
+    let did = try DID(string: "did:web:example.com")
+    #expect(did.method == "web")
+  }
+
+  @Test func methodPreservesLongMethodName() throws {
+    let did = try DID(string: "did:longmethodname:identifier")
+    #expect(did.method == "longmethodname")
+  }
+
+  @Test func methodSurvivesIdentifierWithColons() throws {
+    // Identifier may contain `:` (`did:web:example.com:path`); method is still the segment
+    // between the first two colons.
+    let did = try DID(string: "did:web:example.com:user:alice")
+    #expect(did.method == "web")
+  }
+
+  @Test func methodForSingleCharMethod() throws {
+    let did = try DID(string: "did:m:v")
+    #expect(did.method == "m")
+  }
 }

--- a/Tests/SwiftAtprotoTests/DIDInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/DIDInteropTests.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Wire-shape vectors for the lexicon `did` string format. The `rawValue` is preserved verbatim.
+struct DIDInteropTests {
+  static let validDIDs: [String] = [
+    // PLC method (typical atproto identity).
+    "did:plc:7iza6de2dwap2sbkpav7c6c6",
+    "did:plc:abc",
+    // Web method (server-anchored identity).
+    "did:web:example.com",
+    "did:web:example.com:path",
+    "did:web:example.com:user:alice",
+    // Minimal form: single-character method, single-character identifier.
+    "did:m:v",
+    // Identifier may contain ALPHA / DIGIT / "." / "_" / ":" / "%" / "-".
+    "did:method:abc.def",
+    "did:method:abc-def",
+    "did:method:abc_def",
+    "did:method:abc:def:ghi",
+    "did:method:abc123",
+    "did:method:%41%42",
+    // Long method name (lowercase ASCII only).
+    "did:longmethodname:identifier",
+  ]
+
+  @Test(arguments: validDIDs)
+  func validParses(_ input: String) throws {
+    let did = try DID(string: input)
+    #expect(did.rawValue == input)
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringAtIdentifierTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringAtIdentifierTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringAtIdentifierTests {
+  static let didWire = "did:plc:7iza6de2dwap2sbkpav7c6c6"
+  static let handleWire = "alice.example.com"
+
+  @Test func decodeDIDPreservesWireAndTypedDispatchesToDIDCase() throws {
+    let data = Data("\"\(Self.didWire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<AtIdentifier>.self, from: data)
+    #expect(value.rawValue == Self.didWire)
+    if case .did(let d) = value.typed {
+      #expect(d.rawValue == Self.didWire)
+    } else {
+      Issue.record("expected .did variant")
+    }
+  }
+
+  @Test func decodeHandlePreservesWireAndTypedDispatchesToHandleCase() throws {
+    let data = Data("\"\(Self.handleWire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<AtIdentifier>.self, from: data)
+    #expect(value.rawValue == Self.handleWire)
+    if case .handle(let h) = value.typed {
+      #expect(h.rawValue == Self.handleWire)
+    } else {
+      Issue.record("expected .handle variant")
+    }
+  }
+
+  @Test func invalidAtIdentifierDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\"did:invalid:\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<AtIdentifier>.self, from: data)
+    #expect(value.rawValue == "did:invalid:")
+    #expect(value.typed == nil)
+  }
+
+  @Test func encodeEmitsWireStringForDID() throws {
+    let value = FormatString<AtIdentifier>(rawValue: Self.didWire)
+    let data = try JSONEncoder().encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.didWire)\"")
+  }
+
+  @Test func initFromAtIdentifierPreservesWireString() throws {
+    let id = try AtIdentifier(string: Self.handleWire)
+    let value = FormatString(id)
+    #expect(value.rawValue == Self.handleWire)
+    #expect(value.typed?.rawValue == Self.handleWire)
+  }
+
+  @Test func decodesAtIdentifierFieldInRecord() throws {
+    struct Record: Codable {
+      var actor: FormatString<AtIdentifier>
+    }
+    let json = Data("{\"actor\":\"\(Self.handleWire)\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.actor.rawValue == Self.handleWire)
+    #expect(record.actor.typed != nil)
+  }
+
+  @Test func decodesAtIdentifierArrayFieldInRecord() throws {
+    struct Record: Codable {
+      var actors: [FormatString<AtIdentifier>]
+    }
+    let json = Data("{\"actors\":[\"did:plc:abc\",\"alice.test\",\"bob.example.com\"]}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.actors.count == 3)
+    #expect(record.actors.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<AtIdentifier>(rawValue: Self.didWire)
+    #expect(value.description == Self.didWire)
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringDIDTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringDIDTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringDIDTests {
+  static let wire = "did:plc:7iza6de2dwap2sbkpav7c6c6"
+
+  @Test func decodePreservesWireStringAndTypedYieldsDID() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<DID>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+    #expect(value.typed?.method == "plc")
+  }
+
+  @Test func invalidDIDDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\"not a did\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<DID>.self, from: data)
+    #expect(value.rawValue == "not a did")
+    #expect(value.typed == nil)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<DID>(rawValue: Self.wire)
+    let data = try JSONEncoder().encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+
+  @Test func initFromDIDPreservesWireString() throws {
+    let did = try DID(string: Self.wire)
+    let value = FormatString(did)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func decodesDIDFieldInRecord() throws {
+    struct Record: Codable {
+      var owner: FormatString<DID>
+    }
+    let json = Data("{\"owner\":\"\(Self.wire)\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.owner.rawValue == Self.wire)
+    #expect(record.owner.typed?.method == "plc")
+  }
+
+  @Test func decodesDIDArrayFieldInRecord() throws {
+    struct Record: Codable {
+      var owners: [FormatString<DID>]
+    }
+    let json = Data("{\"owners\":[\"did:plc:abc\",\"did:web:example.com\"]}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.owners.count == 2)
+    #expect(record.owners.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func decodesOversizedDIDWithNilTyped() throws {
+    // Over the 2048 byte cap → strict parser rejects, lenient decode preserves rawValue.
+    let identifier = String(repeating: "a", count: 2048 - 5)  // "did:m:" + body → 2049 byte
+    let wire = "did:m:" + identifier
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<DID>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<DID>(rawValue: Self.wire)
+    #expect(value.description == Self.wire)
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringHandleTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringHandleTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringHandleTests {
+  static let wire = "alice.example.com"
+
+  @Test func decodePreservesWireStringAndTypedYieldsHandle() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Handle>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func invalidHandleDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\"not a handle\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Handle>.self, from: data)
+    #expect(value.rawValue == "not a handle")
+    #expect(value.typed == nil)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<Handle>(rawValue: Self.wire)
+    let data = try JSONEncoder().encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+
+  @Test func initFromHandlePreservesWireString() throws {
+    let handle = try Handle(string: Self.wire)
+    let value = FormatString(handle)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func decodesHandleFieldInRecord() throws {
+    struct Record: Codable {
+      var actor: FormatString<Handle>
+    }
+    let json = Data("{\"actor\":\"\(Self.wire)\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.actor.rawValue == Self.wire)
+    #expect(record.actor.typed != nil)
+  }
+
+  @Test func decodesHandleArrayFieldInRecord() throws {
+    struct Record: Codable {
+      var handles: [FormatString<Handle>]
+    }
+    let json = Data("{\"handles\":[\"alice.example.com\",\"bob.example.org\"]}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.handles.count == 2)
+    #expect(record.handles.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func decodesOversizedHandleWithNilTyped() throws {
+    // Over the 253 byte cap → strict parser rejects, lenient decode preserves rawValue.
+    let label63 = String(repeating: "a", count: 63)
+    let label62 = String(repeating: "a", count: 62)
+    let wire = "\(label63).\(label63).\(label63).\(label62)"  // 254 byte
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Handle>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<Handle>(rawValue: Self.wire)
+    #expect(value.description == Self.wire)
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringNSIDTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringNSIDTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringNSIDTests {
+  static let wire = "com.example.foo"
+
+  @Test func decodePreservesWireStringAndTypedYieldsNSID() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<NSID>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+    #expect(value.typed?.authority == "example.com")
+    #expect(value.typed?.name == "foo")
+  }
+
+  @Test func invalidNSIDDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\"not.an.0nsid\"".utf8)  // last segment starts with digit
+    let value = try JSONDecoder().decode(FormatString<NSID>.self, from: data)
+    #expect(value.rawValue == "not.an.0nsid")
+    #expect(value.typed == nil)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<NSID>(rawValue: Self.wire)
+    let data = try JSONEncoder().encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+
+  @Test func initFromNSIDPreservesWireString() throws {
+    let nsid = try NSID(string: Self.wire)
+    let value = FormatString(nsid)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func decodesNSIDFieldInRecord() throws {
+    struct Record: Codable {
+      var collection: FormatString<NSID>
+    }
+    let json = Data("{\"collection\":\"\(Self.wire)\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.collection.rawValue == Self.wire)
+    #expect(record.collection.typed?.name == "foo")
+  }
+
+  @Test func decodesNSIDArrayFieldInRecord() throws {
+    struct Record: Codable {
+      var collections: [FormatString<NSID>]
+    }
+    let json = Data("{\"collections\":[\"com.example.feed.post\",\"net.example.repo.createRecord\"]}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.collections.count == 2)
+    #expect(record.collections.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func decodesOversizedNSIDWithNilTyped() throws {
+    // Over the 317 byte cap → strict parser rejects, lenient decode preserves rawValue.
+    let label63 = String(repeating: "a", count: 63)
+    let label62 = String(repeating: "a", count: 62)
+    let wire = "\(label63).\(label63).\(label63).\(label63).\(label62)"  // 318 byte
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<NSID>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<NSID>(rawValue: Self.wire)
+    #expect(value.description == Self.wire)
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringRecordKeyTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringRecordKeyTests.swift
@@ -1,0 +1,69 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringRecordKeyTests {
+  static let wire = "3jzfcijpj2z2a"
+
+  @Test func decodePreservesWireStringAndTypedYieldsRecordKey() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<RecordKey>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func invalidRecordKeyDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\".\"".utf8)  // forbidden value
+    let value = try JSONDecoder().decode(FormatString<RecordKey>.self, from: data)
+    #expect(value.rawValue == ".")
+    #expect(value.typed == nil)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<RecordKey>(rawValue: Self.wire)
+    let data = try JSONEncoder().encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+
+  @Test func initFromRecordKeyPreservesWireString() throws {
+    let rkey = try RecordKey(string: Self.wire)
+    let value = FormatString(rkey)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func decodesRecordKeyFieldInRecord() throws {
+    struct Record: Codable {
+      var rkey: FormatString<RecordKey>
+    }
+    let json = Data("{\"rkey\":\"\(Self.wire)\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.rkey.rawValue == Self.wire)
+    #expect(record.rkey.typed != nil)
+  }
+
+  @Test func decodesRecordKeyArrayFieldInRecord() throws {
+    struct Record: Codable {
+      var rkeys: [FormatString<RecordKey>]
+    }
+    let json = Data("{\"rkeys\":[\"self\",\"3jzfcijpj2z2a\",\"abc-def\"]}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.rkeys.count == 3)
+    #expect(record.rkeys.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func decodesOversizedRecordKeyWithNilTyped() throws {
+    // Over the 512 byte cap → strict parser rejects, lenient decode preserves rawValue.
+    let wire = String(repeating: "a", count: 513)
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<RecordKey>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<RecordKey>(rawValue: Self.wire)
+    #expect(value.description == Self.wire)
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringTIDTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringTIDTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringTIDTests {
+  static let wire = "3jzfcijpj2z2a"
+
+  @Test func decodePreservesWireStringAndTypedYieldsTID() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<TID>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func invalidTIDDecodesLenientlyWithNilTyped() throws {
+    let data = Data("\"not-a-tid\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<TID>.self, from: data)
+    #expect(value.rawValue == "not-a-tid")
+    #expect(value.typed == nil)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<TID>(rawValue: Self.wire)
+    let data = try JSONEncoder().encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+
+  @Test func initFromTIDPreservesWireString() throws {
+    let tid = try TID(string: Self.wire)
+    let value = FormatString(tid)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+  }
+
+  @Test func decodesTIDFieldInRecord() throws {
+    struct Record: Codable {
+      var ts: FormatString<TID>
+    }
+    let json = Data("{\"ts\":\"\(Self.wire)\"}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.ts.rawValue == Self.wire)
+    #expect(record.ts.typed != nil)
+  }
+
+  @Test func decodesTIDArrayFieldInRecord() throws {
+    struct Record: Codable {
+      var timestamps: [FormatString<TID>]
+    }
+    let json = Data("{\"timestamps\":[\"3jzfcijpj2z2a\",\"3kbgyjzqfeq2e\"]}".utf8)
+    let record = try JSONDecoder().decode(Record.self, from: json)
+    #expect(record.timestamps.count == 2)
+    #expect(record.timestamps.allSatisfy { $0.typed != nil })
+  }
+
+  @Test func descriptionIsRawValue() {
+    let value = FormatString<TID>(rawValue: Self.wire)
+    #expect(value.description == Self.wire)
+  }
+
+  @Test func generatorOutputRoundTripsThroughFormatString() throws {
+    let tid = TID.next()
+    let value = FormatString(tid)
+    let data = try JSONEncoder().encode(value)
+    let decoded = try JSONDecoder().decode(FormatString<TID>.self, from: data)
+    #expect(decoded.rawValue == tid.rawValue)
+    #expect(decoded.typed?.rawValue == tid.rawValue)
+    #expect(decoded.typed?.timestamp == tid.timestamp)
+    #expect(decoded.typed?.clockId == tid.clockId)
+  }
+}

--- a/Tests/SwiftAtprotoTests/HandleInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/HandleInteropTests.swift
@@ -32,4 +32,56 @@ struct HandleInteropTests {
     let handle = try Handle(string: input)
     #expect(handle.rawValue == input)
   }
+
+  static let invalidHandles: [String] = [
+    // Empty / single label.
+    "", "example", "john",
+    // Dotless / leading dot / trailing dot / empty intermediate label.
+    "a", ".example.com", "example.com.", "a..b",
+    // TLD must start with a letter.
+    "a.0", "a.b.0xy",
+    // Label edge hyphen.
+    "-foo.example.com", "foo-.example.com",
+    // Disallowed characters in labels.
+    "a@b.example.com", "a_b.example.com", "alice.example.com_test", "alice test.example.com",
+    "alice..example.com",
+    // Whitespace and control characters.
+    "alice.example.com ", " alice.example.com", "alice.example.com\t", "alice.example.com\n",
+  ]
+
+  @Test(arguments: invalidHandles)
+  func invalidThrows(_ input: String) {
+    #expect(throws: (any Error).self) { try Handle(string: input) }
+  }
+
+  @Test func acceptsLabelAtSixtyThreeByteBoundary() throws {
+    // Each label may be up to 63 byte. Build a 63 + 1 + 63 = 127-byte handle.
+    let label = String(repeating: "a", count: 63)
+    let input = "\(label).\(label)"
+    let handle = try Handle(string: input)
+    #expect(handle.rawValue.utf8.count == 127)
+  }
+
+  @Test func rejectsLabelOverSixtyThreeBytes() {
+    let label = String(repeating: "a", count: 64)
+    let input = "\(label).example.com"
+    #expect(throws: (any Error).self) { try Handle(string: input) }
+  }
+
+  @Test func acceptsExactly253ByteInput() throws {
+    // 63 + 1 + 63 + 1 + 63 + 1 + 61 = 253 byte. TLD `aaa…` starts with a letter.
+    let label63 = String(repeating: "a", count: 63)
+    let label61 = String(repeating: "a", count: 61)
+    let input = "\(label63).\(label63).\(label63).\(label61)"
+    let handle = try Handle(string: input)
+    #expect(handle.rawValue.utf8.count == 253)
+  }
+
+  @Test func rejectsOver253ByteInput() {
+    let label63 = String(repeating: "a", count: 63)
+    let label62 = String(repeating: "a", count: 62)
+    let input = "\(label63).\(label63).\(label63).\(label62)"
+    #expect(input.utf8.count == 254)
+    #expect(throws: (any Error).self) { try Handle(string: input) }
+  }
 }

--- a/Tests/SwiftAtprotoTests/HandleInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/HandleInteropTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Wire-shape vectors for the lexicon `handle` string format.
+struct HandleInteropTests {
+  static let validHandles: [String] = [
+    // Typical user handle form.
+    "john.example.com",
+    "jay.example.org",
+    "alice.test",
+    // Two-label minimum.
+    "a.co",
+    "example.com",
+    // Punycode label (xn-- prefix) passes the same byte test.
+    "xn--ls8h.test",
+    // Intra-label hyphen is allowed (no edge hyphen).
+    "with-hyphen.example.com",
+    // Label may start with a digit; only the TLD is required to start with a letter.
+    "1abc.example.com",
+    "abc123.example.com",
+    "9abc.example.com",
+    // Many labels.
+    "a.b.c.d.example.com",
+    // Mixed case is preserved verbatim.
+    "Alice.Example.Com",
+  ]
+
+  @Test(arguments: validHandles)
+  func validParses(_ input: String) throws {
+    let handle = try Handle(string: input)
+    #expect(handle.rawValue == input)
+  }
+}

--- a/Tests/SwiftAtprotoTests/NSIDInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/NSIDInteropTests.swift
@@ -78,4 +78,38 @@ struct NSIDInteropTests {
     let input = "\(label64).example.foo"
     #expect(throws: (any Error).self) { try NSID(string: input) }
   }
+
+  // MARK: authority and name accessors
+
+  @Test func authorityReversesAllSegmentsExceptName() throws {
+    // com.example.foo → authority "example.com", name "foo".
+    let nsid = try NSID(string: "com.example.foo")
+    #expect(nsid.authority == "example.com")
+    #expect(nsid.name == "foo")
+  }
+
+  @Test func authorityHandlesFourLabelAuthority() throws {
+    // org.4chan.lex.getThing → authority "lex.4chan.org", name "getThing".
+    let nsid = try NSID(string: "org.4chan.lex.getThing")
+    #expect(nsid.authority == "lex.4chan.org")
+    #expect(nsid.name == "getThing")
+  }
+
+  @Test func authorityForMinimumThreeSegments() throws {
+    // a.b.c → authority "b.a", name "c".
+    let nsid = try NSID(string: "a.b.c")
+    #expect(nsid.authority == "b.a")
+    #expect(nsid.name == "c")
+  }
+
+  @Test func authorityForTypicalLexiconName() throws {
+    let nsid = try NSID(string: "com.example.feed.post")
+    #expect(nsid.authority == "feed.example.com")
+    #expect(nsid.name == "post")
+  }
+
+  @Test func namePreservesCamelCase() throws {
+    let nsid = try NSID(string: "com.example.fooBar")
+    #expect(nsid.name == "fooBar")
+  }
 }

--- a/Tests/SwiftAtprotoTests/NSIDInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/NSIDInteropTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Wire-shape vectors for the lexicon `nsid` string format.
+struct NSIDInteropTests {
+  static let validNSIDs: [String] = [
+    // Typical lexicon NSIDs.
+    "com.example.foo",
+    "com.example.feed.post",
+    "org.example.actor.profile",
+    "net.example.repo.createRecord",
+    // Authority segments may contain digits or start with a digit (but the first segment may
+    // not start with a digit; subsequent ones can).
+    "a.0.c",
+    "org.4chan.lex.getThing",
+    // Name segment is camelCase friendly (alpha + digit, no hyphen).
+    "com.example.fooBar",
+    "com.example.foo123",
+    // Minimum 3 segments.
+    "a.b.c",
+    // Hyphen allowed in non-name segments.
+    "co-op.example.foo",
+    "com.example-org.foo",
+  ]
+
+  @Test(arguments: validNSIDs)
+  func validParses(_ input: String) throws {
+    let nsid = try NSID(string: input)
+    #expect(nsid.rawValue == input)
+  }
+
+  static let invalidNSIDs: [String] = [
+    // Empty / too few segments.
+    "", "com", "com.example",
+    // First segment must not start with a digit.
+    "0two.example.foo",
+    // Name must not start with a digit or contain a hyphen.
+    "com.example.0foo", "com.example.foo-bar", "a-0.b-1.c-3",
+    // Edge hyphen on any segment.
+    "-com.example.foo", "com-.example.foo", "com.example.-foo",
+    // Empty segment (consecutive dots, leading or trailing dot).
+    "com..example.foo", ".com.example.foo", "com.example.foo.",
+    // Disallowed characters.
+    "com.example.foo_bar", "com.example.foo bar", "com.example.foo@bar",
+    "com.example.foo!bar",
+    // Whitespace / control.
+    "com.example.foo\t", "com.example.foo\n", " com.example.foo",
+    // Uppercase letters not allowed in name segment? bluesky-social allows both — name may be
+    // camelCase. We *do* accept these, so they're not in this invalid list.
+  ]
+
+  @Test(arguments: invalidNSIDs)
+  func invalidThrows(_ input: String) {
+    #expect(throws: (any Error).self) { try NSID(string: input) }
+  }
+
+  @Test func acceptsExactly317ByteInput() throws {
+    // 63 + 1 + 63 + 1 + 63 + 1 + 63 + 1 + 61 = 317 byte total (4 authority labels + name).
+    let label63 = String(repeating: "a", count: 63)
+    let label61 = String(repeating: "a", count: 61)
+    let input = "\(label63).\(label63).\(label63).\(label63).\(label61)"
+    let nsid = try NSID(string: input)
+    #expect(nsid.rawValue.utf8.count == 317)
+  }
+
+  @Test func rejectsOver317ByteInput() {
+    let label63 = String(repeating: "a", count: 63)
+    let label62 = String(repeating: "a", count: 62)
+    let input = "\(label63).\(label63).\(label63).\(label63).\(label62)"
+    #expect(input.utf8.count == 318)
+    #expect(throws: (any Error).self) { try NSID(string: input) }
+  }
+
+  @Test func rejectsLabelOverSixtyThreeBytes() {
+    let label64 = String(repeating: "a", count: 64)
+    let input = "\(label64).example.foo"
+    #expect(throws: (any Error).self) { try NSID(string: input) }
+  }
+}

--- a/Tests/SwiftAtprotoTests/RecordKeyInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/RecordKeyInteropTests.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Wire-shape vectors for the lexicon `record-key` string format.
+struct RecordKeyInteropTests {
+  static let validRecordKeys: [String] = [
+    // Common forms.
+    "3jzfcijpj2z2a",
+    "self",
+    "abc",
+    "a",
+    // Allowed punctuation (`_~.:-`).
+    "abc-def",
+    "abc_def",
+    "abc.def",
+    "abc:def",
+    "abc~def",
+    // Mixed case and digits.
+    "ABC123",
+    "a1b2c3",
+    // Multiple dots are allowed as long as the whole string is not exactly `.` or `..`.
+    "...",
+    "....foo",
+    "foo.bar.baz",
+  ]
+
+  @Test(arguments: validRecordKeys)
+  func validParses(_ input: String) throws {
+    let key = try RecordKey(string: input)
+    #expect(key.rawValue == input)
+  }
+
+  static let invalidRecordKeys: [String] = [
+    // Empty.
+    "",
+    // Special forbidden values.
+    ".", "..",
+    // Disallowed characters (anything outside alnum + `_~.:-`).
+    "abc def", "abc/def", "abc@def", "abc#def", "abc(def", "abc%def", "abc+def", "abc=def",
+    "abc,def", "abc;def", "abc?def", "abc!def", "abc*def", "abc<def", "abc>def", "abc[def",
+    "abc'def", "abc\"def", "abc\\def",
+    // Whitespace / control characters.
+    "abc\u{0001}", "abc\t", "abc\n", " abc",
+  ]
+
+  @Test(arguments: invalidRecordKeys)
+  func invalidThrows(_ input: String) {
+    #expect(throws: (any Error).self) { try RecordKey(string: input) }
+  }
+
+  @Test func acceptsExactly512ByteInput() throws {
+    let input = String(repeating: "a", count: 512)
+    let key = try RecordKey(string: input)
+    #expect(key.rawValue.utf8.count == 512)
+  }
+
+  @Test func rejectsOver512ByteInput() {
+    let input = String(repeating: "a", count: 513)
+    #expect(throws: (any Error).self) { try RecordKey(string: input) }
+  }
+}

--- a/Tests/SwiftAtprotoTests/TIDGeneratorTests.swift
+++ b/Tests/SwiftAtprotoTests/TIDGeneratorTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Behavior tests for `TID.next()` (the public default-clock generator) and the internal
+// dependency-injected variant. Parser/accessor concerns live in `TIDInteropTests`.
+struct TIDGeneratorTests {
+  @Test func nextProducesValidTID() {
+    let tid = TID.next()
+    #expect(TID.isValid(tid.rawValue))
+    #expect(tid.rawValue.utf8.count == 13)
+  }
+
+  @Test func nextProducesValidTIDsRepeatedly() {
+    for _ in 0..<100 {
+      let tid = TID.next()
+      #expect(TID.isValid(tid.rawValue))
+    }
+  }
+
+  @Test func nextTimestampIsApproximatelyNow() {
+    let nowMicros = UInt64(Date().timeIntervalSince1970 * 1_000_000)
+    let tid = TID.next()
+    // The generator quantizes to millisecond resolution then advances a sub-ms counter, so
+    // the absolute diff from "now" can be a few ms — accept up to ±1 second to cover slow CI.
+    let diff = tid.timestamp > nowMicros ? tid.timestamp - nowMicros : nowMicros - tid.timestamp
+    #expect(diff < 1_000_000)
+  }
+
+  @Test func nextClockIdIsWithinTenBitRange() {
+    let tid = TID.next()
+    #expect(tid.clockId < 1024)
+  }
+}

--- a/Tests/SwiftAtprotoTests/TIDGeneratorTests.swift
+++ b/Tests/SwiftAtprotoTests/TIDGeneratorTests.swift
@@ -32,4 +32,37 @@ struct TIDGeneratorTests {
     let tid = TID.next()
     #expect(tid.clockId < 1024)
   }
+
+  // MARK: deterministic (dependency-injected) generator
+
+  @Test func deterministicGeneratorRoundTripsInputs() {
+    let now: UInt64 = 1_700_000_000_000_000
+    let clockId: UInt16 = 42
+    let tid = TID.next(prev: nil, now: now, clockId: clockId)
+    #expect(tid.timestamp == now)
+    #expect(tid.clockId == clockId)
+  }
+
+  @Test func deterministicGeneratorBumpsWhenNowEqualsPrev() {
+    let prev = TID.next(prev: nil, now: 1_000_000, clockId: 0)
+    let tid = TID.next(prev: prev, now: 1_000_000, clockId: 0)
+    #expect(tid.timestamp == 1_000_001)
+  }
+
+  @Test func deterministicGeneratorBumpsWhenNowBeforePrev() {
+    let prev = TID.next(prev: nil, now: 2_000_000, clockId: 0)
+    let tid = TID.next(prev: prev, now: 1_500_000, clockId: 0)
+    #expect(tid.timestamp == 2_000_001)
+  }
+
+  @Test func deterministicGeneratorDoesNotBumpWhenNowAfterPrev() {
+    let prev = TID.next(prev: nil, now: 1_000_000, clockId: 0)
+    let tid = TID.next(prev: prev, now: 2_000_000, clockId: 0)
+    #expect(tid.timestamp == 2_000_000)
+  }
+
+  @Test func deterministicGeneratorAcceptsUpperTenBitClockId() {
+    let tid = TID.next(prev: nil, now: 1_000_000, clockId: 1023)
+    #expect(tid.clockId == 1023)
+  }
 }

--- a/Tests/SwiftAtprotoTests/TIDGeneratorTests.swift
+++ b/Tests/SwiftAtprotoTests/TIDGeneratorTests.swift
@@ -65,4 +65,37 @@ struct TIDGeneratorTests {
     let tid = TID.next(prev: nil, now: 1_000_000, clockId: 1023)
     #expect(tid.clockId == 1023)
   }
+
+  // MARK: monotonicity
+
+  @Test func consecutiveNextCallsAreMonotonicallyIncreasing() {
+    var prev: TID? = nil
+    var allRaw: [String] = []
+    for _ in 0..<1000 {
+      let tid = TID.next(prev: prev)
+      if let prev {
+        #expect(tid.timestamp > prev.timestamp)
+      }
+      allRaw.append(tid.rawValue)
+      prev = tid
+    }
+    // All-unique rawValues falls out of strict monotonicity, but assert it explicitly to
+    // catch any accidental clockId collision in same-microsecond cases.
+    #expect(Set(allRaw).count == 1000)
+  }
+
+  @Test func concurrentNextCallsProduceUniqueTIDs() async {
+    let ids = await withTaskGroup(of: TID.self, returning: [TID].self) { group in
+      for _ in 0..<1000 {
+        group.addTask { TID.next() }
+      }
+      var collected: [TID] = []
+      for await tid in group {
+        collected.append(tid)
+      }
+      return collected
+    }
+    #expect(ids.count == 1000)
+    #expect(Set(ids.map(\.rawValue)).count == 1000)
+  }
 }

--- a/Tests/SwiftAtprotoTests/TIDInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/TIDInteropTests.swift
@@ -53,4 +53,35 @@ struct TIDInteropTests {
   func invalidThrows(_ input: String) {
     #expect(throws: (any Error).self) { try TID(string: input) }
   }
+
+  // MARK: timestamp / clockId accessors
+
+  @Test func timestampAndClockIdRoundTripThroughBase32() throws {
+    let knownTimestamp: UInt64 = 1_700_000_000_000_000  // µs since epoch
+    let knownClockId: UInt16 = 42
+    let value = (knownTimestamp << 10) | UInt64(knownClockId)
+    let tid = try TID(string: encodeBase32Sortable(value: value))
+    #expect(tid.timestamp == knownTimestamp)
+    #expect(tid.clockId == knownClockId)
+  }
+
+  @Test func clockIdAtUpperTenBitBoundary() throws {
+    // Per spec, clockId is 10 bits; 1023 is the maximum.
+    let value = (UInt64(1_700_000_000_000_000) << 10) | UInt64(1023)
+    let tid = try TID(string: encodeBase32Sortable(value: value))
+    #expect(tid.clockId == 1023)
+  }
+
+  @Test func clockIdZero() throws {
+    let value = UInt64(1_700_000_000_000_000) << 10  // clockId = 0
+    let tid = try TID(string: encodeBase32Sortable(value: value))
+    #expect(tid.clockId == 0)
+  }
+
+  @Test func allZeroTIDIsRecognized() throws {
+    // The TID spec defines "2222222222222" as the zero value.
+    let tid = try TID(string: "2222222222222")
+    #expect(tid.timestamp == 0)
+    #expect(tid.clockId == 0)
+  }
 }

--- a/Tests/SwiftAtprotoTests/TIDInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/TIDInteropTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Wire-shape vectors for the lexicon `tid` string format. Always 13 base32-sortable chars; the
+// leading char is restricted to `[234567abcdefghij]`.
+struct TIDInteropTests {
+  static let validTIDs: [String] = [
+    // Realistic-looking TIDs.
+    "3jzfcijpj2z2a",
+    "3kbgyjzqfeq2e",
+    // Boundary first characters (lowest = '2', highest of the restricted set = 'j').
+    "2222222222222",
+    "jzzzzzzzzzzzz",
+    // All-digit boundaries within the alphabet (no 0, 1, 8, 9).
+    "7zzzzzzzzzzzz",
+    "234567abcdefg",
+    // Representative letter-start TID (boundary first chars 2, 7, j are covered above).
+    "abcdefghijklm",
+  ]
+
+  @Test(arguments: validTIDs)
+  func validParses(_ input: String) throws {
+    let tid = try TID(string: input)
+    #expect(tid.rawValue == input)
+  }
+
+  static let invalidTIDs: [String] = [
+    // Empty / wrong length.
+    "",
+    "234567abcdef",  // 12
+    "234567abcdefgh",  // 14
+    // First char outside [234567abcdefghij].
+    "1234567abcdef",  // first '1'
+    "0234567abcdef",  // first '0'
+    "82345abcdefgh",  // first '8'
+    "92345abcdefgh",  // first '9'
+    "k234567abcdef",  // first 'k' (>= position 14 of the alphabet)
+    "z234567abcdef",  // first 'z'
+    "A234567abcdef",  // uppercase
+    // Disallowed char in subsequent positions (`0`, `1`, `8`, `9` not in base32-sortable).
+    "3jzfcijpj0z2a", "3jzfcijpj1z2a", "3jzfcijpj8z2a", "3jzfcijpj9z2a",
+    // Uppercase in the body.
+    "3jzfcijpj2z2A",
+    // Disallowed punctuation.
+    "3jzfcijpj-z2a", "3jzfcijpj.z2a", "3jzfcijpj_z2a",
+    // Whitespace / control.
+    "3jzfcijpj z2a", "3jzfcijpj\tz2a", "3jzfcijpj\nz2a",
+  ]
+
+  @Test(arguments: invalidTIDs)
+  func invalidThrows(_ input: String) {
+    #expect(throws: (any Error).self) { try TID(string: input) }
+  }
+}


### PR DESCRIPTION
Add lexicon identifier string format projections (DID, Handle, NSID, TID, RecordKey, AtIdentifier) and a TID generator to swift-atproto, wired into codegen so identifier-format fields are emitted as `FormatString<…>`.