### PR TITLE
Add OAuth scope expansion for Lexicon permission sets

### DIFF
--- a/Sources/SwiftAtproto/LexPermission.swift
+++ b/Sources/SwiftAtproto/LexPermission.swift
@@ -65,3 +65,10 @@ public struct LexPermissionAction: RawRepresentable, Codable, Hashable, Sendable
   public static let update = Self(rawValue: "update")
   public static let delete = Self(rawValue: "delete")
 }
+
+public protocol LexPermissionSet {
+  static var id: String { get }
+  static var title: String? { get }
+  static var detail: String? { get }
+  static var permissions: [LexPermission] { get }
+}

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -183,3 +183,82 @@ public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
     return Self.defaultActions.filter { seen.contains($0) }
   }
 }
+
+public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
+  public let nsid: String
+  public let aud: String?
+
+  public init(nsid: String, aud: String? = nil) throws {
+    guard NSID.isValid(nsid) else {
+      throw OAuthScopeError.invalidSyntax("invalid NSID '\(nsid)' in include scope")
+    }
+    self.nsid = nsid
+    self.aud = aud
+  }
+
+  public init(string: String) throws {
+    let syntax = OAuthScopeSyntax.parse(string)
+    guard syntax.prefix == "include" else {
+      throw OAuthScopeError.invalidResource(syntax.prefix)
+    }
+    if let positional = syntax.positional, positional.isEmpty {
+      throw OAuthScopeError.invalidSyntax("empty positional in include scope")
+    }
+    var nsid: String? = syntax.positional
+    var aud: String? = nil
+    var sawNsidInQuery = false
+    for param in syntax.params {
+      switch param.key {
+      case "nsid":
+        sawNsidInQuery = true
+        if nsid != nil {
+          throw OAuthScopeError.duplicateKey("nsid")
+        }
+        nsid = param.value
+      case "aud":
+        if aud != nil {
+          throw OAuthScopeError.duplicateKey("aud")
+        }
+        guard !param.value.isEmpty else {
+          throw OAuthScopeError.invalidSyntax("empty aud value in include scope")
+        }
+        aud = param.value
+      default:
+        throw OAuthScopeError.invalidSyntax("unknown key '\(param.key)' in include scope")
+      }
+    }
+    if syntax.positional != nil, sawNsidInQuery {
+      throw OAuthScopeError.invalidSyntax("include scope has both positional and nsid query")
+    }
+    guard let nsidValue = nsid else {
+      throw OAuthScopeError.missingRequired("nsid")
+    }
+    try self.init(nsid: nsidValue, aud: aud)
+  }
+
+  public var description: String {
+    var params: [OAuthScopeQueryParam] = []
+    if let aud {
+      params.append(OAuthScopeQueryParam(key: "aud", value: aud))
+    }
+    return OAuthScopeSyntax(prefix: "include", positional: nsid, params: params).description
+  }
+
+  public func isParentAuthorityOf(_ otherNsid: String) -> Bool {
+    if otherNsid == "*" { return false }
+    guard let groupPrefixEnd = nsid.lastIndex(of: ".") else {
+      return false
+    }
+    let groupPrefixEndOffset = nsid.distance(from: nsid.startIndex, to: groupPrefixEnd)
+    let otherLength = otherNsid.utf8.count
+    if groupPrefixEndOffset >= otherLength - 1 {
+      return false
+    }
+    let nsidBytes = Array(nsid.utf8)
+    let otherBytes = Array(otherNsid.utf8)
+    for i in 0...groupPrefixEndOffset where nsidBytes[i] != otherBytes[i] {
+      return false
+    }
+    return true
+  }
+}

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -92,3 +92,94 @@ public struct RpcScope: CustomStringConvertible, Hashable, Sendable {
     return Array(Set(lxm)).sorted()
   }
 }
