### PR TITLE
Skip generated directories when formatting Swift files

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,2 +1,11 @@
 #!/usr/bin/env bash
-swift format -p --recursive . --in-place
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+find . -type d \( \
+  -name "DerivedData" \
+  -o -name ".build" \
+  -o -name ".swiftpm" \
+  -o -name ".git" \
+\) -prune -o -type f -name "*.swift" -exec swift format -p --in-place {} +


### PR DESCRIPTION
This PR updates the formatting helper to ignore generated and tool-managed directories before invoking `swift format`.