### PR TITLE
fix: use matrix.target in test-apple-platforms step name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Test platform ${{ matrix.destination }}
+      - name: Test platform ${{ matrix.target }}
         run: |
           if [ "${{ matrix.target }}" = "iOS" ]; then
             DESTINATION="platform=iOS Simulator,name=iPhone 17e,OS=26.4.1"


### PR DESCRIPTION
The `Test platform` step in the `test-apple-platforms` job referenced `${{ matrix.destination }}`, which is not declared in the matrix (`target: [iOS, macOS]` is the only key), causing the step name to always render as `Test platform ` with no platform suffix; replacing it with `${{ matrix.target }}` aligns with the existing `if [ "${{ matrix.target }}" = "iOS" ]` branch in the same step and restores the intended `Test platform iOS` / `Test platform macOS` labels.