+
+public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
+  public let collection: [String]
+  public let action: [LexPermissionAction]
+
+  public static let defaultActions: [LexPermissionAction] = [.create, .update, .delete]
+
+  public init(collection: [String], action: [LexPermissionAction] = Self.defaultActions) throws {
+    guard !collection.isEmpty else {
+      throw OAuthScopeError.missingRequired("collection")
+    }
+    guard !action.isEmpty else {
+      throw OAuthScopeError.missingRequired("action")
+    }
+    for a in action where !Self.defaultActions.contains(a) {
+      throw OAuthScopeError.invalidSyntax("unknown action '\(a.rawValue)' in repo scope")
+    }
+    self.collection = Self.normalize(collection: collection)
+    self.action = Self.normalize(action: action)
+  }
+
+  public init(string: String) throws {
+    let syntax = OAuthScopeSyntax.parse(string)
+    guard syntax.prefix == "repo" else {
+      throw OAuthScopeError.invalidResource(syntax.prefix)
+    }
+    var collections: [String] = []
+    var actions: [LexPermissionAction] = []
+    var sawCollectionInQuery = false
+    if let positional = syntax.positional {
+      guard !positional.isEmpty else {
+        throw OAuthScopeError.invalidSyntax("empty positional in repo scope")
+      }
+      collections.append(positional)
+    }
+    for param in syntax.params {
+      switch param.key {
+      case "collection":
+        sawCollectionInQuery = true
+        guard !param.value.isEmpty else {
+          throw OAuthScopeError.invalidSyntax("empty collection value in repo scope")
+        }
+        collections.append(param.value)
+      case "action":
+        guard !param.value.isEmpty else {
+          throw OAuthScopeError.invalidSyntax("empty action value in repo scope")
+        }
+        actions.append(LexPermissionAction(rawValue: param.value))
+      default:
+        throw OAuthScopeError.invalidSyntax("unknown key '\(param.key)' in repo scope")
+      }
+    }
+    if syntax.positional != nil, sawCollectionInQuery {
+      throw OAuthScopeError.invalidSyntax("repo scope has both positional and collection query")
+    }
+    guard !collections.isEmpty else {
+      throw OAuthScopeError.missingRequired("collection")
+    }
+    let effectiveActions = actions.isEmpty ? Self.defaultActions : actions
+    try self.init(collection: collections, action: effectiveActions)
+  }
+
+  public var description: String {
+    var params: [OAuthScopeQueryParam] = []
+    var positional: String? = nil
+    if collection.count == 1 {
+      positional = collection[0]
+    } else {
+      for value in collection {
+        params.append(OAuthScopeQueryParam(key: "collection", value: value))
+      }
+    }
+    if action != Self.defaultActions {
+      for a in action {
+        params.append(OAuthScopeQueryParam(key: "action", value: a.rawValue))
+      }
+    }
+    return OAuthScopeSyntax(prefix: "repo", positional: positional, params: params).description
+  }
+
+  private static func normalize(collection: [String]) -> [String] {
+    guard collection.count > 1 else { return collection }
+    if collection.contains("*") { return ["*"] }
+    return Array(Set(collection)).sorted()
+  }
+
+  private static func normalize(action: [LexPermissionAction]) -> [LexPermissionAction] {
+    let seen = Set(action)
+    return Self.defaultActions.filter { seen.contains($0) }
+  }
+}

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public enum OAuthScope {
+  public static let atproto = "atproto"
+}
+
+public enum OAuthScopeError: Error, Hashable, Sendable {
+  case invalidSyntax(String)
+  case invalidResource(String)
+  case duplicateKey(String)
+  case missingRequired(String)
+  case forbiddenCombination(String)
+  case permissionAudMismatch(String)
+  case nsidOutsideAuthority(parent: String, other: String)
+  case unsupportedResource(String)
+}
+
+public struct RpcScope: CustomStringConvertible, Hashable, Sendable {
+  public let aud: String
+  public let lxm: [String]
+
+  public init(aud: String, lxm: [String]) throws {
+    guard !lxm.isEmpty else {
+      throw OAuthScopeError.missingRequired("lxm")
+    }
+    let normalized = Self.normalize(lxm: lxm)
+    if aud == "*", normalized.contains("*") {
+      throw OAuthScopeError.forbiddenCombination("rpc:* with aud:*")
+    }
+    self.aud = aud
+    self.lxm = normalized
+  }
+
+  public init(string: String) throws {
+    let syntax = OAuthScopeSyntax.parse(string)
+    guard syntax.prefix == "rpc" else {
+      throw OAuthScopeError.invalidResource(syntax.prefix)
+    }
+    var lxms: [String] = []
+    var aud: String? = nil
+    var sawLxmInQuery = false
+    if let positional = syntax.positional {
+      guard !positional.isEmpty else {
+        throw OAuthScopeError.invalidSyntax("empty positional in rpc scope")
+      }
+      lxms.append(positional)
+    }
+    for param in syntax.params {
+      switch param.key {
+      case "lxm":
+        sawLxmInQuery = true
+        guard !param.value.isEmpty else {
+          throw OAuthScopeError.invalidSyntax("empty lxm value in rpc scope")
+        }
+        lxms.append(param.value)
+      case "aud":
+        if aud != nil {
+          throw OAuthScopeError.duplicateKey("aud")
+        }
+        aud = param.value
+      default:
+        throw OAuthScopeError.invalidSyntax("unknown key '\(param.key)' in rpc scope")
+      }
+    }
+    if syntax.positional != nil, sawLxmInQuery {
+      throw OAuthScopeError.invalidSyntax("rpc scope has both positional and lxm query")
+    }
+    guard let audValue = aud, !audValue.isEmpty else {
+      throw OAuthScopeError.missingRequired("aud")
+    }
+    try self.init(aud: audValue, lxm: lxms)
+  }
+
+  public var description: String {
+    var params: [OAuthScopeQueryParam] = []
+    var positional: String? = nil
+    if lxm.count == 1 {
+      positional = lxm[0]
+    } else {
+      for value in lxm {
+        params.append(OAuthScopeQueryParam(key: "lxm", value: value))
+      }
+    }
+    params.append(OAuthScopeQueryParam(key: "aud", value: aud))
+    return OAuthScopeSyntax(prefix: "rpc", positional: positional, params: params).description
+  }
+
+  private static func normalize(lxm: [String]) -> [String] {
+    if lxm.count > 1, lxm.contains("*") {
+      return ["*"]
+    }
+    return Array(Set(lxm)).sorted()
+  }
+}

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -261,4 +261,66 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
     }
     return true
   }
