### PR TITLE
feat!: type ATURI authority/collection/rkey as identifier types

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -22,12 +22,12 @@ import Foundation
 public struct ATURI: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
-  // Required authority: a DID or a handle.
-  public let authority: String
+  // Required authority: a DID or a handle, dispatched via `AtIdentifier`.
+  public let authority: AtIdentifier
   // Optional collection NSID.
-  public let collection: String?
+  public let collection: NSID?
   // Optional record key (trailing path segment).
-  public let rkey: String?
+  public let rkey: RecordKey?
   // Optional JSON Pointer fragment (without the leading "#").
   public let fragment: String?
 
@@ -36,9 +36,12 @@ public struct ATURI: LexiconStringFormat {
       throw LexiconStringFormatError.invalid(format: "at-uri", value: string)
     }
     rawValue = string
-    authority = String(parts.authority)
-    collection = parts.collection.map(String.init)
-    rkey = parts.rkey.map(String.init)
+    // `ATURI.parse` runs each component through its identifier-type validator
+    // (`AtIdentifier.isValid` / `NSID.isValid` / `RecordKey.isValid`) before returning, so the
+    // typed inits below cannot throw in practice — the force-tries document that invariant.
+    authority = try! AtIdentifier(string: String(parts.authority))
+    collection = parts.collection.map { try! NSID(string: String($0)) }
+    rkey = parts.rkey.map { try! RecordKey(string: String($0)) }
     fragment = parts.fragment.map(String.init)
   }
 }

--- a/Tests/SwiftAtprotoTests/ATURIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/ATURIInteropTests.swift
@@ -116,18 +116,18 @@ struct ATURIInteropTests {
 
   @Test func parsesComponents() throws {
     let full = try ATURI(string: "at://did:plc:asdf123/com.atproto.feed.post/3jui7kd54zh2y")
-    #expect(full.authority == "did:plc:asdf123")
-    #expect(full.collection == "com.atproto.feed.post")
-    #expect(full.rkey == "3jui7kd54zh2y")
+    #expect(full.authority.rawValue == "did:plc:asdf123")
+    #expect(full.collection?.rawValue == "com.atproto.feed.post")
+    #expect(full.rkey?.rawValue == "3jui7kd54zh2y")
     #expect(full.fragment == nil)
 
     let handleOnly = try ATURI(string: "at://user.bsky.social")
-    #expect(handleOnly.authority == "user.bsky.social")
+    #expect(handleOnly.authority.rawValue == "user.bsky.social")
     #expect(handleOnly.collection == nil)
     #expect(handleOnly.rkey == nil)
 
     let collectionOnly = try ATURI(string: "at://did:plc:asdf123/com.atproto.feed.post")
-    #expect(collectionOnly.collection == "com.atproto.feed.post")
+    #expect(collectionOnly.collection?.rawValue == "com.atproto.feed.post")
     #expect(collectionOnly.rkey == nil)
   }
 
@@ -138,6 +138,6 @@ struct ATURIInteropTests {
   @Test func jsonPointerFragmentIsAccepted() throws {
     let uri = try ATURI(string: "at://did:plc:asdf123/com.atproto.feed.post/record#/text")
     #expect(uri.fragment == "/text")
-    #expect(uri.rkey == "record")
+    #expect(uri.rkey?.rawValue == "record")
   }
 }

--- a/Tests/SwiftAtprotoTests/URIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/URIInteropTests.swift
@@ -198,15 +198,15 @@ struct URIInteropTests {
     let u = try URI(string: "at://did:plc:abc/com.example.foo/rkey")
     #expect(u.atUri != nil)
     #expect(u.atUri?.rawValue == "at://did:plc:abc/com.example.foo/rkey")
-    #expect(u.atUri?.collection == "com.example.foo")
-    #expect(u.atUri?.rkey == "rkey")
+    #expect(u.atUri?.collection?.rawValue == "com.example.foo")
+    #expect(u.atUri?.rkey?.rawValue == "rkey")
   }
 
   @Test func atUriAccessorReturnsValueForHandleOnlyAuthority() throws {
     // ATURI's restricted form permits authority alone (collection/rkey optional).
     let u = try URI(string: "at://example.com")
     #expect(u.atUri != nil)
-    #expect(u.atUri?.authority == "example.com")
+    #expect(u.atUri?.authority.rawValue == "example.com")
     #expect(u.atUri?.collection == nil)
     #expect(u.atUri?.rkey == nil)
   }


### PR DESCRIPTION
Type `ATURI.authority` / `collection` / `rkey` as `AtIdentifier` / `NSID?` / `RecordKey?` (previously `String` / `String?`), so callers get compile-time typed access without going through identifier validators again.