### PR TITLE
feat: support lenient rkey relaxation in ATURI lenient mode

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -45,7 +45,7 @@ public struct ATURI: LexiconStringFormat {
     // typed inits below cannot throw in practice — the force-tries document that invariant.
     authority = try! AtIdentifier(string: String(parts.authority))
     collection = parts.collection.map { try! NSID(string: String($0)) }
-    rkey = parts.rkey.map { try! RecordKey(string: String($0)) }
+    rkey = parts.rkey.map { try! RecordKey(string: String($0), strict: strict) }
     fragment = parts.fragment.map(String.init)
   }
 }
@@ -59,9 +59,9 @@ extension ATURI {
   }
 
   // Restricted-syntax validation per the AT URI spec. When `strict` is false the lenient variant
-  // is applied: trailing slash, query, and percent-encoding errors in the fragment are accepted.
-  // `rkey` is still validated through `RecordKey.isValid` in both modes — relaxing rkey is
-  // tracked in a separate issue.
+  // is applied: trailing slash, query, and percent-encoding errors in the fragment are accepted,
+  // and `rkey` is admitted through `RecordKey.isValidLenient` (non-empty + no path delimiters)
+  // instead of the strict record-key grammar.
   private static func parse(_ input: String, strict: Bool = true) -> Parts? {
     guard input.utf8.count <= 8192 else { return nil }
     for byte in input.utf8 where !isAllowedURIByte(byte) { return nil }
@@ -130,7 +130,7 @@ extension ATURI {
     guard AtIdentifier.isValid(authority) else { return nil }
     if let collection, !NSID.isValid(collection) { return nil }
     if let fragment, !isValidJSONPointer(fragment, strict: strict) { return nil }
-    if let rkey, !RecordKey.isValid(rkey) { return nil }
+    if let rkey, !(strict ? RecordKey.isValid(rkey) : RecordKey.isValidLenient(rkey)) { return nil }
 
     // Strict-only constraints.
     if strict, trailingSlash { return nil }

--- a/Sources/SwiftAtproto/StringFormats/RecordKey.swift
+++ b/Sources/SwiftAtproto/StringFormats/RecordKey.swift
@@ -3,14 +3,29 @@ import Foundation
 // Type for the lexicon `record-key` string format: the opaque trailing segment of an AT URI per
 // the AT Protocol Record Key spec (https://atproto.com/specs/record-key).
 //
-// Wire-shape validation only: 1–512 byte ASCII alnum / `_~.:-`, excluding the special forbidden
-// values `"."` and `".."`.
+// Strict mode (the default `init(string:)`): 1–512 byte ASCII alnum / `_~.:-`, excluding the
+// special forbidden values `"."` and `".."`. A lenient mode is also available via
+// `init(string:strict: false)`; see that initializer for the relaxed grammar and the resulting
+// type-invariant trade-off.
 public struct RecordKey: LexiconStringFormat {
   // The original wire string, kept verbatim.
   public let rawValue: String
 
   public init(string: String) throws {
     guard RecordKey.isValid(string) else {
+      throw LexiconStringFormatError.invalid(format: "record-key", value: string)
+    }
+    rawValue = string
+  }
+
+  // Opt-in lenient parsing. Accepts wire strings that violate the strict record-key spec
+  // (`.` / `..` / over 512 byte / chars outside `[a-zA-Z0-9_~.:-]`) as long as the value is
+  // non-empty and contains no `/`, `?`, or `#`. Caller takes responsibility: a lenient instance
+  // can hold values the strict spec rejects, so type invariants weaken when this overload is
+  // used explicitly.
+  public init(string: String, strict: Bool) throws {
+    let valid = strict ? RecordKey.isValid(string) : RecordKey.isValidLenient(string)
+    guard valid else {
       throw LexiconStringFormatError.invalid(format: "record-key", value: string)
     }
     rawValue = string
@@ -26,6 +41,19 @@ extension RecordKey {
     for byte in u where !(isAlphanumeric(byte) || recordKeyPunct.contains(byte)) { return false }
     return s != "." && s != ".."
   }
+
+  // Lenient: only the structural constraint imposed by AT URI path syntax (non-empty + no
+  // `/`/`?`/`#`). Length and char set restrictions plus the `.` / `..` exclusion are dropped.
+  static func isValidLenient(_ s: some StringProtocol) -> Bool {
+    let u = Array(s.utf8)
+    guard !u.isEmpty else { return false }
+    for byte in u where pathDelimiterByte(byte) { return false }
+    return true
+  }
 }
 
 private let recordKeyPunct = Set("_~.:-".utf8)
+
+private func pathDelimiterByte(_ b: UInt8) -> Bool {
+  b == UInt8(ascii: "/") || b == UInt8(ascii: "?") || b == UInt8(ascii: "#")
+}

--- a/Tests/SwiftAtprotoTests/ATURIInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/ATURIInteropTests.swift
@@ -172,10 +172,13 @@ struct ATURIInteropTests {
     }
   }
 
-  @Test func rkeyValidationStaysStrictEvenInLenientMode() {
-    // ATPROTO-43 explicitly leaves rkey relaxation out of scope (tracked in a follow-up issue);
-    // an rkey that violates RecordKey rules is still rejected in lenient mode.
+  @Test func recordKeyForbiddenValuesAreAcceptedByLenient() throws {
+    // `..` is a strict-only RecordKey violation (length / char / forbidden-value rules drop in
+    // lenient; only non-empty + no path delimiters required).
     let wire = "at://did:plc:asdf123/com.atproto.feed.post/.."
-    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: false) }
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: true) }
+    let uri = try ATURI(string: wire, strict: false)
+    #expect(uri.rawValue == wire)
+    #expect(uri.rkey?.rawValue == "..")
   }
 }

--- a/Tests/SwiftAtprotoTests/FormatStringATURITests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringATURITests.swift
@@ -55,6 +55,16 @@ struct FormatStringATURITests {
     #expect(value.typedLenient != nil)
   }
 
+  @Test func typedIsNilButTypedLenientIsNonNilForForbiddenRkey() throws {
+    let wire = "at://did:plc:asdf123/com.atproto.feed.post/.."
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<ATURI>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+    #expect(value.typedLenient != nil)
+    #expect(value.typedLenient?.rkey?.rawValue == "..")
+  }
+
   @Test func descriptionIsRawValue() {
     let value = FormatString<ATURI>(rawValue: Self.wire)
     #expect(value.description == Self.wire)


### PR DESCRIPTION
Extend `ATURI.init(string:strict: false)` to accept rkeys that violate the strict RecordKey spec (`.`, `..`, oversize, char-set violations), implemented via a new `RecordKey.init(string:strict:)` overload that accepts any non-empty value without AT URI path delimiters (`/`, `?`, `#`).