+
+  public func expand<PS: LexPermissionSet>(_ permissionSet: PS.Type) throws -> [String] {
+    guard PS.id == nsid else {
+      throw OAuthScopeError.invalidSyntax(
+        "permission-set id '\(PS.id)' does not match include scope nsid '\(nsid)'")
+    }
+    return try expand(permissionSet.permissions)
+  }
+
+  public func expand(_ permissions: [LexPermission]) throws -> [String] {
+    var scopes: [String] = []
+    for permission in permissions {
+      switch permission.resource {
+      case .rpc:
+        scopes.append(try expandRpc(permission))
+      case .repo:
+        scopes.append(try expandRepo(permission))
+      default:
+        throw OAuthScopeError.unsupportedResource(permission.resource.rawValue)
+      }
+    }
+    return scopes
+  }
+
+  private func expandRpc(_ permission: LexPermission) throws -> String {
+    let resolvedAud: String
+    if let permAud = permission.aud {
+      if permAud != "*" {
+        throw OAuthScopeError.permissionAudMismatch(
+          "rpc permission has specific aud '\(permAud)' which is not allowed in permission-set")
+      }
+      resolvedAud = "*"
+    } else if permission.inheritAud == true {
+      guard let includeAud = aud else {
+        throw OAuthScopeError.permissionAudMismatch(
+          "rpc permission has inheritAud=true but include scope has no aud")
+      }
+      resolvedAud = includeAud
+    } else {
+      throw OAuthScopeError.missingRequired(
+        "rpc permission has neither aud nor inheritAud=true")
+    }
+
+    guard let lxm = permission.lxm, !lxm.isEmpty else {
+      throw OAuthScopeError.missingRequired("lxm in rpc permission")
+    }
+    for nsidValue in lxm where !isParentAuthorityOf(nsidValue) {
+      throw OAuthScopeError.nsidOutsideAuthority(parent: nsid, other: nsidValue)
+    }
+    return try RpcScope(aud: resolvedAud, lxm: lxm).description
+  }
+
+  private func expandRepo(_ permission: LexPermission) throws -> String {
+    guard let collection = permission.collection, !collection.isEmpty else {
+      throw OAuthScopeError.missingRequired("collection in repo permission")
+    }
+    for nsidValue in collection where !isParentAuthorityOf(nsidValue) {
+      throw OAuthScopeError.nsidOutsideAuthority(parent: nsid, other: nsidValue)
+    }
+    let actions = permission.action ?? RepoScope.defaultActions
+    return try RepoScope(collection: collection, action: actions).description
+  }
 }

--- a/Sources/SwiftAtproto/_OAuthScopeSyntax.swift
+++ b/Sources/SwiftAtproto/_OAuthScopeSyntax.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+struct OAuthScopeQueryParam: Equatable, Hashable, Sendable {
+  let key: String
+  let value: String
+}
+
+struct OAuthScopeSyntax: CustomStringConvertible, Equatable, Hashable, Sendable {
+  let prefix: String
+  let positional: String?
+  let params: [OAuthScopeQueryParam]
+
+  init(prefix: String, positional: String? = nil, params: [OAuthScopeQueryParam] = []) {
+    self.prefix = prefix
+    self.positional = positional
+    self.params = params
+  }
+
+  static func parse(_ scope: String) -> OAuthScopeSyntax {
+    let colonIdx = scope.firstIndex(of: ":")
+    let queryIdx = scope.firstIndex(of: "?")
+    let prefixEnd: String.Index? = minIndex(colonIdx, queryIdx)
+    guard let prefixEnd else {
+      return OAuthScopeSyntax(prefix: scope)
+    }
+    let prefix = String(scope[..<prefixEnd])
+
+    let positional: String?
+    if let colonIdx, colonIdx < (queryIdx ?? scope.endIndex) {
+      let positionalEnd = queryIdx ?? scope.endIndex
+      let raw = String(scope[scope.index(after: colonIdx)..<positionalEnd])
+      positional = decodePercent(raw)
+    } else {
+      positional = nil
+    }
+
+    var params: [OAuthScopeQueryParam] = []
+    if let queryIdx, scope.index(after: queryIdx) < scope.endIndex {
+      let query = scope[scope.index(after: queryIdx)...]
+      for pair in query.split(separator: "&", omittingEmptySubsequences: true) {
+        let parts = pair.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+        let key = decodePercent(String(parts[0]))
+        let value = parts.count == 2 ? decodePercent(String(parts[1])) : ""
+        params.append(OAuthScopeQueryParam(key: key, value: value))
+      }
+    }
+    return OAuthScopeSyntax(prefix: prefix, positional: positional, params: params)
+  }
+
+  var description: String {
+    var result = prefix
+    if let positional {
+      result += ":" + normalizeAllowedChars(encodeComponent(positional))
+    }
+    if !params.isEmpty {
+      let joined = params.map { encodeComponent($0.key) + "=" + encodeComponent($0.value) }.joined(separator: "&")
+      result += "?" + normalizeAllowedChars(joined)
+    }
+    return result
+  }
+}
+
+private func minIndex(_ a: String.Index?, _ b: String.Index?) -> String.Index? {
+  switch (a, b) {
+  case (nil, nil): nil
+  case (let x?, nil): x
+  case (nil, let y?): y
+  case (let x?, let y?): min(x, y)
+  }
+}
+
+private let unreservedScopeCharacters: CharacterSet = {
+  var set = CharacterSet.alphanumerics
+  set.insert(charactersIn: "-_.!~*'()")
+  return set
+}()
+
+private func encodeComponent(_ value: String) -> String {
+  value.addingPercentEncoding(withAllowedCharacters: unreservedScopeCharacters) ?? value
+}
+
+private func decodePercent(_ value: String) -> String {
+  value.removingPercentEncoding ?? value
+}
+
+private let allowedNormalizableEncoded: [String: String] = [
+  "%3A": ":",
+  "%2F": "/",
+  "%2B": "+",
+  "%2C": ",",
+  "%40": "@",
+  "%25": "%",
+]
+
+private func normalizeAllowedChars(_ value: String) -> String {
+  guard value.contains("%") else { return value }
+  var result = ""
+  result.reserveCapacity(value.count)
+  let chars = Array(value)
+  var i = 0
+  while i < chars.count {
+    if chars[i] == "%", i + 2 < chars.count {
+      let encoded = String(chars[i...i + 2]).uppercased()
+      if let decoded = allowedNormalizableEncoded[encoded] {
+        result.append(decoded)
+        i += 3
+        continue
+      }
+    }
+    result.append(chars[i])
+    i += 1
+  }
+  return result
+}

