### PR TITLE
Support OAuth session scope inspection

### DIFF
--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -23,6 +23,12 @@ public struct RpcScope: CustomStringConvertible, Hashable, Sendable {
     guard !lxm.isEmpty else {
       throw OAuthScopeError.missingRequired("lxm")
     }
+    guard Self.isValidAudience(aud) else {
+      throw OAuthScopeError.invalidSyntax("invalid aud '\(aud)' in rpc scope")
+    }
+    for value in lxm where !Self.isValidLxm(value) {
+      throw OAuthScopeError.invalidSyntax("invalid lxm '\(value)' in rpc scope")
+    }
     let normalized = Self.normalize(lxm: lxm)
     if aud == "*", normalized.contains("*") {
       throw OAuthScopeError.forbiddenCombination("rpc:* with aud:*")
@@ -91,6 +97,14 @@ public struct RpcScope: CustomStringConvertible, Hashable, Sendable {
     }
     return Array(Set(lxm)).sorted()
   }
+
+  private static func isValidLxm(_ value: String) -> Bool {
+    value == "*" || NSID.isValid(value)
+  }
+
+  private static func isValidAudience(_ value: String) -> Bool {
+    isValidOAuthAudience(value)
+  }
 }
 
 public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
@@ -108,6 +122,9 @@ public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
     }
     for a in action where !Self.defaultActions.contains(a) {
       throw OAuthScopeError.invalidSyntax("unknown action '\(a.rawValue)' in repo scope")
+    }
+    for value in collection where !Self.isValidCollection(value) {
+      throw OAuthScopeError.invalidSyntax("invalid collection '\(value)' in repo scope")
     }
     self.collection = Self.normalize(collection: collection)
     self.action = Self.normalize(action: action)
@@ -182,6 +199,10 @@ public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
     let seen = Set(action)
     return Self.defaultActions.filter { seen.contains($0) }
   }
+
+  private static func isValidCollection(_ value: String) -> Bool {
+    value == "*" || NSID.isValid(value)
+  }
 }
 
 public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
@@ -191,6 +212,9 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
   public init(nsid: String, aud: String? = nil) throws {
     guard NSID.isValid(nsid) else {
       throw OAuthScopeError.invalidSyntax("invalid NSID '\(nsid)' in include scope")
+    }
+    if let aud, !isValidOAuthAudience(aud) {
+      throw OAuthScopeError.invalidSyntax("invalid aud '\(aud)' in include scope")
     }
     self.nsid = nsid
     self.aud = aud
@@ -322,5 +346,130 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
     }
     let actions = permission.action ?? RepoScope.defaultActions
     return try RepoScope(collection: collection, action: actions).description
