### PR TITLE
Generate Swift declarations for Lexicon permission sets

### DIFF
--- a/Sources/SwiftAtproto/LexPermission.swift
+++ b/Sources/SwiftAtproto/LexPermission.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+public struct LexPermission: Codable, Hashable, Sendable {
+  public let resource: LexPermissionResource
+  public let aud: String?
+  public let inheritAud: Bool?
+  public let lxm: [String]?
+  public let action: [LexPermissionAction]?
+  public let collection: [String]?
+
+  public init(
+    resource: LexPermissionResource,
+    aud: String? = nil,
+    inheritAud: Bool? = nil,
+    lxm: [String]? = nil,
+    action: [LexPermissionAction]? = nil,
+    collection: [String]? = nil
+  ) {
+    self.resource = resource
+    self.aud = aud
+    self.inheritAud = inheritAud
+    self.lxm = lxm
+    self.action = action
+    self.collection = collection
+  }
+}
+
+public struct LexPermissionResource: RawRepresentable, Codable, Hashable, Sendable {
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.rawValue = try decoder.singleValueContainer().decode(String.self)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+
+  public static let rpc = Self(rawValue: "rpc")
+  public static let repo = Self(rawValue: "repo")
+}
+
+public struct LexPermissionAction: RawRepresentable, Codable, Hashable, Sendable {
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.rawValue = try decoder.singleValueContainer().decode(String.self)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+
+  public static let create = Self(rawValue: "create")
+  public static let update = Self(rawValue: "update")
+  public static let delete = Self(rawValue: "delete")
+}