--- a/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
@@ -30,7 +30,10 @@ extension PermissionSetTypeDefinition: SwiftCodeGeneratable {
     EnumDeclSyntax(
       leadingTrivia: leadingTrivia,
       modifiers: [DeclModifierSyntax(name: .keyword(.public))],
-      name: .lexIdentifier(name)
+      name: .lexIdentifier(name),
+      inheritanceClause: InheritanceClauseSyntax {
+        InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("LexPermissionSet")))
+      }
     ) {
       staticLetDecl(leadingTrivia: .newline, ident: "id", value: StringLiteralExprSyntax(content: typeName))
       Self.optionalStringStaticLet(ident: "title", value: title)

--- a/Tests/SwiftAtprotoTests/LexPermissionTests.swift
+++ b/Tests/SwiftAtprotoTests/LexPermissionTests.swift
@@ -64,4 +64,21 @@ struct LexPermissionTests {
     let decoded = try JSONDecoder().decode(LexPermission.self, from: data)
     #expect(decoded == original)
   }
+
+  @Test func conformingTypeSatisfiesProtocol() {
+    #expect(SampleAuthPermissionSet.id == "com.example.auth.sample")
+    #expect(SampleAuthPermissionSet.title == "Sample")
+    #expect(SampleAuthPermissionSet.detail == nil)
+    #expect(SampleAuthPermissionSet.permissions.count == 1)
+    #expect(SampleAuthPermissionSet.permissions[0].resource == .rpc)
+  }
+}
+
+private enum SampleAuthPermissionSet: LexPermissionSet {
+  static let id = "com.example.auth.sample"
+  static let title: String? = "Sample"
+  static let detail: String? = nil
+  static let permissions: [LexPermission] = [
+    LexPermission(resource: .rpc, inheritAud: true, lxm: ["com.example.foo.getThing"])
+  ]
 }

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct OAuthScopeSyntaxTests {
+  @Test func parsesBarePrefix() {
+    let syntax = OAuthScopeSyntax.parse("atproto")
+    #expect(syntax.prefix == "atproto")
+    #expect(syntax.positional == nil)
+    #expect(syntax.params.isEmpty)
+  }
+
+  @Test func parsesPositionalOnly() {
+    let syntax = OAuthScopeSyntax.parse("rpc:com.example.foo")
+    #expect(syntax.prefix == "rpc")
+    #expect(syntax.positional == "com.example.foo")
+    #expect(syntax.params.isEmpty)
+  }
+
+  @Test func parsesPositionalWithQuery() {
+    let syntax = OAuthScopeSyntax.parse("rpc:com.example.foo?aud=did:web:example.com")
+    #expect(syntax.prefix == "rpc")
+    #expect(syntax.positional == "com.example.foo")
+    #expect(syntax.params == [OAuthScopeQueryParam(key: "aud", value: "did:web:example.com")])
+  }
+
+  @Test func parsesQueryOnly() {
+    let syntax = OAuthScopeSyntax.parse("repo?action=create&collection=com.example.post")
+    #expect(syntax.prefix == "repo")
+    #expect(syntax.positional == nil)
+    #expect(
+      syntax.params == [
+        OAuthScopeQueryParam(key: "action", value: "create"),
+        OAuthScopeQueryParam(key: "collection", value: "com.example.post"),
+      ])
+  }
+
+  @Test func parseDecodesPercentEscapedHash() {
+    let syntax = OAuthScopeSyntax.parse(
+      "rpc:com.example.svc?aud=did:web:example.com%23service_id")
+    #expect(syntax.positional == "com.example.svc")
+    #expect(syntax.params == [OAuthScopeQueryParam(key: "aud", value: "did:web:example.com#service_id")])
+  }
+
+  @Test func serializeBarePrefix() {
+    let syntax = OAuthScopeSyntax(prefix: "atproto")
+    #expect(syntax.description == "atproto")
+  }
+
+  @Test func serializePreservesAllowedCharacters() {
+    let syntax = OAuthScopeSyntax(
+      prefix: "rpc",
+      positional: "com.example.foo",
+      params: [OAuthScopeQueryParam(key: "aud", value: "did:web:example.com")]
+    )
+    #expect(syntax.description == "rpc:com.example.foo?aud=did:web:example.com")
+  }
+
+  @Test func serializeEscapesHashInValue() {
+    let syntax = OAuthScopeSyntax(
+      prefix: "rpc",
+      positional: "com.example.svc",
+      params: [OAuthScopeQueryParam(key: "aud", value: "did:web:example.com#service_id")]
+    )
+    #expect(syntax.description == "rpc:com.example.svc?aud=did:web:example.com%23service_id")
+  }
+
+  @Test func roundTripIdempotent() {
+    let inputs = [
+      "atproto",
+      "rpc:com.example.foo",
+      "rpc:com.example.foo?aud=did:web:example.com%23service",
+      "repo?action=create&collection=com.example.post",
+      "include:com.example.bar?aud=*",
+    ]
+    for input in inputs {
+      let parsed = OAuthScopeSyntax.parse(input)
+      let serialized = parsed.description
+      let reparsed = OAuthScopeSyntax.parse(serialized)
+      #expect(parsed == reparsed, "round-trip parse-equality failed for \(input)")
+    }
+  }
+}

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -82,3 +82,92 @@ struct OAuthScopeSyntaxTests {
     }
   }
 }