+  }
+}
+
+public struct ScopesSet: Hashable, Sendable {
+  public let rpcScopes: [RpcScope]
+  public let repoScopes: [RepoScope]
+  public let includeScopes: [IncludeScope]
+  public let rawOther: Set<String>
+
+  public init(_ scopes: [String]) throws {
+    var rpc: [RpcScope] = []
+    var repo: [RepoScope] = []
+    var include: [IncludeScope] = []
+    var other: Set<String> = []
+    for scope in scopes {
+      let syntax = OAuthScopeSyntax.parse(scope)
+      switch syntax.prefix {
+      case "rpc":
+        rpc.append(try RpcScope(string: scope))
+      case "repo":
+        repo.append(try RepoScope(string: scope))
+      case "include":
+        include.append(try IncludeScope(string: scope))
+      default:
+        guard isValidRawOAuthScope(scope) else {
+          throw OAuthScopeError.invalidSyntax("invalid scope '\(scope)'")
+        }
+        other.insert(scope)
+      }
+    }
+    self.rpcScopes = rpc
+    self.repoScopes = repo
+    self.includeScopes = include
+    self.rawOther = other
+  }
+
+  public init(rawScopes scopes: [String]) {
+    var rpc: [RpcScope] = []
+    var repo: [RepoScope] = []
+    var include: [IncludeScope] = []
+    var other: Set<String> = []
+    for scope in scopes {
+      let syntax = OAuthScopeSyntax.parse(scope)
+      switch syntax.prefix {
+      case "rpc":
+        if let parsed = try? RpcScope(string: scope) { rpc.append(parsed) }
+      case "repo":
+        if let parsed = try? RepoScope(string: scope) { repo.append(parsed) }
+      case "include":
+        if let parsed = try? IncludeScope(string: scope) { include.append(parsed) }
+      default:
+        guard isValidRawOAuthScope(scope) else {
+          continue
+        }
+        other.insert(scope)
+      }
+    }
+    self.rpcScopes = rpc
+    self.repoScopes = repo
+    self.includeScopes = include
+    self.rawOther = other
+  }
+
+  public var hasAtprotoScope: Bool {
+    rawOther.contains(OAuthScope.atproto)
+  }
+
+  public func allowsRpc(lxm: String, aud: String) -> Bool {
+    guard hasAtprotoScope else {
+      return false
+    }
+    for scope in rpcScopes {
+      let lxmMatches = scope.lxm.contains(lxm) || scope.lxm.contains("*")
+      let audMatches = scope.aud == aud || scope.aud == "*"
+      if lxmMatches, audMatches {
+        return true
+      }
+    }
+    return false
+  }
+
+  public func allowsRepo(collection: String, action: LexPermissionAction) -> Bool {
+    guard hasAtprotoScope else {
+      return false
+    }
+    for scope in repoScopes {
+      let collMatches = scope.collection.contains(collection) || scope.collection.contains("*")
+      let actionMatches = scope.action.contains(action)
+      if collMatches, actionMatches {
+        return true
+      }
+    }
+    return false
+  }
+}
+
+private func isValidOAuthAudience(_ value: String) -> Bool {
+  if value == "*" {
+    return true
+  }
+  guard
+    let fragmentStart = value.firstIndex(of: "#"),
+    fragmentStart > value.startIndex,
+    value.index(after: fragmentStart) < value.endIndex,
+    value[value.index(after: fragmentStart)...].allSatisfy({ $0.isPrintableNonWhitespaceASCII })
+  else {
+    return false
+  }
+  let didPart = String(value[..<fragmentStart])
+  return (try? DID(string: didPart)) != nil
+}
+
+private func isValidRawOAuthScope(_ scope: String) -> Bool {
+  guard !scope.isEmpty else {
+    return false
+  }
+  return scope.allSatisfy(\.isPrintableNonWhitespaceASCII)
+}
+
+private extension Character {
+  var isPrintableNonWhitespaceASCII: Bool {
+    unicodeScalars.count == 1
+      && unicodeScalars.allSatisfy { scalar in
+        scalar.value >= 0x21 && scalar.value <= 0x7E
+      }
   }
 }

--- a/Sources/SwiftAtproto/OAuthSession.swift
+++ b/Sources/SwiftAtproto/OAuthSession.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public protocol OAuthSession: Sendable {
+  var sessionDid: DID { get }
+  var audienceDid: DID { get }
+  var grantedScopes: ScopesSet { get }
+}