--- a/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
@@ -1,3 +1,9 @@
+import SwiftSyntax
+
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 struct PermissionSetTypeDefinition: Codable {
   let type: FieldType
   let title: String?
@@ -13,5 +19,206 @@ struct PermissionSetTypeDefinition: Codable {
     case detail
     case detailLang = "detail:lang"
     case permissions
+  }
+}
+
+extension PermissionSetTypeDefinition: SwiftCodeGeneratable {
+  func generateDeclaration(
+    leadingTrivia: Trivia? = nil, ts _: TypeSchema, name: String, type typeName: String,
+    defMap _: ExtDefMap, generate _: GenerateOption
+  ) -> any DeclSyntaxProtocol {
+    EnumDeclSyntax(
+      leadingTrivia: leadingTrivia,
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      name: .lexIdentifier(name)
+    ) {
+      staticLetDecl(leadingTrivia: .newline, ident: "id", value: StringLiteralExprSyntax(content: typeName))
+      Self.optionalStringStaticLet(ident: "title", value: title)
+      Self.optionalStringStaticLet(ident: "detail", value: detail)
+      Self.permissionsStaticLet(permissions: permissions)
+    }
+  }
+
+  private static func optionalStringStaticLet(ident: String, value: String?) -> VariableDeclSyntax {
+    let valueExpr: ExprSyntax =
+      if let value {
+        ExprSyntax(StringLiteralExprSyntax(content: value))
+      } else {
+        ExprSyntax(NilLiteralExprSyntax())
+      }
+    return VariableDeclSyntax(
+      leadingTrivia: .newline,
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public)),
+        DeclModifierSyntax(name: .keyword(.static)),
+      ],
+      bindingSpecifier: .keyword(.let)
+    ) {
+      PatternBindingSyntax(
+        pattern: IdentifierPatternSyntax(identifier: .identifier(ident)),
+        typeAnnotation: TypeAnnotationSyntax(
+          type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String")))
+        ),
+        initializer: InitializerClauseSyntax(value: valueExpr)
+      )
+    }
+  }
+
+  private static func permissionsStaticLet(permissions: [PermissionTypeDefinition]) -> VariableDeclSyntax {
+    let arrayExpr = ArrayExprSyntax(
+      leftSquare: .leftSquareToken(),
+      elements: ArrayElementListSyntax {
+        for (i, permission) in permissions.enumerated() {
+          ArrayElementSyntax(
+            leadingTrivia: .newline,
+            expression: permissionInit(permission),
+            trailingComma: i < permissions.count - 1 ? .commaToken() : nil
+          )
+        }
+      },
+      rightSquare: .rightSquareToken(leadingTrivia: .newline)
+    )
+    return VariableDeclSyntax(
+      leadingTrivia: .newline,
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public)),
+        DeclModifierSyntax(name: .keyword(.static)),
+      ],
+      bindingSpecifier: .keyword(.let)
+    ) {
+      PatternBindingSyntax(
+        pattern: IdentifierPatternSyntax(identifier: .identifier("permissions")),
+        typeAnnotation: TypeAnnotationSyntax(
+          type: ArrayTypeSyntax(element: IdentifierTypeSyntax(name: .identifier("LexPermission")))
+        ),
+        initializer: InitializerClauseSyntax(value: arrayExpr)
+      )
+    }
+  }
+
+  private static func permissionInit(_ permission: PermissionTypeDefinition) -> ExprSyntax {
+    var args: [LabeledExprSyntax] = []
+    args.append(labeledArg(label: "resource", expression: resourceExpr(permission.resource)))
+    if let aud = permission.aud {
+      args.append(labeledArg(label: "aud", expression: StringLiteralExprSyntax(content: aud)))
+    }
+    if let inheritAud = permission.inheritAud {
+      args.append(labeledArg(label: "inheritAud", expression: BooleanLiteralExprSyntax(booleanLiteral: inheritAud)))
+    }
+    if let lxm = permission.lxm {
+      args.append(labeledArg(label: "lxm", expression: stringArrayExpr(lxm)))
+    }
+    if let action = permission.action {
+      args.append(labeledArg(label: "action", expression: actionArrayExpr(action)))
+    }
+    if let collection = permission.collection {
+      args.append(labeledArg(label: "collection", expression: stringArrayExpr(collection)))
+    }
+    for i in 0..<args.count {
+      args[i].leadingTrivia = .newline
+      if i < args.count - 1 {
+        args[i].trailingComma = .commaToken()
+      }
+    }
+    return ExprSyntax(
+      FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("LexPermission")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax(args),
+        rightParen: .rightParenToken(leadingTrivia: .newline)
+      )
+    )
+  }
+
+  private static func labeledArg(label: String, expression: some ExprSyntaxProtocol) -> LabeledExprSyntax {
+    LabeledExprSyntax(
+      label: .identifier(label),
+      colon: .colonToken(),
+      expression: expression
+    )
+  }
+
+  private static func stringArrayExpr(_ values: [String]) -> ExprSyntax {
+    ExprSyntax(
+      ArrayExprSyntax(
+        leftSquare: .leftSquareToken(),
+        elements: ArrayElementListSyntax {
+          for (i, value) in values.enumerated() {
+            ArrayElementSyntax(
+              expression: StringLiteralExprSyntax(content: value),
+              trailingComma: i < values.count - 1 ? .commaToken() : nil
+            )
+          }
+        },
+        rightSquare: .rightSquareToken()
+      )
+    )
+  }
+
+  private static func actionArrayExpr(_ values: [PermissionAction]) -> ExprSyntax {
+    ExprSyntax(
+      ArrayExprSyntax(
+        leftSquare: .leftSquareToken(),
+        elements: ArrayElementListSyntax {
+          for (i, value) in values.enumerated() {
+            ArrayElementSyntax(
+              expression: actionExpr(value),
+              trailingComma: i < values.count - 1 ? .commaToken() : nil
+            )
+          }
+        },
+        rightSquare: .rightSquareToken()
+      )
+    )
+  }
+
+  private static func resourceExpr(_ resource: PermissionResource) -> ExprSyntax {
+    switch resource {
+    case .rpc:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("rpc")))
+    case .repo:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("repo")))
+    default:
+      ExprSyntax(
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("LexPermissionResource")),
+          leftParen: .leftParenToken(),
+          arguments: LabeledExprListSyntax([
+            LabeledExprSyntax(
+              label: .identifier("rawValue"),
+              colon: .colonToken(),
+              expression: StringLiteralExprSyntax(content: resource.rawValue)
+            )
+          ]),
+          rightParen: .rightParenToken()
+        )
+      )
+    }
+  }
+
+  private static func actionExpr(_ action: PermissionAction) -> ExprSyntax {
+    switch action {
+    case .create:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("create")))
+    case .update:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("update")))
+    case .delete:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("delete")))
+    default:
+      ExprSyntax(
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("LexPermissionAction")),
+          leftParen: .leftParenToken(),
+          arguments: LabeledExprListSyntax([
+            LabeledExprSyntax(
+              label: .identifier("rawValue"),
+              colon: .colonToken(),
+              expression: StringLiteralExprSyntax(content: action.rawValue)
+            )
+          ]),
+          rightParen: .rightParenToken()
+        )
+      )
+    }
   }
 }

