### PR TITLE
feat: add strict/lenient parsing modes for datetime and at-uri

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -32,7 +32,11 @@ public struct ATURI: LexiconStringFormat {
   public let fragment: String?
 
   public init(string: String) throws {
-    guard let parts = ATURI.parse(string) else {
+    try self.init(string: string, strict: true)
+  }
+
+  public init(string: String, strict: Bool) throws {
+    guard let parts = ATURI.parse(string, strict: strict) else {
       throw LexiconStringFormatError.invalid(format: "at-uri", value: string)
     }
     rawValue = string
@@ -54,8 +58,11 @@ extension ATURI {
     var fragment: Substring?
   }
 
-  // Strict restricted-syntax validation per the AT URI spec. Returns nil on any violation.
-  private static func parse(_ input: String) -> Parts? {
+  // Restricted-syntax validation per the AT URI spec. When `strict` is false the lenient variant
+  // is applied: trailing slash, query, and percent-encoding errors in the fragment are accepted.
+  // `rkey` is still validated through `RecordKey.isValid` in both modes — relaxing rkey is
+  // tracked in a separate issue.
+  private static func parse(_ input: String, strict: Bool = true) -> Parts? {
     guard input.utf8.count <= 8192 else { return nil }
     for byte in input.utf8 where !isAllowedURIByte(byte) { return nil }
     guard input.hasPrefix("at://") else { return nil }
@@ -122,24 +129,27 @@ extension ATURI {
     // Component validation (applies in both strict and lenient).
     guard AtIdentifier.isValid(authority) else { return nil }
     if let collection, !NSID.isValid(collection) { return nil }
-    if let fragment, !isValidJSONPointer(fragment) { return nil }
+    if let fragment, !isValidJSONPointer(fragment, strict: strict) { return nil }
+    if let rkey, !RecordKey.isValid(rkey) { return nil }
 
     // Strict-only constraints.
-    if trailingSlash { return nil }
-    if hasQuery { return nil }
-    if let rkey, !RecordKey.isValid(rkey) { return nil }
+    if strict, trailingSlash { return nil }
+    if strict, hasQuery { return nil }
 
     return Parts(authority: authority, collection: collection, rkey: rkey, fragment: fragment)
   }
 
   // MARK: - JSON Pointer fragment
 
-  // JSON Pointer fragment: starts with "/", allowed pointer chars, with valid percent-encoding.
-  private static func isValidJSONPointer(_ s: Substring) -> Bool {
+  // JSON Pointer fragment: starts with "/", allowed pointer chars; strict mode additionally
+  // requires valid percent-encoding (Swift `removingPercentEncoding` succeeds). Lenient mode
+  // accepts malformed `%xx` sequences.
+  private static func isValidJSONPointer(_ s: Substring, strict: Bool = true) -> Bool {
     let u = Array(s.utf8)
     guard u.first == slash else { return false }
     for byte in u where !(isAlphanumeric(byte) || pointerPunct.contains(byte)) { return false }
-    return String(s).removingPercentEncoding != nil
+    if strict, String(s).removingPercentEncoding == nil { return false }
+    return true
   }
 }
 

--- a/Sources/SwiftAtproto/StringFormats/AtprotoDatetimeParseStrategy.swift
+++ b/Sources/SwiftAtproto/StringFormats/AtprotoDatetimeParseStrategy.swift
@@ -3,7 +3,11 @@ import Foundation
 public struct AtprotoDatetimeParseStrategy: ParseStrategy {
   static let maxLength = 64
 
-  public init() {}
+  public let lenient: Bool
+
+  public init(lenient: Bool = false) {
+    self.lenient = lenient
+  }
 
   private static let calendar = ProlepticGregorianCalendar()
   // 0000-01-01T00:00:00Z; instants before this are rejected.
@@ -16,7 +20,8 @@ public struct AtprotoDatetimeParseStrategy: ParseStrategy {
       throw LexiconStringFormatError.tooLong(format: "datetime", limit: Self.maxLength)
     }
 
-    var scanner = Scanner(value)
+    let input = lenient ? Self.normalizeForLenient(value) : value
+    var scanner = Scanner(input)
     guard let fields = scanner.scan() else { throw invalid() }
 
     // Resolve the instant in the proleptic Gregorian calendar (matching the reference
@@ -37,6 +42,20 @@ public struct AtprotoDatetimeParseStrategy: ParseStrategy {
 
 extension ParseStrategy where Self == AtprotoDatetimeParseStrategy {
   public static var atprotoDatetime: Self { .init() }
+  public static var atprotoDatetimeLenient: Self { .init(lenient: true) }
+}
+
+extension AtprotoDatetimeParseStrategy {
+  // Lenient pre-normalization: append `Z` when the input has no timezone designator (ends in a
+  // digit). Other lenient normalizations stay opt-in for the caller.
+  fileprivate static func normalizeForLenient(_ value: String) -> String {
+    guard let last = value.last else { return value }
+    if last == "Z" || last == "z" || last == "+" || last == "-" { return value }
+    if let scalar = last.unicodeScalars.first, ("0"..."9").contains(Character(scalar)) {
+      return value + "Z"
+    }
+    return value
+  }
 }
 
 private struct Scanner {

--- a/Sources/SwiftAtproto/StringFormats/Date+LexiconStringFormat.swift
+++ b/Sources/SwiftAtproto/StringFormats/Date+LexiconStringFormat.swift
@@ -5,5 +5,9 @@ extension Date: LexiconStringFormat {
     self = try Date(string, strategy: .atprotoDatetime)
   }
 
+  public init(string: String, strict: Bool) throws {
+    self = try Date(string, strategy: strict ? .atprotoDatetime : .atprotoDatetimeLenient)
+  }
+
   public var rawValue: String { formatted(.atprotoDatetime) }
 }

--- a/Sources/SwiftAtproto/StringFormats/FormatString.swift
+++ b/Sources/SwiftAtproto/StringFormats/FormatString.swift
@@ -16,6 +16,8 @@ public struct FormatString<T: LexiconStringFormat>: RawRepresentable, Codable, H
 
   public var typed: T? { try? T(string: rawValue) }
 
+  public var typedLenient: T? { try? T(string: rawValue, strict: false) }
+
   public init(from decoder: any Decoder) throws {
     rawValue = try String(from: decoder)
   }

--- a/Sources/SwiftAtproto/StringFormats/LexiconStringFormat.swift
+++ b/Sources/SwiftAtproto/StringFormats/LexiconStringFormat.swift
@@ -3,6 +3,14 @@ import Foundation
 public protocol LexiconStringFormat: Hashable, Sendable {
   var rawValue: String { get }
   init(string: String) throws
+  init(string: String, strict: Bool) throws
+}
+
+extension LexiconStringFormat {
+  // Formats without a lenient override (most identifier formats) fall through to strict.
+  public init(string: String, strict: Bool) throws {
+    try self.init(string: string)
+  }
 }
 
 public enum LexiconStringFormatError: Error, Equatable {

--- a/Tests/SwiftAtprotoTests/ATURIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/ATURIInteropTests.swift
@@ -140,4 +140,42 @@ struct ATURIInteropTests {
     #expect(uri.fragment == "/text")
     #expect(uri.rkey?.rawValue == "record")
   }
+
+  // MARK: lenient parsing (3 relaxations: trailing slash / query / fragment %)
+
+  @Test func trailingSlashIsRejectedByStrictAcceptedByLenient() throws {
+    let wire = "at://did:plc:asdf123/com.atproto.feed.post/"
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: true) }
+    let uri = try ATURI(string: wire, strict: false)
+    #expect(uri.rawValue == wire)
+  }
+
+  @Test func queryIsRejectedByStrictAcceptedByLenient() throws {
+    let wire = "at://did:plc:asdf123?foo=bar"
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: true) }
+    let uri = try ATURI(string: wire, strict: false)
+    #expect(uri.rawValue == wire)
+  }
+
+  @Test func malformedFragmentPercentEncodingIsRejectedByStrictAcceptedByLenient() throws {
+    // `%FF` is a syntactically allowed pointer byte sequence but produces invalid UTF-8 when
+    // percent-decoded; strict mirrors atproto by rejecting it, lenient accepts.
+    let wire = "at://did:plc:asdf123#/%FF"
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: true) }
+    let uri = try ATURI(string: wire, strict: false)
+    #expect(uri.rawValue == wire)
+  }
+
+  @Test func defaultInitIsEquivalentToStrict() {
+    #expect(throws: (any Error).self) {
+      try ATURI(string: "at://did:plc:asdf123?foo=bar")
+    }
+  }
+
+  @Test func rkeyValidationStaysStrictEvenInLenientMode() {
+    // ATPROTO-43 explicitly leaves rkey relaxation out of scope (tracked in a follow-up issue);
+    // an rkey that violates RecordKey rules is still rejected in lenient mode.
+    let wire = "at://did:plc:asdf123/com.atproto.feed.post/.."
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: false) }
+  }
 }