+
+struct RpcScopeTests {
+  @Test func parsePositionalAndAud() throws {
+    let scope = try RpcScope(string: "rpc:com.example.service?aud=did:web:example.com%23service_id")
+    #expect(scope.lxm == ["com.example.service"])
+    #expect(scope.aud == "did:web:example.com#service_id")
+  }
+
+  @Test func parseQueryFormCanonicalizes() throws {
+    let scope = try RpcScope(
+      string: "rpc?lxm=com.example.method2&lxm=com.example.method1&aud=*")
+    #expect(scope.lxm == ["com.example.method1", "com.example.method2"])
+    #expect(scope.aud == "*")
+  }
+
+  @Test func lxmWildcardCollapsesEvenWithOtherValues() throws {
+    let scope = try RpcScope(
+      string: "rpc?lxm=com.example.m1&lxm=com.example.m2&lxm=*&aud=did:web:example.com")
+    #expect(scope.lxm == ["*"])
+  }
+
+  @Test func wildcardLxmAndWildcardAudIsRejected() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:*?aud=*")
+    }
+  }
+
+  @Test func serializePositionalForSingleLxm() throws {
+    let scope = try RpcScope(aud: "did:web:example.com", lxm: ["com.example.method1"])
+    #expect(scope.description == "rpc:com.example.method1?aud=did:web:example.com")
+  }
+
+  @Test func serializeMultipleLxmAsQuery() throws {
+    let scope = try RpcScope(
+      aud: "*", lxm: ["com.example.method2", "com.example.method1"])
+    #expect(
+      scope.description
+        == "rpc?lxm=com.example.method1&lxm=com.example.method2&aud=*")
+  }
+
+  @Test func serializeEscapesHashInAud() throws {
+    let scope = try RpcScope(
+      aud: "did:web:example.com#service_id", lxm: ["com.example.method"])
+    #expect(
+      scope.description == "rpc:com.example.method?aud=did:web:example.com%23service_id")
+  }
+
+  @Test func roundTripCanonicalForms() throws {
+    let canonical = [
+      "rpc:com.example.method1?aud=*",
+      "rpc:*?aud=did:web:example.com%23service_id",
+      "rpc?lxm=com.example.method1&lxm=com.example.method2&aud=did:web:example.com%23service_id",
+    ]
+    for input in canonical {
+      let scope = try RpcScope(string: input)
+      #expect(scope.description == input, "round-trip mismatch for \(input)")
+    }
+  }
+
+  @Test func missingAudThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:com.example.method")
+    }
+  }
+
+  @Test func unknownKeyThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:com.example.method?aud=*&extra=value")
+    }
+  }
+
+  @Test func emptyPositionalThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:?aud=did:web:example.com")
+    }
+  }
+
+  @Test func emptyAudThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:com.example.method?aud=")
+    }
+  }
+
+  @Test func emptyLxmValueThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc?lxm=&aud=did:web:example.com")
+    }
+  }
+}

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -171,3 +171,86 @@ struct RpcScopeTests {
     }
   }
 }