--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -8,6 +8,8 @@ public protocol ATPClientProtocol: _XRPCCallable {
   func getAuthorization(endpoint: String) -> String?
 
   func refreshSession() async -> Bool
+
+  var oauthSession: (any OAuthSession)? { get }
 }
 
 public protocol _XRPCClientProtocol: ATPClientProtocol {
@@ -18,6 +20,7 @@ public protocol _XRPCClientProtocol: ATPClientProtocol {
 
 extension ATPClientProtocol {
   public func getProxy(nsid _: String) -> String? { nil }
+  public var oauthSession: (any OAuthSession)? { nil }
 }
 
 public protocol XRPCError: Error, LocalizedError, Decodable, Sendable {

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -99,7 +99,7 @@ struct RpcScopeTests {
 
   @Test func lxmWildcardCollapsesEvenWithOtherValues() throws {
     let scope = try RpcScope(
-      string: "rpc?lxm=com.example.m1&lxm=com.example.m2&lxm=*&aud=did:web:example.com")
+      string: "rpc?lxm=com.example.m1&lxm=com.example.m2&lxm=*&aud=did:web:example.com%23service")
     #expect(scope.lxm == ["*"])
   }
 
@@ -110,8 +110,8 @@ struct RpcScopeTests {
   }
 
   @Test func serializePositionalForSingleLxm() throws {
-    let scope = try RpcScope(aud: "did:web:example.com", lxm: ["com.example.method1"])
-    #expect(scope.description == "rpc:com.example.method1?aud=did:web:example.com")
+    let scope = try RpcScope(aud: "did:web:example.com#service", lxm: ["com.example.method1"])
+    #expect(scope.description == "rpc:com.example.method1?aud=did:web:example.com%23service")
   }
 
   @Test func serializeMultipleLxmAsQuery() throws {
@@ -168,6 +168,24 @@ struct RpcScopeTests {
   @Test func emptyLxmValueThrows() {
     #expect(throws: OAuthScopeError.self) {
       try RpcScope(string: "rpc?lxm=&aud=did:web:example.com")
+    }
+  }
+
+  @Test func invalidAudienceThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:com.example.method?aud=not-a-did")
+    }
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:com.example.method?aud=did:web:example.com")
+    }
+  }
+
+  @Test func invalidLxmThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:com.example.*?aud=did:web:example.com%23service")
+    }
+    #expect(throws: OAuthScopeError.self) {
+      try RpcScope(string: "rpc:not-an-nsid?aud=did:web:example.com%23service")
     }
   }
 }
@@ -251,6 +269,15 @@ struct RepoScopeTests {
   @Test func emptyCollectionValueThrows() {
     #expect(throws: OAuthScopeError.self) {
       try RepoScope(string: "repo?collection=&action=create")
+    }
+  }
+
+  @Test func invalidCollectionThrows() {
+    #expect(throws: OAuthScopeError.self) {
+      try RepoScope(string: "repo:com.example.*")
+    }
+    #expect(throws: OAuthScopeError.self) {
+      try RepoScope(string: "repo:not-an-nsid")
     }
   }
 }
@@ -401,7 +428,7 @@ struct IncludeScopeExpandTests {
       let permissions = [
         LexPermission(
           resource: .rpc,
-          aud: "did:web:example.com",
+          aud: "did:web:example.com#service",
           lxm: ["com.example.auth.foo"]
         )
       ]
@@ -434,7 +461,7 @@ struct IncludeScopeExpandTests {
         )
       ]
       let scope = try IncludeScope(
-        nsid: "com.example.auth.scope", aud: "did:web:example.com")
+        nsid: "com.example.auth.scope", aud: "did:web:example.com#service")
       _ = try scope.expand(permissions)
       _ = include
     }
@@ -452,7 +479,7 @@ struct IncludeScopeExpandTests {
 
   @Test func expandsMixedRpcAndRepo() throws {
     let include = try IncludeScope(
-      nsid: "com.example.auth.scope", aud: "did:web:example.com")
+      nsid: "com.example.auth.scope", aud: "did:web:example.com#service")
     let permissions = [
       LexPermission(
         resource: .rpc,
@@ -469,20 +496,20 @@ struct IncludeScopeExpandTests {
     #expect(scopes.count == 2)
     #expect(
       scopes[0]
-        == "rpc?lxm=com.example.auth.bar&lxm=com.example.auth.foo&aud=did:web:example.com")
+        == "rpc?lxm=com.example.auth.bar&lxm=com.example.auth.foo&aud=did:web:example.com%23service")
     #expect(scopes[1] == "repo:com.example.auth.record?action=create")
   }
 
   @Test func expandsFromPermissionSetType() throws {
     let include = try IncludeScope(
-      nsid: "com.example.auth.scope", aud: "did:web:example.com")
+      nsid: "com.example.auth.scope", aud: "did:web:example.com#service")
     let scopes = try include.expand(MatchingPermissionSet.self)
-    #expect(scopes == ["rpc:com.example.auth.foo?aud=did:web:example.com"])
+    #expect(scopes == ["rpc:com.example.auth.foo?aud=did:web:example.com%23service"])
   }
 
   @Test func rejectsMismatchedPermissionSetId() throws {
     let include = try IncludeScope(
-      nsid: "com.example.auth.other", aud: "did:web:example.com")
+      nsid: "com.example.auth.other", aud: "did:web:example.com#service")
     #expect(throws: OAuthScopeError.self) {
       try include.expand(MatchingPermissionSet.self)
     }
