### PR TITLE
chore: drop deprecated XRPC client APIs and dead helpers

### DIFF
--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -18,14 +18,6 @@ public protocol _XRPCClientProtocol: ATPClientProtocol {
 
 extension ATPClientProtocol {
   public func getProxy(nsid _: String) -> String? { nil }
-
-  public func call<X: XRPCQuery>(_ requestType: X.Type, input: X.Input.Query, retry _: Bool) async throws -> X.ResponseBody {
-    try await call(requestType, input: input)
-  }
-
-  public func call<X: XRPCProcedure>(_ requestType: X.Type, input: X.RequestBody? = nil, retry _: Bool) async throws -> X.ResponseBody {
-    try await call(requestType, input: input)
-  }
 }
 
 public protocol XRPCError: Error, LocalizedError, Decodable, Sendable {

--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -1,14 +1,5 @@
 import Foundation
 
-#if canImport(FoundationNetworking)
-  import FoundationNetworking
-#endif
-
-public enum HTTPMethod {
-  case get
-  case post
-}
-
 public protocol ATPClientProtocol: _XRPCCallable {
   var serviceEndpoint: URL { get }
   var decoder: JSONDecoder { get }
@@ -25,27 +16,8 @@ public protocol _XRPCClientProtocol: ATPClientProtocol {
   func signout()
 }
 
-extension URLSession {
-  func executeTask(for request: URLRequest) async throws -> (Data, UInt) {
-    let (data, response) = try await URLSession.shared.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-      fatalError()
-    }
-    return (data, UInt(httpResponse.statusCode))
-  }
-}
-
 extension ATPClientProtocol {
   public func getProxy(nsid _: String) -> String? { nil }
-
-  private static func encode(_ string: String, component: XRPCComponent) -> String {
-    switch component {
-    case .nsid:
-      string.addingPercentEncoding(withAllowedCharacters: .nsidAllowed) ?? string
-    case .parameter:
-      string.addingPercentEncoding(withAllowedCharacters: .parameterAllowed) ?? string
-    }
-  }
 
   public func call<X: XRPCQuery>(_ requestType: X.Type, input: X.Input.Query, retry _: Bool) async throws -> X.ResponseBody {
     try await call(requestType, input: input)

--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -16,14 +16,7 @@ public protocol ATPClientProtocol: _XRPCCallable {
   func tokenIsExpired(error: some XRPCError) -> Bool
   func getAuthorization(endpoint: String) -> String?
 
-  @available(*, deprecated, renamed: "call", message: "Use the type-safe 'call(_:input:retry:)' method instead.")
-  func fetch<T: Decodable>(
-    endpoint: String, contentType: String, httpMethod: HTTPMethod, params: Parameters?,
-    input: (some Encodable)?, retry: Bool
-  ) async throws -> T
   func refreshSession() async -> Bool
-
-  static var errorDomain: String { get }
 }
 
 public protocol _XRPCClientProtocol: ATPClientProtocol {
@@ -42,13 +35,8 @@ extension URLSession {
   }
 }
 
-extension _XRPCClientProtocol {
-  public static var errorDomain: String { "XRPCErrorDomain" }
-}
-
 extension ATPClientProtocol {
   public func getProxy(nsid _: String) -> String? { nil }
-  public static var errorDomain: String { "ATPErrorDomain" }
 
   private static func encode(_ string: String, component: XRPCComponent) -> String {
     switch component {
@@ -57,71 +45,6 @@ extension ATPClientProtocol {
     case .parameter:
       string.addingPercentEncoding(withAllowedCharacters: .parameterAllowed) ?? string
     }
-  }
-
-  @available(*, deprecated, renamed: "call", message: "Use the type-safe 'call(_:input:retry:)' method instead.")
-  public func fetch<T: Decodable>(
-    endpoint nsid: String, contentType: String, httpMethod: HTTPMethod, params: Parameters?, input: (some Encodable)?, retry: Bool
-  ) async throws -> T {
-    var url = serviceEndpoint.appending(path: Self.encode(nsid, component: .nsid))
-    if httpMethod == .get, let params = params {
-      url.append(percentEncodedQueryItems: Self.makeParameters(params: params))
-    }
-
-    var request = URLRequest(url: url)
-    request.addValue("application/json", forHTTPHeaderField: "Accept")
-    if let authorization = getAuthorization(endpoint: nsid) {
-      request.addValue("Bearer \(authorization)", forHTTPHeaderField: "Authorization")
-    }
-    if let proxy = getProxy(nsid: nsid) {
-      request.addValue(proxy, forHTTPHeaderField: "atproto-proxy")
-    }
-    switch httpMethod {
-    case .get:
-      request.httpMethod = "GET"
-    case .post:
-      request.httpMethod = "POST"
-      request.addValue(contentType, forHTTPHeaderField: "Content-Type")
-      if let input {
-        let encoder = JSONEncoder()
-        encoder.dataEncodingStrategy = .xrpc
-        encoder.outputFormatting = [.withoutEscapingSlashes]
-        let body: Data =
-          switch input {
-          case let data as Data:
-            data
-          default:
-            try encoder.encode(input)
-          }
-        request.httpBody = body
-        request.addValue("\(body.count)", forHTTPHeaderField: "Content-Length")
-      }
-    }
-
-    let (data, statusCode) = try await URLSession.shared.executeTask(for: request)
-
-    guard 200...299 ~= statusCode else {
-      if let error = try? decoder.decode(UnExpectedError.self, from: data) {
-        if tokenIsExpired(error: error), retry, await refreshSession() {
-          return try await fetch(
-            endpoint: Self.encode(nsid, component: .nsid), contentType: contentType, httpMethod: httpMethod,
-            params: params, input: input, retry: false
-          )
-        }
-        throw error
-      } else {
-        let message = String(decoding: data, as: UTF8.self)
-        throw NSError(domain: Self.errorDomain, code: 0, userInfo: [NSLocalizedDescriptionKey: "Server error: \(message)(\(statusCode))"])
-      }
-    }
-
-    if T.self == Bool.self {
-      return true as! T
-    }
-    if T.self == Data.self {
-      return data as! T
-    }
-    return try decoder.decode(T.self, from: data)
   }
 
   public func call<X: XRPCQuery>(_ requestType: X.Type, input: X.Input.Query, retry _: Bool) async throws -> X.ResponseBody {


### PR DESCRIPTION
The recent `FormatString` migration already shipped a breaking change in this release, so there is no longer a reason to keep the deprecated XRPC APIs around. Drop the deprecated `fetch(...)`/`errorDomain` on `ATPClientProtocol`, the helpers only `fetch` was using (`HTTPMethod`, `URLSession.executeTask`, the duplicate `encode(_:component:)`), and the no-op `call(_:input:retry:)` shims, so the runtime exposes a single `call(_:input:)` entry point.