+
+struct RepoScopeTests {
+  @Test func parsePositionalWithDefaultActions() throws {
+    let scope = try RepoScope(string: "repo:com.example.post")
+    #expect(scope.collection == ["com.example.post"])
+    #expect(scope.action == RepoScope.defaultActions)
+  }
+
+  @Test func parseQueryFormWithExplicitAction() throws {
+    let scope = try RepoScope(string: "repo:com.example.post?action=create")
+    #expect(scope.collection == ["com.example.post"])
+    #expect(scope.action == [.create])
+  }
+
+  @Test func parseAllActionsExplicitDropsBackToDefault() throws {
+    let scope = try RepoScope(
+      string: "repo:*?action=create&action=update&action=delete")
+    #expect(scope.collection == ["*"])
+    #expect(scope.action == RepoScope.defaultActions)
+  }
+
+  @Test func parseCollectionWildcardCollapses() throws {
+    let scope = try RepoScope(
+      string: "repo?collection=com.example.foo&collection=*&collection=com.example.bar")
+    #expect(scope.collection == ["*"])
+  }
+
+  @Test func parseSortsCollectionsAndActions() throws {
+    let scope = try RepoScope(
+      string: "repo?action=delete&action=create&collection=com.example.bar&collection=com.example.foo")
+    #expect(scope.collection == ["com.example.bar", "com.example.foo"])
+    #expect(scope.action == [.create, .delete])
+  }
+
+  @Test func serializeOmitsDefaultActions() throws {
+    let scope = try RepoScope(collection: ["com.example.post"])
+    #expect(scope.description == "repo:com.example.post")
+  }
+
+  @Test func serializeIncludesNonDefaultActions() throws {
+    let scope = try RepoScope(collection: ["com.example.post"], action: [.create])
+    #expect(scope.description == "repo:com.example.post?action=create")
+  }
+
+  @Test func serializeMultipleCollectionsAsQuery() throws {
+    let scope = try RepoScope(
+      collection: ["com.example.foo", "com.example.bar"], action: [.create])
+    #expect(
+      scope.description
+        == "repo?collection=com.example.bar&collection=com.example.foo&action=create")
+  }
+
+  @Test func roundTripCanonicalForms() throws {
+    let canonical = [
+      "repo:com.example.post",
+      "repo:com.example.post?action=create",
+      "repo:*?action=delete",
+      "repo?collection=com.example.bar&collection=com.example.foo&action=create",
+    ]
+    for input in canonical {
+      let scope = try RepoScope(string: input)
+      #expect(scope.description == input, "round-trip mismatch for \(input)")
+    }
+  }
+
+  @Test func unknownActionThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RepoScope(string: "repo:com.example.post?action=wibble")
+    }
+  }
+
+  @Test func emptyPositionalThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RepoScope(string: "repo:?action=create")
+    }
+  }
+
+  @Test func emptyCollectionValueThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RepoScope(string: "repo?collection=&action=create")
+    }
+  }
+}

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -497,3 +497,98 @@ private enum MatchingPermissionSet: LexPermissionSet {
     LexPermission(resource: .rpc, inheritAud: true, lxm: ["com.example.auth.foo"])
   ]
 }