@@ -551,12 +578,12 @@ struct EndToEndScopeExpansionTests {
     let wire = try JSONDecoder().decode(
       PermissionSetWire.self, from: Data(Self.authCreatePostsJSON.utf8))
     let include = try IncludeScope(
-      nsid: "com.example.authCreatePosts", aud: "did:web:example.com")
+      nsid: "com.example.authCreatePosts", aud: "did:web:example.com#service")
     let scopes = try include.expand(wire.defs.main.permissions)
     #expect(scopes.count == 2)
     #expect(
       scopes[0]
-        == "rpc?lxm=com.example.video.getJobStatus&lxm=com.example.video.getUploadLimits&lxm=com.example.video.uploadVideo&aud=did:web:example.com"
+        == "rpc?lxm=com.example.video.getJobStatus&lxm=com.example.video.getUploadLimits&lxm=com.example.video.uploadVideo&aud=did:web:example.com%23service"
     )
     #expect(
       scopes[1]
@@ -568,11 +595,11 @@ struct EndToEndScopeExpansionTests {
     let wire = try JSONDecoder().decode(
       PermissionSetWire.self, from: Data(Self.authCreatePostsJSON.utf8))
     let include = try IncludeScope(
-      nsid: "com.example.authCreatePosts", aud: "did:web:example.com")
+      nsid: "com.example.authCreatePosts", aud: "did:web:example.com#service")
     let scopes = try include.expand(wire.defs.main.permissions)
 
     let rpc = try RpcScope(string: scopes[0])
-    #expect(rpc.aud == "did:web:example.com")
+    #expect(rpc.aud == "did:web:example.com#service")
     #expect(
       rpc.lxm == [
         "com.example.video.getJobStatus",
@@ -590,5 +617,126 @@ struct EndToEndScopeExpansionTests {
         "com.example.feed.threadgate",
       ])
     #expect(repo.description == scopes[1])
