### PR TITLE
feat: nest lexicon checkouts under host/path and symlink local sources

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -120,6 +120,12 @@ let package = Package(
       name: "ATProtoCryptoTests",
       dependencies: ["ATProtoCrypto"]
     ),
+    .testTarget(
+      name: "SourceControlTests",
+      dependencies: [
+        .target(name: "SourceControl", condition: .when(platforms: [.macOS, .linux]))
+      ]
+    ),
     .plugin(
       name: "ATProtoLexiconFetcher",
       capability: .command(

--- a/Sources/SourceControl/RepositoryLocation.swift
+++ b/Sources/SourceControl/RepositoryLocation.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+// Identifies the on-disk checkout subdirectory for a remote lexicon repository.
+// `segments` is the URL host followed by every non-empty path component, with a
+// trailing `.git` stripped from the last one. The path depth is not fixed:
+// `https://example.com/path/to/repo.git` becomes
+// `["example.com", "path", "to", "repo"]`, producing
+// `.lexicons/checkouts/example.com/path/to/repo` once joined to the checkout
+// root.
+public struct RepositoryLocation: Equatable, Sendable {
+  public let segments: [String]
+
+  public init(segments: [String]) {
+    self.segments = segments
+  }
+
+  public static func parse(from url: URL) throws -> RepositoryLocation {
+    guard let host = url.host(), !host.isEmpty else {
+      throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
+    }
+    let pathSegments = url.pathComponents.filter { $0 != "/" && !$0.isEmpty }
+    guard !pathSegments.isEmpty else {
+      throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
+    }
+    // Reject path-traversal segments so a malicious or typo-ed URL cannot
+    // escape `.lexicons/checkouts/` via `appending(components:)`.
+    if pathSegments.contains(where: { $0 == "." || $0 == ".." }) {
+      throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
+    }
+    var result = [host]
+    result.append(contentsOf: pathSegments.dropLast())
+    var repo = pathSegments.last!
+    if repo.hasSuffix(".git") {
+      repo = String(repo.dropLast(4))
+    }
+    guard !repo.isEmpty else {
+      throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
+    }
+    result.append(repo)
+    return RepositoryLocation(segments: result)
+  }
+
+  // Strip userinfo (token:secret@) before rendering a URL into a user-visible
+  // error message so credentials embedded in `.atproto.json` never leak into
+  // CI logs.
+  static func redactedDescription(of url: URL) -> String {
+    guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+      return url.scheme.map { "\($0)://<unparseable>" } ?? "<unparseable>"
+    }
+    components.user = nil
+    components.password = nil
+    return components.string ?? url.scheme.map { "\($0)://<unparseable>" } ?? "<unparseable>"
+  }
+}
+
+// The associated value is a redacted URL description (never the raw URL value),
+// so equality works on plain strings instead of `URL`'s normalization-sensitive
+// `==`, and userinfo cannot leak through error rendering or comparisons.
+public enum RepositoryLocationError: Error, CustomStringConvertible, Equatable {
+  case unsupportedURL(String)
+
+  public var description: String {
+    switch self {
+    case .unsupportedURL(let location):
+      return
+        "Cannot derive a checkout path from lexicon location \(location). Expected a URL with at least one path component (e.g. https://<host>/<path>/<repo>(.git))."
+    }
+  }
+}

--- a/Sources/SourceControl/RepositoryLocation.swift
+++ b/Sources/SourceControl/RepositoryLocation.swift
@@ -1,12 +1,14 @@
 import Foundation
 
 // Identifies the on-disk checkout subdirectory for a remote lexicon repository.
-// `segments` is the URL host followed by every non-empty path component, with a
-// trailing `.git` stripped from the last one. The path depth is not fixed:
+// `segments` is `<scheme>` + `<host[:port]>` (lowercased, default port stripped)
+// followed by every non-empty path component, with a trailing `.git` stripped
+// from the last one. The path depth is not fixed:
 // `https://example.com/path/to/repo.git` becomes
-// `["example.com", "path", "to", "repo"]`, producing
-// `.lexicons/checkouts/example.com/path/to/repo` once joined to the checkout
-// root.
+// `["https", "example.com", "path", "to", "repo"]`, producing
+// `.lexicons/checkouts/https/example.com/path/to/repo` once joined to the
+// checkout root. Different schemes/ports/host casings always map to distinct
+// directories so two URLs that point at different remotes never collide.
 public struct RepositoryLocation: Equatable, Sendable {
   public let segments: [String]
 
@@ -15,8 +17,23 @@ public struct RepositoryLocation: Equatable, Sendable {
   }
 
   public static func parse(from url: URL) throws -> RepositoryLocation {
-    guard let host = url.host(), !host.isEmpty else {
+    guard let scheme = url.scheme?.lowercased(), !scheme.isEmpty else {
       throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
+    }
+    if scheme == "file" {
+      // `file://` is the local-lexicon escape hatch and never produces a
+      // checkout directory.
+      throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
+    }
+    guard let rawHost = url.host(), !rawHost.isEmpty else {
+      throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
+    }
+    let host = rawHost.lowercased()
+    let authority: String
+    if let port = url.port, port != defaultPort(for: scheme) {
+      authority = "\(host):\(port)"
+    } else {
+      authority = host
     }
     let pathSegments = url.pathComponents.filter { $0 != "/" && !$0.isEmpty }
     guard !pathSegments.isEmpty else {
@@ -27,7 +44,7 @@ public struct RepositoryLocation: Equatable, Sendable {
     if pathSegments.contains(where: { $0 == "." || $0 == ".." }) {
       throw RepositoryLocationError.unsupportedURL(redactedDescription(of: url))
     }
-    var result = [host]
+    var result = [scheme, authority]
     result.append(contentsOf: pathSegments.dropLast())
     var repo = pathSegments.last!
     if repo.hasSuffix(".git") {
@@ -38,6 +55,16 @@ public struct RepositoryLocation: Equatable, Sendable {
     }
     result.append(repo)
     return RepositoryLocation(segments: result)
+  }
+
+  private static func defaultPort(for scheme: String) -> Int? {
+    switch scheme {
+    case "https": return 443
+    case "http": return 80
+    case "ssh": return 22
+    case "git": return 9418
+    default: return nil
+    }
   }
 
   // Strip userinfo (token:secret@) before rendering a URL into a user-visible

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -42,10 +42,11 @@ enum LexiconSource {
 }
 
 // Move a checkout from the legacy `<checkoutDir>/<repo>` location to the new
-// `<checkoutDir>/<host>/<...path...>/<repo>` layout and rewrite its `origin`
-// remote so future fetches honor the configured `remoteURL`. No-op when the
-// new path already holds a valid working copy, when something else is occupying
-// the new path, or when the legacy path is missing / isn't a real working copy.
+// `<checkoutDir>/<scheme>/<host>/<...path...>/<repo>` layout and rewrite its
+// `origin` remote so future fetches honor the configured `remoteURL`. No-op
+// when the new path already holds a valid working copy, when something else is
+// occupying the new path, or when the legacy path is missing / isn't a real
+// working copy.
 func migrateLegacyCheckout(legacyURL: URL, newURL: URL, remoteURL: URL) throws {
   if GitRepositoryProvider.workingCopyExists(at: newURL.path()) { return }
   // If the new path is already occupied by something that isn't a working copy

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -33,6 +33,14 @@ public func lockFileURL(packageRootURL: URL) -> URL {
   packageRootURL.appending(component: ".atproto-lock.json")
 }
 
+// Where a lexicon dependency's files come from. Remote dependencies are
+// cloned into `.lexicons/checkouts/`; local dependencies (`file://`) skip
+// git entirely and are read directly from disk.
+enum LexiconSource {
+  case remote(checkoutURL: URL)
+  case local(directoryURL: URL)
+}
+
 // Move a checkout from the legacy `<checkoutDir>/<repo>` location to the new
 // `<checkoutDir>/<host>/<...path...>/<repo>` layout and rewrite its `origin`
 // remote so future fetches honor the configured `remoteURL`. No-op when the
@@ -64,18 +72,22 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
   let lexiconsDirectory = lexiconsDirectoryURL(packageRootURL: rootURL)
   let lockFileURL = lockFileURL(packageRootURL: rootURL)
 
-  // Resolve every dependency to its checkout path and run the legacy-layout
-  // migration up front, before the originHash fast-path. Otherwise an unchanged
-  // configuration would let stale `<checkoutDir>/<repo>` directories live on
-  // indefinitely after this upgrade.
-  let preparedDependencies: [(LexiconDependency, URL)] = try config.dependencies.map { dependency in
+  // Resolve every dependency to its source (remote checkout or local path) and
+  // run the legacy-layout migration up front, before the originHash fast-path.
+  // Otherwise an unchanged configuration would let stale `<checkoutDir>/<repo>`
+  // directories live on indefinitely after this upgrade.
+  let preparedDependencies: [(LexiconDependency, LexiconSource)] = try config.dependencies.map {
+    dependency in
+    if dependency.location.scheme == "file" {
+      return (dependency, .local(directoryURL: URL(fileURLWithPath: dependency.location.path)))
+    }
     let location = try RepositoryLocation.parse(from: dependency.location)
     let destURL = checkoutDirectory.appending(path: location.segments.joined(separator: "/"))
     try migrateLegacyCheckout(
       legacyURL: checkoutDirectory.appending(component: location.segments.last!),
       newURL: destURL,
       remoteURL: dependency.location)
-    return (dependency, destURL)
+    return (dependency, .remote(checkoutURL: destURL))
   }
 
   let lexiconsIsExisting = FileManager.default.fileExists(atPath: lexiconsDirectory.path())
@@ -90,45 +102,69 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
   }
   try FileManager.default.createDirectory(at: lexiconsDirectory, withIntermediateDirectories: true)
   var resolvedDendencies = [ResolvedLexiconDependency]()
-  for (dependency, destURL) in preparedDependencies {
-    let clone: GitRepository
-    if !GitRepositoryProvider.workingCopyExists(at: destURL.path()) {
-      try FileManager.default.createDirectory(
-        at: destURL.deletingLastPathComponent(),
-        withIntermediateDirectories: true)
-      clone = try GitRepositoryProvider.createWorkingCopy(
-        sourcePath: dependency.location.absoluteString,
-        at: destURL.path())
-    } else {
-      clone = GitRepositoryProvider.openWorkingCopy(at: destURL.path())
-      try clone.fetch()
-    }
-
+  for (dependency, source) in preparedDependencies {
+    let srcRootURL: URL
     let revision: String
-    switch dependency.state {
-    case .tag(let tag):
-      try clone.checkout(tag: tag)
-      revision = try clone.resolveRevision(tag: tag)
-    case .revision(let identifier):
-      revision = try clone.resolveRevision(identifier: identifier)
-      try clone.checkout(revision: revision)
+    switch source {
+    case .local(let directoryURL):
+      // Local dependencies skip clone/fetch and ignore `dependency.state`; the
+      // lockfile records a sentinel revision so the schema stays valid.
+      srcRootURL = directoryURL
+      revision = "local"
+    case .remote(let destURL):
+      let clone: GitRepository
+      if !GitRepositoryProvider.workingCopyExists(at: destURL.path()) {
+        try FileManager.default.createDirectory(
+          at: destURL.deletingLastPathComponent(),
+          withIntermediateDirectories: true)
+        clone = try GitRepositoryProvider.createWorkingCopy(
+          sourcePath: dependency.location.absoluteString,
+          at: destURL.path())
+      } else {
+        clone = GitRepositoryProvider.openWorkingCopy(at: destURL.path())
+        try clone.fetch()
+      }
+      switch dependency.state {
+      case .tag(let tag):
+        try clone.checkout(tag: tag)
+        revision = try clone.resolveRevision(tag: tag)
+      case .revision(let identifier):
+        revision = try clone.resolveRevision(identifier: identifier)
+        try clone.checkout(revision: revision)
+      }
+      srcRootURL = destURL
     }
     resolvedDendencies.append(.init(config: dependency, revision: revision))
 
+    // For local dependencies install lexicons as symlinks so edits to the
+    // source files are visible to the next codegen pass without re-running
+    // fetch; for remote ones the checkout is the only stable copy so we copy.
+    let install: (URL, URL) throws -> Void
+    switch source {
+    case .local:
+      install = { src, dst in
+        if FileManager.default.fileExists(atPath: dst.path()) { return }
+        try FileManager.default.createSymbolicLink(at: dst, withDestinationURL: src)
+      }
+    case .remote:
+      install = { src, dst in
+        if FileManager.default.fileExists(atPath: dst.path()) { return }
+        try FileManager.default.copyItem(at: src, to: dst)
+      }
+    }
+
     for lexicon in dependency.lexicons {
       if let nsIds = lexicon.nsIds {
-        let srcBaseURL = destURL.appending(component: lexicon.rootPath)
+        let srcBaseURL = srcRootURL.appending(component: lexicon.rootPath)
         for nsId in nsIds {
           let dest = nsId.url(from: lexiconsDirectory)
           if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().path(percentEncoded: false)) {
             try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
           }
-          try FileManager.default.copyItem(
-            at: nsId.url(from: srcBaseURL),
-            to: dest)
+          try install(nsId.url(from: srcBaseURL), dest)
         }
       } else {
-        let srcBaseURL = destURL.appending(component: lexicon.path)
+        let srcBaseURL = srcRootURL.appending(component: lexicon.path)
         for name in try FileManager.default.contentsOfDirectory(atPath: srcBaseURL.path()) {
           let srcURL = srcBaseURL.appending(component: name)
           let lexiconBaseDirectory = lexiconsDirectory.appending(component: lexicon.prefix.replacingOccurrences(of: ".", with: "/"))
@@ -136,9 +172,7 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
             try FileManager.default.createDirectory(at: lexiconBaseDirectory, withIntermediateDirectories: true)
           }
           let lexiconDirectory = lexiconBaseDirectory.appending(component: name)
-          if !FileManager.default.fileExists(atPath: lexiconDirectory.path()) {
-            try FileManager.default.copyItem(at: srcURL, to: lexiconDirectory)
-          }
+          try install(srcURL, lexiconDirectory)
         }
       }
     }

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -33,6 +33,27 @@ public func lockFileURL(packageRootURL: URL) -> URL {
   packageRootURL.appending(component: ".atproto-lock.json")
 }
 
+// Move a checkout from the legacy `<checkoutDir>/<repo>` location to the new
+// `<checkoutDir>/<host>/<...path...>/<repo>` layout and rewrite its `origin`
+// remote so future fetches honor the configured `remoteURL`. No-op when the
+// new path already holds a valid working copy, when something else is occupying
+// the new path, or when the legacy path is missing / isn't a real working copy.
+func migrateLegacyCheckout(legacyURL: URL, newURL: URL, remoteURL: URL) throws {
+  if GitRepositoryProvider.workingCopyExists(at: newURL.path()) { return }
+  // If the new path is already occupied by something that isn't a working copy
+  // (interrupted prior mv, manual stub, leftover state), don't overwrite it
+  // here — the downstream `git clone` will surface a clear error instead of us
+  // silently destroying user data.
+  if FileManager.default.fileExists(atPath: newURL.path()) { return }
+  guard GitRepositoryProvider.workingCopyExists(at: legacyURL.path()) else { return }
+  try FileManager.default.createDirectory(
+    at: newURL.deletingLastPathComponent(),
+    withIntermediateDirectories: true)
+  try FileManager.default.moveItem(at: legacyURL, to: newURL)
+  let moved = GitRepositoryProvider.openWorkingCopy(at: newURL.path())
+  _ = try moved.callGit(["remote", "set-url", "origin", remoteURL.absoluteString])
+}
+
 public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig {
   let data = try Data(contentsOf: configurationURL)
   let originHash = SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
@@ -42,6 +63,21 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
   let checkoutDirectory = checkoutDirectoryURL(packageRootURL: rootURL)
   let lexiconsDirectory = lexiconsDirectoryURL(packageRootURL: rootURL)
   let lockFileURL = lockFileURL(packageRootURL: rootURL)
+
+  // Resolve every dependency to its checkout path and run the legacy-layout
+  // migration up front, before the originHash fast-path. Otherwise an unchanged
+  // configuration would let stale `<checkoutDir>/<repo>` directories live on
+  // indefinitely after this upgrade.
+  let preparedDependencies: [(LexiconDependency, URL)] = try config.dependencies.map { dependency in
+    let location = try RepositoryLocation.parse(from: dependency.location)
+    let destURL = checkoutDirectory.appending(path: location.segments.joined(separator: "/"))
+    try migrateLegacyCheckout(
+      legacyURL: checkoutDirectory.appending(component: location.segments.last!),
+      newURL: destURL,
+      remoteURL: dependency.location)
+    return (dependency, destURL)
+  }
+
   let lexiconsIsExisting = FileManager.default.fileExists(atPath: lexiconsDirectory.path())
   if lexiconsIsExisting,
     let resolvedStore = try? LexiconsStore.load(from: lockFileURL),
@@ -54,14 +90,12 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
   }
   try FileManager.default.createDirectory(at: lexiconsDirectory, withIntermediateDirectories: true)
   var resolvedDendencies = [ResolvedLexiconDependency]()
-  for dependency in config.dependencies {
-    var name = dependency.location.lastPathComponent
-    if name.hasSuffix(".git") {
-      name = String(name.dropLast(4))
-    }
-    let destURL = checkoutDirectory.appending(component: name)
+  for (dependency, destURL) in preparedDependencies {
     let clone: GitRepository
     if !GitRepositoryProvider.workingCopyExists(at: destURL.path()) {
+      try FileManager.default.createDirectory(
+        at: destURL.deletingLastPathComponent(),
+        withIntermediateDirectories: true)
       clone = try GitRepositoryProvider.createWorkingCopy(
         sourcePath: dependency.location.absoluteString,
         at: destURL.path())

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -41,6 +41,34 @@ enum LexiconSource {
   case local(directoryURL: URL)
 }
 
+public enum LexiconConfigError: Error, CustomStringConvertible, Equatable {
+  case unsafeLexiconSubpath(field: String, value: String)
+
+  public var description: String {
+    switch self {
+    case .unsafeLexiconSubpath(let field, let value):
+      return
+        "Invalid lexicon \(field) \"\(value)\": must be a relative path with no `..`, `.`, or absolute prefix."
+    }
+  }
+}
+
+// Reject `..`, `.`, and absolute paths in any lexicon-supplied sub-path so a
+// malicious or typo-ed `.atproto.json` cannot escape `.lexicons/lexicons/` or
+// the dependency's source root when joined via `appending(component:)`.
+func validatedLexiconSubpath(_ raw: String, field: String) throws -> String {
+  if raw.hasPrefix("/") {
+    throw LexiconConfigError.unsafeLexiconSubpath(field: field, value: raw)
+  }
+  let segments = raw.split(separator: "/", omittingEmptySubsequences: true).map(String.init)
+  for segment in segments {
+    if segment == "." || segment == ".." {
+      throw LexiconConfigError.unsafeLexiconSubpath(field: field, value: raw)
+    }
+  }
+  return segments.joined(separator: "/")
+}
+
 // Move a checkout from the legacy `<checkoutDir>/<repo>` location to the new
 // `<checkoutDir>/<scheme>/<host>/<...path...>/<repo>` layout and rewrite its
 // `origin` remote so future fetches honor the configured `remoteURL`. No-op
@@ -155,8 +183,12 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
     }
 
     for lexicon in dependency.lexicons {
+      let safePrefix = try validatedLexiconSubpath(
+        lexicon.prefix.replacingOccurrences(of: ".", with: "/"),
+        field: "prefix")
       if let nsIds = lexicon.nsIds {
-        let srcBaseURL = srcRootURL.appending(component: lexicon.rootPath)
+        let safeRootPath = try validatedLexiconSubpath(lexicon.rootPath, field: "rootPath")
+        let srcBaseURL = srcRootURL.appending(component: safeRootPath)
         for nsId in nsIds {
           let dest = nsId.url(from: lexiconsDirectory)
           if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().path(percentEncoded: false)) {
@@ -165,10 +197,11 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
           try install(nsId.url(from: srcBaseURL), dest)
         }
       } else {
-        let srcBaseURL = srcRootURL.appending(component: lexicon.path)
+        let safePath = try validatedLexiconSubpath(lexicon.path, field: "path")
+        let srcBaseURL = srcRootURL.appending(component: safePath)
         for name in try FileManager.default.contentsOfDirectory(atPath: srcBaseURL.path()) {
           let srcURL = srcBaseURL.appending(component: name)
-          let lexiconBaseDirectory = lexiconsDirectory.appending(component: lexicon.prefix.replacingOccurrences(of: ".", with: "/"))
+          let lexiconBaseDirectory = lexiconsDirectory.appending(component: safePrefix)
           if !FileManager.default.fileExists(atPath: lexiconBaseDirectory.path()) {
             try FileManager.default.createDirectory(at: lexiconBaseDirectory, withIntermediateDirectories: true)
           }

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -41,6 +41,13 @@ enum LexiconSource {
   case local(directoryURL: URL)
 }
 
+// Case-insensitive `file://` check, kept in sync with `RepositoryLocation.parse`
+// which also lowercases the scheme before comparing. Used both by the dependency
+// router and by the originHash fast-path so the two never disagree.
+func isLocalDependency(_ location: URL) -> Bool {
+  location.scheme?.lowercased() == "file"
+}
+
 public enum LexiconConfigError: Error, CustomStringConvertible, Equatable {
   case unsafeLexiconSubpath(field: String, value: String)
 
@@ -122,7 +129,7 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
   // directories live on indefinitely after this upgrade.
   let preparedDependencies: [(LexiconDependency, LexiconSource)] = try config.dependencies.map {
     dependency in
-    if dependency.location.scheme == "file" {
+    if isLocalDependency(dependency.location) {
       return (dependency, .local(directoryURL: URL(fileURLWithPath: dependency.location.path)))
     }
     let location = try RepositoryLocation.parse(from: dependency.location)
@@ -134,8 +141,18 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
     return (dependency, .remote(checkoutURL: destURL))
   }
 
+  // Local dependencies are mutable — the user can edit the source tree
+  // between runs and a previous swift-atproto release may have written a
+  // lockfile that still treats them as remote. Skip the originHash fast-path
+  // whenever any dep is local so the install loop always re-runs and
+  // rewrites `revision = "local"`.
+  let hasLocalDependency = preparedDependencies.contains { _, source in
+    if case .local = source { return true }
+    return false
+  }
   let lexiconsIsExisting = FileManager.default.fileExists(atPath: lexiconsDirectory.path())
-  if lexiconsIsExisting,
+  if !hasLocalDependency,
+    lexiconsIsExisting,
     let resolvedStore = try? LexiconsStore.load(from: lockFileURL),
     originHash == resolvedStore.originHash
   {

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -88,7 +88,22 @@ func migrateLegacyCheckout(legacyURL: URL, newURL: URL, remoteURL: URL) throws {
     withIntermediateDirectories: true)
   try FileManager.default.moveItem(at: legacyURL, to: newURL)
   let moved = GitRepositoryProvider.openWorkingCopy(at: newURL.path())
-  _ = try moved.callGit(["remote", "set-url", "origin", remoteURL.absoluteString])
+  // Strip userinfo / query / fragment before writing the URL into `.git/config`
+  // so a `https://oauth2:ghp_xxx@…` location from `.atproto.json` never lands
+  // on disk in plaintext. The credential helper can still attach auth at fetch
+  // time via the redacted host.
+  _ = try moved.callGit(["remote", "set-url", "origin", redactedRemoteOrigin(from: remoteURL)])
+}
+
+func redactedRemoteOrigin(from url: URL) -> String {
+  guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+    return url.absoluteString
+  }
+  components.user = nil
+  components.password = nil
+  components.query = nil
+  components.fragment = nil
+  return components.string ?? url.absoluteString
 }
 
 public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -17,20 +17,37 @@ public func main(outdir outdirBaseURL: URL, path: String, generate: GenerateOpti
 }
 
 func collectJSONFileURLs(at baseURL: URL) -> [URL] {
+  // `FileManager.enumerator` does not traverse symbolic links, so it would
+  // miss local lexicon trees installed under `.lexicons/lexicons/` as symlinks.
+  // Walk the tree manually instead, resolving each entry's target while
+  // keeping the logical path rooted at `baseURL` so `prefix(baseURL:)` still
+  // works on the returned URLs.
   var fileURLs = [URL]()
-  if let enumerator = FileManager.default.enumerator(at: baseURL, includingPropertiesForKeys: [.isRegularFileKey], options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
-    for case let fileUrl as URL in enumerator {
-      do {
-        let fileAttributes = try fileUrl.resourceValues(forKeys: [.isRegularFileKey])
-        if fileAttributes.isRegularFile!, fileUrl.pathExtension == "json" {
-          fileURLs.append(fileUrl)
-        }
-      } catch {
-        print(error, fileUrl)
-      }
+  walkLexicons(at: baseURL, into: &fileURLs)
+  return fileURLs
+}
+
+private func walkLexicons(at url: URL, into result: inout [URL]) {
+  let target = url.resolvingSymlinksInPath()
+  guard
+    let entries = try? FileManager.default.contentsOfDirectory(
+      at: target,
+      includingPropertiesForKeys: [.isDirectoryKey],
+      options: [.skipsHiddenFiles, .skipsPackageDescendants])
+  else { return }
+  for entry in entries {
+    let logical = url.appending(component: entry.lastPathComponent)
+    let physical = entry.resolvingSymlinksInPath()
+    var isDir: ObjCBool = false
+    guard FileManager.default.fileExists(atPath: physical.path, isDirectory: &isDir) else {
+      continue
+    }
+    if isDir.boolValue {
+      walkLexicons(at: logical, into: &result)
+    } else if logical.pathExtension == "json" {
+      result.append(logical)
     }
   }
-  return fileURLs
 }
 
 func decodeSchemasByPrefix(from fileURLs: [URL], baseURL: URL) async throws -> [String: [Schema]] {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -23,12 +23,18 @@ func collectJSONFileURLs(at baseURL: URL) -> [URL] {
   // keeping the logical path rooted at `baseURL` so `prefix(baseURL:)` still
   // works on the returned URLs.
   var fileURLs = [URL]()
-  walkLexicons(at: baseURL, into: &fileURLs)
+  var visited = Set<String>()
+  walkLexicons(at: baseURL, visited: &visited, into: &fileURLs)
   return fileURLs
 }
 
-private func walkLexicons(at url: URL, into result: inout [URL]) {
+private func walkLexicons(at url: URL, visited: inout Set<String>, into result: inout [URL]) {
   let target = url.resolvingSymlinksInPath()
+  // Detect symlink cycles (and reentry into a shared subtree) by remembering
+  // each directory's resolved physical path. Without this guard a `foo -> .`
+  // symlink would recurse until the stack overflows.
+  let visitedKey = target.standardizedFileURL.path
+  guard visited.insert(visitedKey).inserted else { return }
   guard
     let entries = try? FileManager.default.contentsOfDirectory(
       at: target,
@@ -43,7 +49,7 @@ private func walkLexicons(at url: URL, into result: inout [URL]) {
       continue
     }
     if isDir.boolValue {
-      walkLexicons(at: logical, into: &result)
+      walkLexicons(at: logical, visited: &visited, into: &result)
     } else if logical.pathExtension == "json" {
       result.append(logical)
     }

--- a/Tests/SourceControlTests/LocalLexiconInstallTests.swift
+++ b/Tests/SourceControlTests/LocalLexiconInstallTests.swift
@@ -1,0 +1,175 @@
+#if os(macOS) || os(Linux)
+
+  import Foundation
+  import Testing
+
+  @testable import SourceControl
+
+  struct LocalLexiconInstallTests {
+    // Helpers ----------------------------------------------------------------
+
+    private static func makeTempRoot() throws -> URL {
+      let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("swift-atproto-local-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+      return url
+    }
+
+    /// Sets up a fake project skeleton with `.atproto.json` containing `body` and an
+    /// empty source tree at `lex-src/`. Returns the configuration URL and the source root.
+    private static func makeProject(_ body: String) throws -> (config: URL, source: URL) {
+      let root = try makeTempRoot()
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+      let configURL = project.appendingPathComponent(".atproto.json")
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+      return (configURL, source)
+    }
+
+    private static func writeLexicon(at url: URL, id: String) throws {
+      try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try Data(#"{"lexicon":1,"id":"\#(id)","defs":{}}"#.utf8).write(to: url)
+    }
+
+    // Tests ------------------------------------------------------------------
+
+    @Test func localFileSchemeInstallsSymlinks() throws {
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      let lexFile = source.appendingPathComponent("lexicons/app/bsky/feed/post.json")
+      try Self.writeLexicon(at: lexFile, id: "app.bsky.feed.post")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      // For non-nsIds the installer symlinks each top-level entry of
+      // `lexicon.path`. With `path: "lexicons/app/bsky"` the only entry is `feed`,
+      // so a directory symlink lives at `.lexicons/lexicons/app/bsky/feed`.
+      let installedDir = project.appendingPathComponent(".lexicons/lexicons/app/bsky/feed")
+      let attrs = try FileManager.default.attributesOfItem(atPath: installedDir.path)
+      #expect(attrs[.type] as? FileAttributeType == .typeSymbolicLink)
+      let target = try FileManager.default.destinationOfSymbolicLink(atPath: installedDir.path)
+      #expect(target.hasSuffix("lexicons/app/bsky/feed"))
+      // The file is reachable through the symlink.
+      #expect(FileManager.default.fileExists(atPath: installedDir.appendingPathComponent("post.json").path))
+    }
+
+    @Test func rejectsLexiconPathWithParentTraversal() throws {
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      let escape = root.appendingPathComponent("escape", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: escape.appendingPathComponent("secret.json"), id: "secret")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "prefix": "evil", "path": "../escape" }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      #expect(throws: (any Error).self) {
+        _ = try main(configurationURL: configURL, outdir: nil)
+      }
+      // The escape file must never appear under .lexicons/lexicons/.
+      let installed = project.appendingPathComponent(".lexicons/lexicons/evil/secret.json")
+      #expect(!FileManager.default.fileExists(atPath: installed.path))
+    }
+
+    @Test func rejectsRootPathWithParentTraversal() throws {
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      let escape = root.appendingPathComponent("escape", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
+      // nsIds path joins as `<rootPath>/<nsid_components>.json`. So if rootPath
+      // is `../escape` and we point nsId at `secret`, the source URL becomes
+      // `<source>/../escape/secret.json`.
+      try Self.writeLexicon(at: escape.appendingPathComponent("secret.json"), id: "secret")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      // `path: "../escape/evil"` makes rootPath="../escape" (strips the prefix-as-path).
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{
+              "prefix": "evil",
+              "path": "../escape/evil",
+              "nsIds": ["secret"]
+            }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      #expect(throws: (any Error).self) {
+        _ = try main(configurationURL: configURL, outdir: nil)
+      }
+    }
+
+    @Test func rejectsAbsoluteLexiconPath() throws {
+      // Create a sibling `etc` directory inside the source root so that an
+      // absolute `/etc` path would, if URL append silently stripped the leading
+      // slash, point at real content. We assert the install rejects the path
+      // explicitly rather than relying on the missing-directory side effect.
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("etc/secret.json"), id: "secret")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "prefix": "evil", "path": "/etc" }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      #expect(throws: (any Error).self) {
+        _ = try main(configurationURL: configURL, outdir: nil)
+      }
+      // The secret must never leak into the project's lexicons directory.
+      let leaked = project.appendingPathComponent(".lexicons/lexicons/evil/secret.json")
+      #expect(!FileManager.default.fileExists(atPath: leaked.path))
+    }
+  }
+
+#endif

--- a/Tests/SourceControlTests/LocalLexiconInstallTests.swift
+++ b/Tests/SourceControlTests/LocalLexiconInstallTests.swift
@@ -1,5 +1,6 @@
 #if os(macOS) || os(Linux)
 
+  import Crypto
   import Foundation
   import Testing
 
@@ -169,6 +170,95 @@
       // The secret must never leak into the project's lexicons directory.
       let leaked = project.appendingPathComponent(".lexicons/lexicons/evil/secret.json")
       #expect(!FileManager.default.fileExists(atPath: leaked.path))
+    }
+
+    @Test func staleLockfileIsRefreshedForLocalDependency() throws {
+      // Simulates the upgrade path where an older swift-atproto wrote a lockfile
+      // with `revision = <user-supplied-sha>` for a file:// dep (because file://
+      // was treated as remote), then the user upgrades to the version with
+      // file:// → .local routing. The originHash matches the current config so
+      // the fast-path would normally return early and leave the stale revision
+      // in place; with the bypass, `main()` must re-run install and rewrite the
+      // revision to "local".
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/app/bsky/feed/post.json"), id: "app.bsky.feed.post")
+
+      let configBody = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "state": { "revision": "stale-sha" }
+          }]
+        }
+        """
+      let configURL = project.appendingPathComponent(".atproto.json")
+      try configBody.write(to: configURL, atomically: true, encoding: .utf8)
+
+      // Pre-seed the lockfile with the *same* originHash as the config above
+      // and a revision that lies (`"stale-sha"` instead of `"local"`).
+      let configData = try Data(contentsOf: configURL)
+      let originHash = SHA256.hash(data: configData).map { String(format: "%02x", $0) }.joined()
+      let staleLockfile = """
+        {
+          "originHash": "\(originHash)",
+          "generator": "0.0.0-stale",
+          "module": "Sources/Out",
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "state": { "revision": "stale-sha" }
+          }]
+        }
+        """
+      let lockfileURL = project.appendingPathComponent(".atproto-lock.json")
+      try staleLockfile.write(to: lockfileURL, atomically: true, encoding: .utf8)
+      // The fast-path also requires `.lexicons/lexicons/` to exist on disk.
+      try FileManager.default.createDirectory(
+        at: project.appendingPathComponent(".lexicons/lexicons", isDirectory: true),
+        withIntermediateDirectories: true)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      let refreshed = try LexiconsStore.load(from: lockfileURL)
+      let localDep = refreshed.dependencies.first { $0.location.scheme?.lowercased() == "file" }
+      #expect(localDep?.state.revision == "local")
+    }
+
+    @Test func uppercaseFileSchemeIsTreatedAsLocal() throws {
+      // Mirrors `localFileSchemeInstallsSymlinks` but with a `FILE://` scheme to
+      // pin the case-insensitive contract between misc.swift and
+      // RepositoryLocation.parse (which already lowercases).
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/app/bsky/feed/post.json"), id: "app.bsky.feed.post")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "FILE://\(source.path)",
+            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      let installedDir = project.appendingPathComponent(".lexicons/lexicons/app/bsky/feed")
+      let attrs = try FileManager.default.attributesOfItem(atPath: installedDir.path)
+      #expect(attrs[.type] as? FileAttributeType == .typeSymbolicLink)
     }
   }
 

--- a/Tests/SourceControlTests/MigrationTests.swift
+++ b/Tests/SourceControlTests/MigrationTests.swift
@@ -1,0 +1,153 @@
+#if os(macOS) || os(Linux)
+
+  import Foundation
+  import Testing
+
+  @testable import SourceControl
+
+  struct MigrationTests {
+    // Helpers ----------------------------------------------------------------
+
+    /// Creates a temporary directory and registers it for removal at the end of the test.
+    private static func makeTempDir() throws -> URL {
+      let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        .appendingPathComponent("swift-atproto-migration-\(UUID().uuidString)", isDirectory: true)
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+      return url
+    }
+
+    /// Creates a bare git repository at `bareURL` so the working-copy clone has something
+    /// to point its `origin` at.
+    @discardableResult
+    private static func makeBareSource(at bareURL: URL) throws -> URL {
+      try FileManager.default.createDirectory(at: bareURL, withIntermediateDirectories: true)
+      _ = try GitShellHelper.run(["init", "--bare", "-q", bareURL.path])
+      return bareURL
+    }
+
+    /// Creates a non-bare working copy at `cloneURL` whose origin points at `bareURL`.
+    private static func makeWorkingCopy(at cloneURL: URL, from bareURL: URL) throws {
+      try FileManager.default.createDirectory(at: cloneURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+      try GitRepositoryProvider.clone(origin: bareURL.path, destination: cloneURL.path, options: ["--no-checkout"])
+    }
+
+    private static func readOriginUrl(at workingCopy: URL) throws -> String {
+      let repo = GitRepositoryProvider.openWorkingCopy(at: workingCopy.path)
+      let raw = try repo.callGit(["config", "--get", "remote.origin.url"])
+      return raw.trimmingCharacters(in: .newlines)
+    }
+
+    // Tests ------------------------------------------------------------------
+
+    @Test func migratesLegacyWorkingCopyToNewLayout() throws {
+      let root = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      let bare = try Self.makeBareSource(at: root.appendingPathComponent("source.git", isDirectory: true))
+      let legacy = root.appendingPathComponent("checkouts/repo", isDirectory: true)
+      try Self.makeWorkingCopy(at: legacy, from: bare)
+
+      let newURL = root.appendingPathComponent("checkouts/example.com/owner/repo", isDirectory: true)
+      let remote = URL(string: "https://example.com/owner/repo.git")!
+      try migrateLegacyCheckout(legacyURL: legacy, newURL: newURL, remoteURL: remote)
+
+      #expect(GitRepositoryProvider.workingCopyExists(at: newURL.path))
+      #expect(!FileManager.default.fileExists(atPath: legacy.path))
+      let originUrl = try Self.readOriginUrl(at: newURL)
+      #expect(originUrl == "https://example.com/owner/repo.git")
+    }
+
+    @Test func skipsWhenNewLayoutAlreadyHasWorkingCopy() throws {
+      let root = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      let bareA = try Self.makeBareSource(at: root.appendingPathComponent("source-a.git", isDirectory: true))
+      let bareB = try Self.makeBareSource(at: root.appendingPathComponent("source-b.git", isDirectory: true))
+
+      let legacy = root.appendingPathComponent("checkouts/repo", isDirectory: true)
+      try Self.makeWorkingCopy(at: legacy, from: bareA)
+
+      let newURL = root.appendingPathComponent("checkouts/example.com/owner/repo", isDirectory: true)
+      try Self.makeWorkingCopy(at: newURL, from: bareB)
+
+      let remote = URL(string: "https://example.com/owner/repo.git")!
+      try migrateLegacyCheckout(legacyURL: legacy, newURL: newURL, remoteURL: remote)
+
+      // Both directories must remain untouched.
+      #expect(GitRepositoryProvider.workingCopyExists(at: newURL.path))
+      #expect(GitRepositoryProvider.workingCopyExists(at: legacy.path))
+    }
+
+    @Test func skipsWhenLegacyIsNotAWorkingCopy() throws {
+      let root = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      let legacy = root.appendingPathComponent("checkouts/repo", isDirectory: true)
+      try FileManager.default.createDirectory(at: legacy, withIntermediateDirectories: true)
+      try Data("hello".utf8).write(to: legacy.appendingPathComponent("file.txt"))
+
+      let newURL = root.appendingPathComponent("checkouts/example.com/owner/repo", isDirectory: true)
+      let remote = URL(string: "https://example.com/owner/repo.git")!
+      try migrateLegacyCheckout(legacyURL: legacy, newURL: newURL, remoteURL: remote)
+
+      // Legacy untouched; nothing created at new path.
+      #expect(FileManager.default.fileExists(atPath: legacy.appendingPathComponent("file.txt").path))
+      #expect(!FileManager.default.fileExists(atPath: newURL.path))
+    }
+
+    @Test func refusesToOverwriteNonWorkingCopyAtNewPath() throws {
+      let root = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      let bare = try Self.makeBareSource(at: root.appendingPathComponent("source.git", isDirectory: true))
+      let legacy = root.appendingPathComponent("checkouts/repo", isDirectory: true)
+      try Self.makeWorkingCopy(at: legacy, from: bare)
+
+      let newURL = root.appendingPathComponent("checkouts/example.com/owner/repo", isDirectory: true)
+      try FileManager.default.createDirectory(at: newURL, withIntermediateDirectories: true)
+      try Data("junk".utf8).write(to: newURL.appendingPathComponent("placeholder"))
+
+      let remote = URL(string: "https://example.com/owner/repo.git")!
+      try migrateLegacyCheckout(legacyURL: legacy, newURL: newURL, remoteURL: remote)
+
+      // Legacy preserved; new path's junk preserved.
+      #expect(GitRepositoryProvider.workingCopyExists(at: legacy.path))
+      #expect(FileManager.default.fileExists(atPath: newURL.appendingPathComponent("placeholder").path))
+    }
+
+    @Test func idempotentReRunAfterSuccessfulMove() throws {
+      let root = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      let bare = try Self.makeBareSource(at: root.appendingPathComponent("source.git", isDirectory: true))
+      let legacy = root.appendingPathComponent("checkouts/repo", isDirectory: true)
+      try Self.makeWorkingCopy(at: legacy, from: bare)
+
+      let newURL = root.appendingPathComponent("checkouts/example.com/owner/repo", isDirectory: true)
+      let remote = URL(string: "https://example.com/owner/repo.git")!
+      try migrateLegacyCheckout(legacyURL: legacy, newURL: newURL, remoteURL: remote)
+      // Second invocation with the legacy now missing must not throw.
+      try migrateLegacyCheckout(legacyURL: legacy, newURL: newURL, remoteURL: remote)
+      #expect(GitRepositoryProvider.workingCopyExists(at: newURL.path))
+    }
+
+    @Test func setUrlUsesRedactedRemote() throws {
+      let root = try Self.makeTempDir()
+      defer { try? FileManager.default.removeItem(at: root) }
+
+      let bare = try Self.makeBareSource(at: root.appendingPathComponent("source.git", isDirectory: true))
+      let legacy = root.appendingPathComponent("checkouts/repo", isDirectory: true)
+      try Self.makeWorkingCopy(at: legacy, from: bare)
+
+      let newURL = root.appendingPathComponent("checkouts/example.com/owner/repo", isDirectory: true)
+      let remote = URL(string: "https://oauth2:ghp_secret@example.com/owner/repo.git")!
+      try migrateLegacyCheckout(legacyURL: legacy, newURL: newURL, remoteURL: remote)
+
+      let originUrl = try Self.readOriginUrl(at: newURL)
+      #expect(!originUrl.contains("ghp_secret"))
+      #expect(!originUrl.contains("oauth2"))
+      #expect(originUrl.contains("example.com/owner/repo.git"))
+    }
+  }
+
+#endif

--- a/Tests/SourceControlTests/RepositoryLocationTests.swift
+++ b/Tests/SourceControlTests/RepositoryLocationTests.swift
@@ -9,61 +9,61 @@
     @Test func httpsWithGitSuffix() throws {
       let url = URL(string: "https://example.com/owner/repo.git")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "owner", "repo"]))
     }
 
     @Test func httpsWithoutGitSuffix() throws {
       let url = URL(string: "https://example.com/owner/repo")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "owner", "repo"]))
     }
 
     @Test func httpsWithTrailingSlash() throws {
       let url = URL(string: "https://example.com/owner/repo/")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "owner", "repo"]))
     }
 
     @Test func preservesCase() throws {
       let url = URL(string: "https://example.com/Owner/Repo.git")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "Owner", "Repo"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "Owner", "Repo"]))
     }
 
     @Test func singleSegmentPath() throws {
       let url = URL(string: "https://git.example.com/lex.git")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["git.example.com", "lex"]))
+      #expect(location == RepositoryLocation(segments: ["https", "git.example.com", "lex"]))
     }
 
     @Test func multiLevelSubgroup() throws {
       let url = URL(string: "https://example.com/group/sub/repo.git")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "group", "sub", "repo"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "group", "sub", "repo"]))
     }
 
     @Test func stripsOnlyLowercaseDotGit() throws {
       let url = URL(string: "https://example.com/owner/repo.GIT")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo.GIT"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "owner", "repo.GIT"]))
     }
 
     @Test func stripsSingleDotGit() throws {
       let url = URL(string: "https://example.com/owner/repo.git.git")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo.git"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "owner", "repo.git"]))
     }
 
     @Test func ownerEqualsRepoIsAllowed() throws {
       let url = URL(string: "https://example.com/foo/foo.git")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "foo", "foo"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "foo", "foo"]))
     }
 
     @Test func userinfoStrippedButPathParses() throws {
       let url = URL(string: "https://oauth2:ghp_secret@example.com/owner/repo.git")!
       let location = try RepositoryLocation.parse(from: url)
-      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+      #expect(location == RepositoryLocation(segments: ["https", "example.com", "owner", "repo"]))
     }
 
     @Test func throwsWhenPathIsEmpty() {
@@ -105,6 +105,63 @@
         #expect(!message.contains("oauth2"))
       } catch {
         Issue.record("unexpected error type: \(type(of: error))")
+      }
+    }
+
+    @Test func hostIsCaseFolded() throws {
+      let lower = try RepositoryLocation.parse(from: URL(string: "https://example.com/owner/repo.git")!)
+      let upper = try RepositoryLocation.parse(from: URL(string: "https://EXAMPLE.com/owner/repo.git")!)
+      let mixed = try RepositoryLocation.parse(from: URL(string: "https://GitHub.com/owner/repo.git")!)
+      #expect(lower == upper)
+      #expect(mixed.segments == ["https", "github.com", "owner", "repo"])
+    }
+
+    @Test func differentSchemesAreDistinct() throws {
+      let https = try RepositoryLocation.parse(from: URL(string: "https://example.com/owner/repo")!)
+      let http = try RepositoryLocation.parse(from: URL(string: "http://example.com/owner/repo")!)
+      let ssh = try RepositoryLocation.parse(from: URL(string: "ssh://git@example.com/owner/repo.git")!)
+      #expect(https != http)
+      #expect(https != ssh)
+      #expect(http != ssh)
+    }
+
+    @Test func nonStandardPortDistinguishesCheckout() throws {
+      let plain = try RepositoryLocation.parse(from: URL(string: "https://example.com/owner/repo.git")!)
+      let custom = try RepositoryLocation.parse(from: URL(string: "https://example.com:8443/owner/repo.git")!)
+      #expect(plain != custom)
+    }
+
+    @Test func defaultHttpsPortIsOmitted() throws {
+      let plain = try RepositoryLocation.parse(from: URL(string: "https://example.com/owner/repo.git")!)
+      let withDefault = try RepositoryLocation.parse(from: URL(string: "https://example.com:443/owner/repo.git")!)
+      #expect(plain == withDefault)
+    }
+
+    @Test func defaultHttpPortIsOmitted() throws {
+      let plain = try RepositoryLocation.parse(from: URL(string: "http://example.com/owner/repo.git")!)
+      let withDefault = try RepositoryLocation.parse(from: URL(string: "http://example.com:80/owner/repo.git")!)
+      #expect(plain == withDefault)
+    }
+
+    @Test func percentEncodedDotDotIsRejected() {
+      let url = URL(string: "https://example.com/owner/%2e%2e/escape/repo")!
+      #expect(throws: RepositoryLocationError.self) {
+        _ = try RepositoryLocation.parse(from: url)
+      }
+    }
+
+    @Test func scpStyleUrlIsRejected() {
+      // `git@example.com:owner/repo.git` parses with host=nil and is rejected.
+      let url = URL(string: "git@example.com:owner/repo.git")!
+      #expect(throws: RepositoryLocationError.self) {
+        _ = try RepositoryLocation.parse(from: url)
+      }
+    }
+
+    @Test func bareGitOnlyRepoSegmentIsRejected() {
+      let url = URL(string: "https://example.com/owner/.git")!
+      #expect(throws: RepositoryLocationError.self) {
+        _ = try RepositoryLocation.parse(from: url)
       }
     }
   }

--- a/Tests/SourceControlTests/RepositoryLocationTests.swift
+++ b/Tests/SourceControlTests/RepositoryLocationTests.swift
@@ -1,0 +1,112 @@
+#if os(macOS) || os(Linux)
+
+  import Foundation
+  import Testing
+
+  @testable import SourceControl
+
+  struct RepositoryLocationTests {
+    @Test func httpsWithGitSuffix() throws {
+      let url = URL(string: "https://example.com/owner/repo.git")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+    }
+
+    @Test func httpsWithoutGitSuffix() throws {
+      let url = URL(string: "https://example.com/owner/repo")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+    }
+
+    @Test func httpsWithTrailingSlash() throws {
+      let url = URL(string: "https://example.com/owner/repo/")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+    }
+
+    @Test func preservesCase() throws {
+      let url = URL(string: "https://example.com/Owner/Repo.git")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "Owner", "Repo"]))
+    }
+
+    @Test func singleSegmentPath() throws {
+      let url = URL(string: "https://git.example.com/lex.git")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["git.example.com", "lex"]))
+    }
+
+    @Test func multiLevelSubgroup() throws {
+      let url = URL(string: "https://example.com/group/sub/repo.git")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "group", "sub", "repo"]))
+    }
+
+    @Test func stripsOnlyLowercaseDotGit() throws {
+      let url = URL(string: "https://example.com/owner/repo.GIT")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo.GIT"]))
+    }
+
+    @Test func stripsSingleDotGit() throws {
+      let url = URL(string: "https://example.com/owner/repo.git.git")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo.git"]))
+    }
+
+    @Test func ownerEqualsRepoIsAllowed() throws {
+      let url = URL(string: "https://example.com/foo/foo.git")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "foo", "foo"]))
+    }
+
+    @Test func userinfoStrippedButPathParses() throws {
+      let url = URL(string: "https://oauth2:ghp_secret@example.com/owner/repo.git")!
+      let location = try RepositoryLocation.parse(from: url)
+      #expect(location == RepositoryLocation(segments: ["example.com", "owner", "repo"]))
+    }
+
+    @Test func throwsWhenPathIsEmpty() {
+      let url = URL(string: "https://example.com/")!
+      #expect(throws: RepositoryLocationError.self) {
+        _ = try RepositoryLocation.parse(from: url)
+      }
+    }
+
+    @Test func throwsForFileURL() {
+      let url = URL(string: "file:///tmp/repo")!
+      #expect(throws: RepositoryLocationError.self) {
+        _ = try RepositoryLocation.parse(from: url)
+      }
+    }
+
+    @Test func throwsOnDotDotSegment() {
+      let url = URL(string: "https://example.com/owner/../escape/repo")!
+      #expect(throws: RepositoryLocationError.self) {
+        _ = try RepositoryLocation.parse(from: url)
+      }
+    }
+
+    @Test func throwsOnDotSegment() {
+      let url = URL(string: "https://example.com/owner/./repo")!
+      #expect(throws: RepositoryLocationError.self) {
+        _ = try RepositoryLocation.parse(from: url)
+      }
+    }
+
+    @Test func errorRedactsUserinfo() {
+      let url = URL(string: "https://oauth2:ghp_secret@example.com/")!
+      do {
+        _ = try RepositoryLocation.parse(from: url)
+        Issue.record("expected throw")
+      } catch let error as RepositoryLocationError {
+        let message = error.description
+        #expect(!message.contains("ghp_secret"))
+        #expect(!message.contains("oauth2"))
+      } catch {
+        Issue.record("unexpected error type: \(type(of: error))")
+      }
+    }
+  }
+
+#endif

--- a/Tests/SwiftAtprotoLexTests/WalkLexiconsTests.swift
+++ b/Tests/SwiftAtprotoLexTests/WalkLexiconsTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+
+@testable import SwiftAtprotoLex
+
+final class WalkLexiconsTests: XCTestCase {
+  private func makeTempDir() throws -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent("swift-atproto-walk-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  func testCollectsJSONFilesThroughDirectorySymlinks() throws {
+    let root = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let source = root.appendingPathComponent("source", isDirectory: true)
+    let nested = source.appendingPathComponent("nested", isDirectory: true)
+    try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: nested.appendingPathComponent("a.json"))
+
+    let base = root.appendingPathComponent("base", isDirectory: true)
+    try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+    let link = base.appendingPathComponent("link", isDirectory: true)
+    try FileManager.default.createSymbolicLink(at: link, withDestinationURL: source)
+
+    let urls = collectJSONFileURLs(at: base)
+    let names = urls.map { $0.lastPathComponent }.sorted()
+    XCTAssertEqual(names, ["a.json"])
+  }
+
+  func testTerminatesOnSymlinkLoop() throws {
+    let root = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let base = root.appendingPathComponent("base", isDirectory: true)
+    try FileManager.default.createDirectory(at: base, withIntermediateDirectories: true)
+    try Data("{}".utf8).write(to: base.appendingPathComponent("ok.json"))
+    let loop = base.appendingPathComponent("loop", isDirectory: true)
+    // `loop` points back to its own parent — without cycle detection the
+    // recursive walker would re-enter forever.
+    try FileManager.default.createSymbolicLink(at: loop, withDestinationURL: base)
+
+    let urls = collectJSONFileURLs(at: base)
+    // The single real JSON is reported exactly once even though the cycle
+    // exposes it through `base/loop/ok.json`, `base/loop/loop/ok.json`, ...
+    XCTAssertEqual(urls.map(\.lastPathComponent), ["ok.json"])
+  }
+}


### PR DESCRIPTION
Essentially different repositories no longer collide on disk because every remote checkout is nested under `<host>/<...path...>`, and local `file://` dependencies install their lexicons as symlinks so source edits flow through to the next codegen pass.