--- a/Tests/SwiftAtprotoTests/DatetimeInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/DatetimeInteropTests.swift
@@ -99,4 +99,37 @@ struct DatetimeInteropTests {
   func invalidExamplesThrow(_ value: String) {
     #expect(throws: (any Error).self) { try Date(string: value) }
   }
+
+  // MARK: lenient parsing
+
+  @Test func tzMissingIsRejectedByStrict() {
+    #expect(throws: (any Error).self) {
+      try Date(string: "1985-04-12T23:20:50.123", strict: true)
+    }
+  }
+
+  @Test func tzMissingIsAcceptedByLenient() throws {
+    let lenient = try Date(string: "1985-04-12T23:20:50.123", strict: false)
+    let strict = try Date(string: "1985-04-12T23:20:50.123Z", strict: true)
+    #expect(lenient == strict)
+  }
+
+  @Test func tzMissingWithoutFractionIsAcceptedByLenient() throws {
+    let lenient = try Date(string: "1985-04-12T23:20:50", strict: false)
+    let strict = try Date(string: "1985-04-12T23:20:50Z", strict: true)
+    #expect(lenient == strict)
+  }
+
+  @Test func validStrictInputIsAlsoAcceptedByLenient() throws {
+    let strict = try Date(string: "1985-04-12T23:20:50.123Z", strict: true)
+    let lenient = try Date(string: "1985-04-12T23:20:50.123Z", strict: false)
+    #expect(strict == lenient)
+  }
+
+  @Test func malformedInputIsRejectedByLenientToo() {
+    // lenient only handles TZ omission; structural errors still fail
+    #expect(throws: (any Error).self) {
+      try Date(string: "1985-04-12T25:20:50.123Z", strict: false)
+    }
+  }
 }