+  }
+}
+
+struct ScopesSetTests {
+  @Test func parsesAtprotoAndRpcScopes() throws {
+    let set = try ScopesSet([
+      "atproto",
+      "rpc:com.example.foo?aud=did:web:example.com%23service",
+    ])
+    #expect(set.hasAtprotoScope)
+    #expect(set.rpcScopes.count == 1)
+    #expect(set.repoScopes.isEmpty)
+    #expect(set.includeScopes.isEmpty)
+  }
+
+  @Test func parsesIncludeScope() throws {
+    let set = try ScopesSet(["include:com.example.foo.auth?aud=*"])
+    #expect(set.includeScopes.count == 1)
+    #expect(set.includeScopes[0].nsid == "com.example.foo.auth")
+  }
+
+  @Test func unknownPrefixGoesToRawOther() throws {
+    let set = try ScopesSet(["transition:generic", "atproto"])
+    #expect(set.rawOther.contains("transition:generic"))
+    #expect(set.hasAtprotoScope)
+  }
+
+  @Test func throwingInitRejectsInvalidScope() {
+    #expect(throws: OAuthScopeError.self) {
+      _ = try ScopesSet(["rpc:*?aud=*"])
+    }
+  }
+
+  @Test func rawScopesInitSkipsInvalid() {
+    let set = ScopesSet(rawScopes: [
+      "atproto",
+      "rpc:*?aud=*",
+      "rpc:com.example.foo?aud=did:web:example.com%23service",
+    ])
+    #expect(set.hasAtprotoScope)
+    #expect(set.rpcScopes.count == 1)
+    #expect(set.rpcScopes[0].lxm == ["com.example.foo"])
+  }
+
+  @Test func allowsRpcExactMatch() throws {
+    let set = try ScopesSet(["atproto", "rpc:com.example.foo?aud=did:web:example.com%23service"])
+    #expect(set.allowsRpc(lxm: "com.example.foo", aud: "did:web:example.com#service"))
+    #expect(!set.allowsRpc(lxm: "com.example.bar", aud: "did:web:example.com#service"))
+    #expect(!set.allowsRpc(lxm: "com.example.foo", aud: "did:web:other.com"))
+  }
+
+  @Test func allowsRpcWildcardLxm() throws {
+    let set = try ScopesSet(["atproto", "rpc:*?aud=did:web:example.com%23service"])
+    #expect(set.allowsRpc(lxm: "com.example.anything", aud: "did:web:example.com#service"))
+    #expect(!set.allowsRpc(lxm: "com.example.anything", aud: "did:web:other.com"))
+  }
+
+  @Test func allowsRpcWildcardAud() throws {
+    let set = try ScopesSet(["atproto", "rpc:com.example.foo?aud=*"])
+    #expect(set.allowsRpc(lxm: "com.example.foo", aud: "did:web:example.com#service"))
+    #expect(set.allowsRpc(lxm: "com.example.foo", aud: "did:web:other.com"))
+  }
+
+  @Test func allowsRpcReturnsFalseOnEmptyScopes() throws {
+    let set = try ScopesSet(["atproto"])
+    #expect(!set.allowsRpc(lxm: "com.example.foo", aud: "did:web:example.com"))
+  }
+
+  @Test func allowsRepoExactMatch() throws {
+    let set = try ScopesSet(["atproto", "repo:com.example.post?action=create"])
+    #expect(set.allowsRepo(collection: "com.example.post", action: .create))
+    #expect(!set.allowsRepo(collection: "com.example.post", action: .delete))
+    #expect(!set.allowsRepo(collection: "com.example.other", action: .create))
+  }
+
+  @Test func allowsRepoDefaultActions() throws {
+    let set = try ScopesSet(["atproto", "repo:com.example.post"])
+    #expect(set.allowsRepo(collection: "com.example.post", action: .create))
+    #expect(set.allowsRepo(collection: "com.example.post", action: .update))
+    #expect(set.allowsRepo(collection: "com.example.post", action: .delete))
+  }
+
+  @Test func allowsRepoCollectionWildcard() throws {
+    let set = try ScopesSet(["atproto", "repo:*?action=create"])
+    #expect(set.allowsRepo(collection: "com.example.anything", action: .create))
+    #expect(!set.allowsRepo(collection: "com.example.anything", action: .update))
+  }
+
+  @Test func multipleScopesCombineForBroadCoverage() throws {
+    let set = try ScopesSet([
+      "atproto",
+      "rpc:com.example.foo?aud=did:web:example.com%23service",
+      "rpc:com.example.bar?aud=did:web:example.com%23service",
+      "repo:com.example.post?action=create",
+    ])
+    #expect(set.allowsRpc(lxm: "com.example.foo", aud: "did:web:example.com#service"))
+    #expect(set.allowsRpc(lxm: "com.example.bar", aud: "did:web:example.com#service"))
+    #expect(set.allowsRepo(collection: "com.example.post", action: .create))
+  }
+
+  @Test func allowsRequireAtprotoScope() throws {
+    let set = try ScopesSet([
+      "rpc:com.example.foo?aud=did:web:example.com%23service",
+      "repo:com.example.post?action=create",
+    ])
+    #expect(!set.hasAtprotoScope)
+    #expect(!set.allowsRpc(lxm: "com.example.foo", aud: "did:web:example.com#service"))
+    #expect(!set.allowsRepo(collection: "com.example.post", action: .create))
+  }
+
+  @Test func throwingInitRejectsMalformedRawScopes() {
+    for scope in ["", "bad scope", "emoji:☺️"] {
+      #expect(throws: OAuthScopeError.self) {
+        _ = try ScopesSet([scope])
+      }
+    }
+  }
+
+  @Test func rawScopesInitSkipsMalformedRawScopes() {
+    let set = ScopesSet(rawScopes: ["", "bad scope", "emoji:☺️", "transition:generic"])
+    #expect(set.rawOther == ["transition:generic"])
   }
 }