--- a/Sources/SwiftAtprotoLex/Definitions/PermissionTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/PermissionTypeDefinition.swift
@@ -1,5 +1,5 @@
 struct PermissionTypeDefinition: Codable {
-  var type: FieldType { .permission }
+  let type: FieldType
   let resource: PermissionResource
   let aud: String?
   let inheritAud: Bool?

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -97,6 +97,8 @@ final class Schema: Encodable, DecodableWithConfiguration, Sendable {
       case .string(let def):
         guard def.knownValues != nil || def.enum != nil else { break }
         out[name] = ts
+      case .permissionSet:
+        out[name] = ts
       default:
         break
       }
@@ -470,6 +472,8 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
     case .procedure(let def):
       def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .query(let def):
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
+    case .permissionSet(let def):
       def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     default:
       fatalError()

--- a/Tests/SwiftAtprotoTests/LexPermissionTests.swift
+++ b/Tests/SwiftAtprotoTests/LexPermissionTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct LexPermissionTests {
+  @Test func resourceKnownConstantsRoundTrip() throws {
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    for value in [LexPermissionResource.rpc, .repo] {
+      let data = try encoder.encode(value)
+      #expect(String(data: data, encoding: .utf8) == "\"\(value.rawValue)\"")
+      let decoded = try decoder.decode(LexPermissionResource.self, from: data)
+      #expect(decoded == value)
+    }
+  }
+
+  @Test func resourcePreservesUnknownRawValue() throws {
+    let data = Data("\"blob\"".utf8)
+    let decoded = try JSONDecoder().decode(LexPermissionResource.self, from: data)
+    #expect(decoded.rawValue == "blob")
+    #expect(decoded != .rpc)
+    #expect(decoded != .repo)
+
+    let reEncoded = try JSONEncoder().encode(decoded)
+    #expect(String(data: reEncoded, encoding: .utf8) == "\"blob\"")
+  }
+
+  @Test func actionKnownConstantsRoundTrip() throws {
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    for value in [LexPermissionAction.create, .update, .delete] {
+      let data = try encoder.encode(value)
+      #expect(String(data: data, encoding: .utf8) == "\"\(value.rawValue)\"")
+      let decoded = try decoder.decode(LexPermissionAction.self, from: data)
+      #expect(decoded == value)
+    }
+  }
+
+  @Test func actionPreservesUnknownRawValue() throws {
+    let data = Data("\"wibble\"".utf8)
+    let decoded = try JSONDecoder().decode(LexPermissionAction.self, from: data)
+    #expect(decoded.rawValue == "wibble")
+    #expect(decoded != .create)
+  }
+
+  @Test func permissionRpcDefaultsOmitOptionalsAtInit() {
+    let perm = LexPermission(resource: .rpc, inheritAud: true, lxm: ["app.bsky.feed.getTimeline"])
+    #expect(perm.resource == .rpc)
+    #expect(perm.inheritAud == true)
+    #expect(perm.lxm == ["app.bsky.feed.getTimeline"])
+    #expect(perm.aud == nil)
+    #expect(perm.action == nil)
+    #expect(perm.collection == nil)
+  }
+
+  @Test func permissionRoundTripPreservesAllFields() throws {
+    let original = LexPermission(
+      resource: .repo,
+      action: [.create, .delete, LexPermissionAction(rawValue: "wibble")],
+      collection: ["app.bsky.feed.post"]
+    )
+    let data = try JSONEncoder().encode(original)
+    let decoded = try JSONDecoder().decode(LexPermission.self, from: data)
+    #expect(decoded == original)
+  }
+}


### PR DESCRIPTION
This PR adds runtime types for Lexicon permission metadata and wires permission-set definitions into SwiftAtprotoLex code generation. 