--- a/Tests/SwiftAtprotoTests/FormatStringATURITests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringATURITests.swift
@@ -46,6 +46,15 @@ struct FormatStringATURITests {
     #expect(record.subject.typed != nil)
   }
 
+  @Test func typedIsNilButTypedLenientIsNonNilForTrailingSlash() throws {
+    let wire = "at://did:plc:asdf123/com.atproto.feed.post/"
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<ATURI>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+    #expect(value.typedLenient != nil)
+  }
+
   @Test func descriptionIsRawValue() {
     let value = FormatString<ATURI>(rawValue: Self.wire)
     #expect(value.description == Self.wire)

--- a/Tests/SwiftAtprotoTests/FormatStringDateTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringDateTests.swift
@@ -53,6 +53,14 @@ struct FormatStringDateTests {
     #expect(record.createdAt.typed != nil)
   }
 
+  @Test func typedIsNilButTypedLenientIsNonNilForTzOmittedInput() throws {
+    let data = Data("\"1985-04-12T23:20:50.123\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Date>.self, from: data)
+    #expect(value.rawValue == "1985-04-12T23:20:50.123")
+    #expect(value.typed == nil)
+    #expect(value.typedLenient != nil)
+  }
+
   @Test func descriptionIsRawValue() {
     let value = FormatString<Date>(rawValue: "2024-01-15T12:30:00+09:00")
     #expect(value.description == "2024-01-15T12:30:00+09:00")


### PR DESCRIPTION
Add `init(string:strict:)` to `LexiconStringFormat` and `typedLenient` to `FormatString<T>`, with lenient implementations for `Date` (TZ omission) and `ATURI` (trailing slash, query, fragment percent-encoding).

## Out of scope

- ATURI rkey lenient relaxation