--- a/Tests/SwiftAtprotoTests/OAuthSessionTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthSessionTests.swift
@@ -20,6 +20,23 @@ struct OAuthSessionTests {
       session.grantedScopes.allowsRpc(
         lxm: "com.example.foo", aud: "did:web:pds.example.com#service"))
   }
+
+  @Test func defaultOAuthSessionOnATPClientProtocolIsNil() {
+    let client = MinimalATPClient()
+    let typeErased: any ATPClientProtocol = client
+    #expect(typeErased.oauthSession == nil)
+  }
+
+  @Test func clientCanOverrideOAuthSession() throws {
+    let session = try SampleOAuthSession(
+      sessionDidString: "did:web:user.example.com",
+      audienceDidString: "did:web:pds.example.com",
+      scopeStrings: ["atproto"]
+    )
+    let client = OAuthAwareATPClient(session: session)
+    let typeErased: any ATPClientProtocol = client
+    #expect(typeErased.oauthSession?.sessionDid.rawValue == "did:web:user.example.com")
+  }
 }
 
 private struct SampleOAuthSession: OAuthSession {
@@ -32,4 +49,28 @@ private struct SampleOAuthSession: OAuthSession {
     self.audienceDid = try DID(string: audienceDidString)
     self.grantedScopes = try ScopesSet(scopeStrings)
   }
+}
+
+private struct MinimalATPClient: @unchecked Sendable, ATPClientProtocol {
+  let serviceEndpoint = URL(string: "https://example.com")!
+  let decoder = JSONDecoder()
+  func tokenIsExpired(error _: some XRPCError) -> Bool { false }
+  func getAuthorization(endpoint _: String) -> String? { nil }
+  func refreshSession() async -> Bool { false }
+  func response(_: XRPCRequestComponents) async throws -> Data { Data() }
+}
+
+private struct OAuthAwareATPClient: @unchecked Sendable, ATPClientProtocol {
+  let serviceEndpoint = URL(string: "https://example.com")!
+  let decoder = JSONDecoder()
+  let oauthSession: (any OAuthSession)?
+
+  init(session: some OAuthSession) {
+    self.oauthSession = session
+  }
+
+  func tokenIsExpired(error _: some XRPCError) -> Bool { false }
+  func getAuthorization(endpoint _: String) -> String? { nil }
+  func refreshSession() async -> Bool { false }
+  func response(_: XRPCRequestComponents) async throws -> Data { Data() }
 }

--- a/Tests/SwiftAtprotoTests/OAuthSessionTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthSessionTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct OAuthSessionTests {
+  @Test func conformingTypeExposesAllProperties() throws {
+    let session = try SampleOAuthSession(
+      sessionDidString: "did:web:user.example.com",
+      audienceDidString: "did:web:pds.example.com",
+      scopeStrings: [
+        "atproto",
+        "rpc:com.example.foo?aud=did:web:pds.example.com%23service",
+      ]
+    )
+    #expect(session.sessionDid.rawValue == "did:web:user.example.com")
+    #expect(session.audienceDid.rawValue == "did:web:pds.example.com")
+    #expect(session.grantedScopes.hasAtprotoScope)
+    #expect(
+      session.grantedScopes.allowsRpc(
+        lxm: "com.example.foo", aud: "did:web:pds.example.com#service"))
+  }
+}
+
+private struct SampleOAuthSession: OAuthSession {
+  let sessionDid: DID
+  let audienceDid: DID
+  let grantedScopes: ScopesSet
+
+  init(sessionDidString: String, audienceDidString: String, scopeStrings: [String]) throws {
+    self.sessionDid = try DID(string: sessionDidString)
+    self.audienceDid = try DID(string: audienceDidString)
+    self.grantedScopes = try ScopesSet(scopeStrings)
+  }
+}


### PR DESCRIPTION
This adds a lightweight OAuth session boundary for clients that already manage their own OAuth flow. 