+
+private struct PermissionSetWire: Decodable {
+  let defs: Defs
+
+  struct Defs: Decodable {
+    let main: Main
+  }
+
+  struct Main: Decodable {
+    let permissions: [LexPermission]
+  }
+}
+
+struct EndToEndScopeExpansionTests {
+  private static let authCreatePostsJSON = #"""
+    {
+      "lexicon": 1,
+      "id": "com.example.authCreatePosts",
+      "defs": {
+        "main": {
+          "type": "permission-set",
+          "title": "Create Example Posts",
+          "detail": "Can not update or delete posts.",
+          "permissions": [
+            {
+              "type": "permission",
+              "resource": "rpc",
+              "inheritAud": true,
+              "lxm": [
+                "com.example.video.uploadVideo",
+                "com.example.video.getJobStatus",
+                "com.example.video.getUploadLimits"
+              ]
+            },
+            {
+              "type": "permission",
+              "resource": "repo",
+              "action": ["create"],
+              "collection": [
+                "com.example.feed.post",
+                "com.example.feed.postgate",
+                "com.example.feed.threadgate"
+              ]
+            }
+          ]
+        }
+      }
+    }
+    """#
+
+  @Test func expandsAuthCreatePostsAgainstCanonicalScopes() throws {
+    let wire = try JSONDecoder().decode(
+      PermissionSetWire.self, from: Data(Self.authCreatePostsJSON.utf8))
+    let include = try IncludeScope(
+      nsid: "com.example.authCreatePosts", aud: "did:web:example.com")
+    let scopes = try include.expand(wire.defs.main.permissions)
+    #expect(scopes.count == 2)
+    #expect(
+      scopes[0]
+        == "rpc?lxm=com.example.video.getJobStatus&lxm=com.example.video.getUploadLimits&lxm=com.example.video.uploadVideo&aud=did:web:example.com"
+    )
+    #expect(
+      scopes[1]
+        == "repo?collection=com.example.feed.post&collection=com.example.feed.postgate&collection=com.example.feed.threadgate&action=create"
+    )
+  }
+
+  @Test func roundTripExpandedScopesParseBack() throws {
+    let wire = try JSONDecoder().decode(
+      PermissionSetWire.self, from: Data(Self.authCreatePostsJSON.utf8))
+    let include = try IncludeScope(
+      nsid: "com.example.authCreatePosts", aud: "did:web:example.com")
+    let scopes = try include.expand(wire.defs.main.permissions)
+
+    let rpc = try RpcScope(string: scopes[0])
+    #expect(rpc.aud == "did:web:example.com")
+    #expect(
+      rpc.lxm == [
+        "com.example.video.getJobStatus",
+        "com.example.video.getUploadLimits",
+        "com.example.video.uploadVideo",
+      ])
+    #expect(rpc.description == scopes[0])
+
+    let repo = try RepoScope(string: scopes[1])
+    #expect(repo.action == [.create])
+    #expect(
+      repo.collection == [
+        "com.example.feed.post",
+        "com.example.feed.postgate",
+        "com.example.feed.threadgate",
+      ])
+    #expect(repo.description == scopes[1])
+  }
+}

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -254,3 +254,88 @@ struct RepoScopeTests {
     }
   }
 }
+
+struct IncludeScopeTests {
+  @Test func parsePositionalNsid() throws {
+    let scope = try IncludeScope(string: "include:com.example.foo.auth")
+    #expect(scope.nsid == "com.example.foo.auth")
+    #expect(scope.aud == nil)
+  }
+
+  @Test func parseWithAud() throws {
+    let scope = try IncludeScope(
+      string: "include:com.example.foo.auth?aud=did:web:example.com%23service")
+    #expect(scope.nsid == "com.example.foo.auth")
+    #expect(scope.aud == "did:web:example.com#service")
+  }
+
+  @Test func serializeWithoutAud() throws {
+    let scope = try IncludeScope(nsid: "com.example.foo.auth")
+    #expect(scope.description == "include:com.example.foo.auth")
+  }
+
+  @Test func serializeWithAud() throws {
+    let scope = try IncludeScope(
+      nsid: "com.example.foo.auth", aud: "did:web:example.com#service")
+    #expect(scope.description == "include:com.example.foo.auth?aud=did:web:example.com%23service")
+  }
+
+  @Test func roundTripCanonicalForms() throws {
+    let canonical = [
+      "include:com.example.foo.auth",
+      "include:com.example.foo.auth?aud=*",
+      "include:com.example.foo.auth?aud=did:web:example.com%23service",
+    ]
+    for input in canonical {
+      let scope = try IncludeScope(string: input)
+      #expect(scope.description == input, "round-trip mismatch for \(input)")
+    }
+  }
+
+  @Test func invalidNsidThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try IncludeScope(nsid: "not-an-nsid")
+    }
+  }
+
+  @Test func parentAuthorityAllowsSibling() throws {
+    let scope = try IncludeScope(nsid: "com.example.foo.auth")
+    #expect(scope.isParentAuthorityOf("com.example.foo.identifier") == true)
+  }
+
+  @Test func parentAuthorityAllowsDeeperChild() throws {
+    let scope = try IncludeScope(nsid: "com.example.foo.auth")
+    #expect(scope.isParentAuthorityOf("com.example.foo.bar.baz") == true)
+  }
+
+  @Test func parentAuthorityRejectsParentSibling() throws {
+    let scope = try IncludeScope(nsid: "com.example.foo.auth")
+    #expect(scope.isParentAuthorityOf("com.example.bar") == false)
+    #expect(scope.isParentAuthorityOf("com.example.bar.something") == false)
+  }
+
+  @Test func parentAuthorityRejectsSelfPrefixWithoutChild() throws {
+    let scope = try IncludeScope(nsid: "com.example.foo.auth")
+    #expect(scope.isParentAuthorityOf("com.example.foo") == false)
+  }
+
+  @Test func parentAuthorityRejectsWildcard() throws {
+    let scope = try IncludeScope(nsid: "com.example.foo.auth")
+    #expect(scope.isParentAuthorityOf("*") == false)
+  }
+
+  @Test func emptyPositionalThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try IncludeScope(string: "include:")
+    }
+    #expect(throws: OAuthScopeError.self) {
+      try IncludeScope(string: "include:?aud=did:web:example.com")
+    }
+  }
+
+  @Test func emptyAudThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try IncludeScope(string: "include:com.example.foo.auth?aud=")
+    }
+  }
+}

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -339,3 +339,161 @@ struct IncludeScopeTests {
     }
   }
 }
+
+struct IncludeScopeExpandTests {
+  @Test func expandsRpcWithInheritAud() throws {
+    let include = try IncludeScope(
+      nsid: "com.example.auth.scope", aud: "did:web:example.com#service")
+    let permissions = [
+      LexPermission(
+        resource: .rpc,
+        inheritAud: true,
+        lxm: ["com.example.auth.foo"]
+      )
+    ]
+    let scopes = try include.expand(permissions)
+    #expect(
+      scopes == ["rpc:com.example.auth.foo?aud=did:web:example.com%23service"])
+  }
+
+  @Test func expandsRpcWithWildcardAud() throws {
+    let include = try IncludeScope(nsid: "com.example.auth.scope")
+    let permissions = [
+      LexPermission(
+        resource: .rpc,
+        aud: "*",
+        lxm: ["com.example.auth.foo"]
+      )
+    ]
+    let scopes = try include.expand(permissions)
+    #expect(scopes == ["rpc:com.example.auth.foo?aud=*"])
+  }
+
+  @Test func expandsRepo() throws {
+    let include = try IncludeScope(nsid: "com.example.auth.scope")
+    let permissions = [
+      LexPermission(
+        resource: .repo,
+        action: [.create],
+        collection: ["com.example.auth.record"]
+      )
+    ]
+    let scopes = try include.expand(permissions)
+    #expect(scopes == ["repo:com.example.auth.record?action=create"])
+  }
+
+  @Test func expandsRepoWithDefaultActionsOmitted() throws {
+    let include = try IncludeScope(nsid: "com.example.auth.scope")
+    let permissions = [
+      LexPermission(
+        resource: .repo,
+        action: [.create, .update, .delete],
+        collection: ["com.example.auth.record"]
+      )
+    ]
+    let scopes = try include.expand(permissions)
+    #expect(scopes == ["repo:com.example.auth.record"])
+  }
+
+  @Test func rejectsRpcWithSpecificAudInPermissionSet() {
+    #expect(throws: OAuthScopeError.self) {
+      let include = try IncludeScope(nsid: "com.example.auth.scope")
+      let permissions = [
+        LexPermission(
+          resource: .rpc,
+          aud: "did:web:example.com",
+          lxm: ["com.example.auth.foo"]
+        )
+      ]
+      _ = try include.expand(permissions)
+    }
+  }
+
+  @Test func rejectsRpcInheritAudWithoutIncludeAud() {
+    #expect(throws: OAuthScopeError.self) {
+      let include = try IncludeScope(nsid: "com.example.auth.scope")
+      let permissions = [
+        LexPermission(
+          resource: .rpc,
+          inheritAud: true,
+          lxm: ["com.example.auth.foo"]
+        )
+      ]
+      _ = try include.expand(permissions)
+    }
+  }
+
+  @Test func rejectsNsidOutsideAuthority() {
+    #expect(throws: OAuthScopeError.self) {
+      let include = try IncludeScope(nsid: "com.example.auth.scope")
+      let permissions = [
+        LexPermission(
+          resource: .rpc,
+          inheritAud: true,
+          lxm: ["com.other.namespace.foo"]
+        )
+      ]
+      let scope = try IncludeScope(
+        nsid: "com.example.auth.scope", aud: "did:web:example.com")
+      _ = try scope.expand(permissions)
+      _ = include
+    }
+  }
+
+  @Test func rejectsUnsupportedResource() {
+    #expect(throws: OAuthScopeError.self) {
+      let include = try IncludeScope(nsid: "com.example.auth.scope")
+      let permissions = [
+        LexPermission(resource: LexPermissionResource(rawValue: "blob"))
+      ]
+      _ = try include.expand(permissions)
+    }
+  }
+
+  @Test func expandsMixedRpcAndRepo() throws {
+    let include = try IncludeScope(
+      nsid: "com.example.auth.scope", aud: "did:web:example.com")
+    let permissions = [
+      LexPermission(
+        resource: .rpc,
+        inheritAud: true,
+        lxm: ["com.example.auth.foo", "com.example.auth.bar"]
+      ),
+      LexPermission(
+        resource: .repo,
+        action: [.create],
+        collection: ["com.example.auth.record"]
+      ),
+    ]
+    let scopes = try include.expand(permissions)
+    #expect(scopes.count == 2)
+    #expect(
+      scopes[0]
+        == "rpc?lxm=com.example.auth.bar&lxm=com.example.auth.foo&aud=did:web:example.com")
+    #expect(scopes[1] == "repo:com.example.auth.record?action=create")
+  }
+
+  @Test func expandsFromPermissionSetType() throws {
+    let include = try IncludeScope(
+      nsid: "com.example.auth.scope", aud: "did:web:example.com")
+    let scopes = try include.expand(MatchingPermissionSet.self)
+    #expect(scopes == ["rpc:com.example.auth.foo?aud=did:web:example.com"])
+  }
+
+  @Test func rejectsMismatchedPermissionSetId() throws {
+    let include = try IncludeScope(
+      nsid: "com.example.auth.other", aud: "did:web:example.com")
+    #expect(throws: OAuthScopeError.self) {
+      try include.expand(MatchingPermissionSet.self)
+    }
+  }
+}
+
+private enum MatchingPermissionSet: LexPermissionSet {
+  static let id = "com.example.auth.scope"
+  static let title: String? = nil
+  static let detail: String? = nil
+  static let permissions: [LexPermission] = [
+    LexPermission(resource: .rpc, inheritAud: true, lxm: ["com.example.auth.foo"])
+  ]
+}


### PR DESCRIPTION
This PR gives swift-atproto first-class support for AT Protocol OAuth scope strings, so applications can request the exact permissions a Lexicon permission-set declares without hand-writing scope syntax. 