### PR TITLE
feat: add URI.Kind classification tag for exhaustive switch dispatch

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/URI.swift
+++ b/Sources/SwiftAtproto/StringFormats/URI.swift
@@ -27,6 +27,13 @@ public struct URI: LexiconStringFormat {
   public let rawValue: String
   // The URI scheme (before the colon), preserved verbatim (no lowercase canonicalization).
   public let scheme: String
+  public let kind: Kind
+
+  public enum Kind: Sendable, Hashable {
+    case url
+    case aturl
+    case other
+  }
 
   public init(string: String) throws {
     guard let parsedScheme = URI.parse(string) else {
@@ -34,6 +41,7 @@ public struct URI: LexiconStringFormat {
     }
     rawValue = string
     scheme = parsedScheme
+    kind = URI.classify(string)
   }
 
   // Best-effort `URL` projection. The `encodingInvalidCharacters` parameter is forwarded to
@@ -59,6 +67,15 @@ public struct URI: LexiconStringFormat {
 }
 
 extension URI {
+  // `at:` is matched case-sensitively; `AT://` falls through to the URL branch.
+  private static func classify(_ s: String) -> Kind {
+    if s.hasPrefix("at:") {
+      if (try? ATURI(string: s)) != nil { return .aturl }
+    }
+    if URL(string: s) != nil { return .url }
+    return .other
+  }
+
   // 8 KiB per atproto spec.
   private static let maxLength = 8 * 1024
 

--- a/Tests/SwiftAtprotoTests/FormatStringURITests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringURITests.swift
@@ -84,4 +84,24 @@ struct FormatStringURITests {
     #expect(value.description == Self.wire)
     #expect("\(value)" == Self.wire)
   }
+
+  @Test func kindIsPreservedThroughFormatStringRoundTrip() throws {
+    let cases: [(wire: String, expectedKind: URI.Kind)] = [
+      ("at://example.com", .aturl),
+      ("at://did:plc:abc/com.example.foo/rkey", .aturl),
+      ("https://example.com/path", .url),
+      ("at:/", .url),
+      ("file:///etc/hosts", .url),
+    ]
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.withoutEscapingSlashes]
+    for (wire, expectedKind) in cases {
+      let data = Data("\"\(wire)\"".utf8)
+      let value = try JSONDecoder().decode(FormatString<URI>.self, from: data)
+      #expect(value.rawValue == wire)
+      #expect(value.typed?.kind == expectedKind)
+      let encoded = try encoder.encode(value)
+      #expect(String(decoding: encoded, as: UTF8.self) == "\"\(wire)\"")
+    }
+  }
 }

--- a/Tests/SwiftAtprotoTests/URIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/URIInteropTests.swift
@@ -230,4 +230,57 @@ struct URIInteropTests {
     let u = try URI(string: "at://example.com/not-an-nsid")
     #expect(u.atUri == nil)
   }
+
+  // MARK: kind classification
+
+  @Test func atHandleAuthorityClassifiesAsAturl() throws {
+    let uri = try URI(string: "at://example.com")
+    #expect(uri.kind == .aturl)
+  }
+
+  @Test func atDIDAuthorityClassifiesAsAturl() throws {
+    let uri = try URI(string: "at://did:plc:abc/com.example.foo/rkey")
+    #expect(uri.kind == .aturl)
+  }
+
+  @Test func atPathAbsoluteFallsBackToUrl() throws {
+    // `at:/` is a valid lexicon `uri` (path-absolute) but not a valid ATURI → URL fallback.
+    let uri = try URI(string: "at:/")
+    #expect(uri.kind == .url)
+  }
+
+  @Test func atPathAbsoluteWithBodyFallsBackToUrl() throws {
+    let uri = try URI(string: "at:/x")
+    #expect(uri.kind == .url)
+  }
+
+  @Test func httpsClassifiesAsUrl() throws {
+    let uri = try URI(string: "https://example.com/path")
+    #expect(uri.kind == .url)
+  }
+
+  @Test func fileClassifiesAsUrl() throws {
+    let uri = try URI(string: "file:///etc/hosts")
+    #expect(uri.kind == .url)
+  }
+
+  @Test func didOpaqueClassifiesAsUrl() throws {
+    let uri = try URI(string: "did:plc:abc")
+    #expect(uri.kind == .url)
+  }
+
+  @Test func dataClassifiesAsUrl() throws {
+    let uri = try URI(string: "data:text/plain,Hello")
+    #expect(uri.kind == .url)
+  }
+
+  @Test func bothParsersFailingClassifiesAsOther() throws {
+    // `at://example.com:notaport` is wire-shape valid (`uri` accepts the body) but:
+    //   - ATURI rejects because authority `example.com:notaport` is neither a valid DID nor a
+    //     valid handle (the `:` inside a single label breaks the handle grammar)
+    //   - URL(string:) returns nil due to port grammar (`:` must be followed by digits)
+    // → classify falls through to `.other`.
+    let uri = try URI(string: "at://example.com:notaport")
+    #expect(uri.kind == .other)
+  }
 }


### PR DESCRIPTION
Add a `URI.Kind` enum (`url` / `aturl` / `other`) and a stored `kind` property to `URI`, so callers can exhaustively switch on the classification without per-call `URL(string:)` / `ATURI(string:)` re-parsing.