### PR TITLE
Add lenient Language parsing mode

### DIFF
--- a/Sources/SwiftAtproto/StringFormats/Language.swift
+++ b/Sources/SwiftAtproto/StringFormats/Language.swift
@@ -6,8 +6,8 @@ import Foundation
 //
 // Scope: the canonical BCP-47 langtag grammar plus the RFC 5646 §2.2.8 grandfathered/irregular
 // whitelist, in strict mode. The parser only validates grammar — it does not consult any subtag
-// registry. A lenient mode (`_` separators, etc.) and canonicalization are intentionally NOT
-// supported.
+// registry. Lenient mode is still syntax-only BCP-47 parsing: it does not accept `_` separators
+// or perform canonicalization, but it skips RFC 5646 §4.1 duplicate-subtag value checks.
 public struct Language: LexiconStringFormat {
   // The original wire string, kept verbatim (no normalization).
   public let rawValue: String
@@ -15,7 +15,14 @@ public struct Language: LexiconStringFormat {
   public let components: Components
 
   public init(string: String) throws {
-    guard let components = Language.parse(string) else {
+    try self.init(string: string, strict: true)
+  }
+
+  // When `strict == false`, skips RFC 5646 §4.1 duplicate variant / extension-singleton
+  // rejection; grammar, length cap, and ASCII charset gates still apply. Lenient instances
+  // may therefore hold duplicate subtags — an invariant strict-parsed values never violate.
+  public init(string: String, strict: Bool) throws {
+    guard let components = Language.parse(string, strict: strict) else {
       throw LexiconStringFormatError.invalid(format: "language", value: string)
     }
     rawValue = string
@@ -136,9 +143,15 @@ extension Language {
   private static let grandfatheredLowercasedMap: [String: Grandfathered] =
     Dictionary(uniqueKeysWithValues: Grandfathered.allCases.map { ($0.rawValue.lowercased(), $0) })
 
-  // Strict parser. Returns nil on any grammar violation; the caller wraps that in
-  // `LexiconStringFormatError.invalid(format: "language", …)`.
+  // Strict parser. Returns nil on any grammar or value violation; the caller wraps that in
+  // `LexiconStringFormatError.invalid(format: "language", ...)`.
   static func parse(_ input: String) -> Components? {
+    parse(input, strict: true)
+  }
+
+  // Shared parser. Strict mode also enforces RFC 5646 §4.1 duplicate variant / extension
+  // singleton rejection. Lenient mode only checks well-formed syntax.
+  static func parse(_ input: String, strict: Bool) -> Components? {
     guard !input.isEmpty, input.utf8.count <= maxLength else { return nil }
     for byte in input.utf8 where !isAllowedByte(byte) { return nil }
 
@@ -202,8 +215,10 @@ extension Language {
     var variants: [Variant] = []
     var seenVariants: Set<String> = []
     while i < n, isVariantSubtag(subtags[i]) {
-      let key = subtags[i].lowercased()
-      guard seenVariants.insert(key).inserted else { return nil }
+      if strict {
+        let key = subtags[i].lowercased()
+        guard seenVariants.insert(key).inserted else { return nil }
+      }
       variants.append(Variant(rawValue: String(subtags[i])))
       i += 1
     }
@@ -213,8 +228,10 @@ extension Language {
     var seenSingletons: Set<Character> = []
     while i < n, isExtensionSingleton(subtags[i]) {
       guard let singleton = subtags[i].first else { return nil }
-      let key = Character(singleton.lowercased())
-      guard seenSingletons.insert(key).inserted else { return nil }
+      if strict {
+        let key = Character(singleton.lowercased())
+        guard seenSingletons.insert(key).inserted else { return nil }
+      }
       i += 1
       var extSubtags: [String] = []
       while i < n, isExtensionSubtag(subtags[i]) {

--- a/Tests/SwiftAtprotoTests/FormatStringLanguageTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringLanguageTests.swift
@@ -20,6 +20,19 @@ struct FormatStringLanguageTests {
     let value = try JSONDecoder().decode(FormatString<Language>.self, from: data)
     #expect(value.rawValue == "not a language tag")
     #expect(value.typed == nil)
+    #expect(value.typedLenient == nil)
+  }
+
+  @Test(arguments: [
+    "de-DE-1901-1901",
+    "en-a-foo-a-bar",
+  ])
+  func typedIsNilButTypedLenientAcceptsDuplicateSubtags(_ wire: String) throws {
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<Language>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+    #expect(value.typedLenient?.rawValue == wire)
   }
 
   @Test func encodeEmitsWireString() throws {

--- a/Tests/SwiftAtprotoTests/LanguageAdversarialTests.swift
+++ b/Tests/SwiftAtprotoTests/LanguageAdversarialTests.swift
@@ -105,23 +105,54 @@ struct LanguageAdversarialTests {
 
   // MARK: - RFC 5646 §4.1 MUST-NOT: subtag uniqueness
 
-  @Test func rejectsDuplicateVariantSubtags() {
+  @Test func rejectsDuplicateVariantSubtags() throws {
     // §4.1: "The same variant subtag MUST NOT be used more than once within a language tag."
     #expect(throws: (any Error).self) { try Language(string: "de-1996-1996") }
+    #expect(throws: (any Error).self) { try Language(string: "de-1996-1996", strict: true) }
+    let lenient = try Language(string: "de-1996-1996", strict: false)
+    #expect(lenient.components.variants.map(\.rawValue) == ["1996", "1996"])
   }
 
-  @Test func rejectsDuplicateVariantSubtagsCaseInsensitively() {
+  @Test func rejectsDuplicateVariantSubtagsCaseInsensitively() throws {
     // §2.1.1 subtag comparison is case-insensitive.
     #expect(throws: (any Error).self) { try Language(string: "sl-rozaj-ROZAJ") }
+    let lenient = try Language(string: "sl-rozaj-ROZAJ", strict: false)
+    #expect(lenient.components.variants.map(\.rawValue) == ["rozaj", "ROZAJ"])
   }
 
   @Test func rejectsDuplicateExtensionSingletons() {
     // §4.1: "The same singleton MUST NOT be used more than once in a language tag."
     #expect(throws: (any Error).self) { try Language(string: "en-u-co-phonebk-u-other") }
+    let lenient = try? Language(string: "en-u-co-phonebk-u-other", strict: false)
+    #expect(lenient?.components.extensions.map(\.singleton) == ["u", "u"])
   }
 
   @Test func rejectsDuplicateExtensionSingletonsCaseInsensitively() {
     #expect(throws: (any Error).self) { try Language(string: "en-U-co-u-other") }
+    let lenient = try? Language(string: "en-U-co-u-other", strict: false)
+    #expect(lenient?.components.extensions.map(\.singleton) == ["U", "u"])
+  }
+
+  // Lenient only relaxes RFC 5646 §4.1 value checks; every other syntax gate
+  // (non-ASCII, control bytes, underscore, length cap, missing extension subtag) must
+  // still reject.
+  static let lenientSyntaxInvalid: [String] = {
+    let overLength =
+      "en-x-" + String(repeating: "a", count: 8) + "-"
+      + String(repeating: "b", count: 8) + "-" + String(repeating: "c", count: 8)
+      + "-" + String(repeating: "d", count: 8) + "-"
+      + String(repeating: "e", count: 8) + "-"
+      + String(repeating: "f", count: 8) + "-" + String(repeating: "g", count: 6)
+    return confusables + controlChars + [
+      "not a language tag",
+      "en-u",  // extension singleton with no subtag
+      overLength,  // 65 bytes
+    ]
+  }()
+
+  @Test(arguments: lenientSyntaxInvalid)
+  func lenientStillRejectsSyntaxInvalidLanguage(_ tag: String) {
+    #expect(throws: (any Error).self) { try Language(string: tag, strict: false) }
   }
 
   // MARK: - Hashable identity


### PR DESCRIPTION
Aligns the `language` string format with the strict/lenient two-tier model already used by `at-uri` and `datetime`. Strict parsing preserves the current behavior; lenient only relaxes the RFC 5646 §4.1 duplicate variant / extension-singleton value checks, while grammar, length cap, and ASCII charset still gate both modes. 