### PR TITLE
Guard repository writes with granted OAuth scopes

### DIFF
--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -28,6 +28,7 @@ public enum OAuthScopeError: Error, Hashable, Sendable {
   case nsidOutsideAuthority(parent: String, other: String)
   case unsupportedResource(String)
   case insufficientScope(lxm: String, aud: String)
+  case insufficientRepoScope(collection: String, action: LexPermissionAction)
 }
 
 public struct RpcScope: CustomStringConvertible, Hashable, Sendable {

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -4,6 +4,20 @@ public enum OAuthScope {
   public static let atproto = "atproto"
 }
 
+public struct RepoWriteRequirement: Hashable, Sendable {
+  public let collection: String
+  public let action: LexPermissionAction
+
+  public init(collection: String, action: LexPermissionAction) {
+    self.collection = collection
+    self.action = action
+  }
+}
+
+public protocol RepoWriteOperationDescribing: Sendable {
+  var repoWriteRequirements: [RepoWriteRequirement] { get }
+}
+
 public enum OAuthScopeError: Error, Hashable, Sendable {
   case invalidSyntax(String)
   case invalidResource(String)

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -26,6 +26,7 @@ extension _XRPCCallable {
   public func call<X: XRPCProcedure>(_ procedure: X.Type, input: X.RequestBody?) async throws -> X.ResponseBody {
     let proxy = getProxy(nsid: X.id)
     try enforceScopeGuard(X.self, proxy: proxy)
+    try enforceRepoScopeGuard(input as? any RepoWriteOperationDescribing)
     var request = try constructRequest(procedure, input: input)
     if let proxy {
       request.headers[.atprotoProxy] = proxy
@@ -39,6 +40,16 @@ extension _XRPCCallable {
     let aud = proxy ?? "\(session.audienceDid.rawValue)#atproto_pds"
     guard session.grantedScopes.allowsRpc(lxm: lxm, aud: aud) else {
       throw OAuthScopeError.insufficientScope(lxm: lxm, aud: aud)
+    }
+  }
+
+  private func enforceRepoScopeGuard(_ op: (any RepoWriteOperationDescribing)?) throws {
+    guard let session = (self as? ATPClientProtocol)?.oauthSession else { return }
+    guard let op else { return }
+    for req in op.repoWriteRequirements {
+      guard session.grantedScopes.allowsRepo(collection: req.collection, action: req.action) else {
+        throw OAuthScopeError.insufficientRepoScope(collection: req.collection, action: req.action)
+      }
     }
   }
 

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -61,11 +61,20 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
       required[key] = false
     }
     let hasConstraints = sortedProperties.contains { $0.1.hasConstraints }
+    let repoWriteAction = Self.repoWriteAction(nsid: ts.id, inputName: name)
+    let inheritedNames: [String] = {
+      if ts.isRecord { return ["ATProtoRecord"] }
+      var names = ["Codable", "Hashable", "Sendable"]
+      if repoWriteAction != nil {
+        names.append("RepoWriteOperationDescribing")
+      }
+      return names
+    }()
     return StructDeclSyntax(
       leadingTrivia: leadingTrivia,
       modifiers: [declModifierSyntax],
       name: .lexIdentifier(name),
-      inheritanceClause: InheritanceClauseSyntax(typeNames: ts.isRecord ? ["ATProtoRecord"] : ["Codable", "Hashable", "Sendable"])
+      inheritanceClause: InheritanceClauseSyntax(typeNames: inheritedNames)
     ) {
       if ts.isRecord {
         VariableDeclSyntax(
@@ -149,6 +158,10 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
         .with(\.leadingTrivia, .newlines(2))
       if hasConstraints {
         staticMakeDecl(ts: ts, name: name, defMap: defMap, required: required)
+          .with(\.leadingTrivia, .newlines(2))
+      }
+      if let actionRaw = repoWriteAction {
+        Self.repoWriteRequirementsAccessor(actionRaw: actionRaw)
           .with(\.leadingTrivia, .newlines(2))
       }
       if !enumCaseIsEmpty {
@@ -867,5 +880,76 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
         }
       )
     }
+  }
+
+  private static func repoWriteAction(nsid: String, inputName: String) -> String? {
+    guard inputName.hasSuffix("_Input") else { return nil }
+    switch nsid {
+    case "com.atproto.repo.createRecord": return "create"
+    case "com.atproto.repo.putRecord": return "update"
+    case "com.atproto.repo.deleteRecord": return "delete"
+    default: return nil
+    }
+  }
+
+  private static func repoWriteRequirementsAccessor(actionRaw: String) -> VariableDeclSyntax {
+    VariableDeclSyntax(
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      bindingSpecifier: .keyword(.var),
+      bindings: [
+        PatternBindingSyntax(
+          pattern: IdentifierPatternSyntax(identifier: .identifier("repoWriteRequirements")),
+          typeAnnotation: TypeAnnotationSyntax(
+            type: ArrayTypeSyntax(
+              element: IdentifierTypeSyntax(name: .identifier("RepoWriteRequirement"))
+            )
+          ),
+          accessorBlock: AccessorBlockSyntax(
+            leftBrace: .leftBraceToken(),
+            accessors: AccessorBlockSyntax.Accessors([
+              CodeBlockItemSyntax(
+                item: CodeBlockItemSyntax.Item(
+                  ArrayExprSyntax(
+                    leftSquare: .leftSquareToken(),
+                    elements: ArrayElementListSyntax([
+                      ArrayElementSyntax(
+                        expression: FunctionCallExprSyntax(
+                          calledExpression: DeclReferenceExprSyntax(
+                            baseName: .identifier("RepoWriteRequirement")),
+                          leftParen: .leftParenToken(),
+                          arguments: LabeledExprListSyntax([
+                            LabeledExprSyntax(
+                              label: .identifier("collection"),
+                              colon: .colonToken(),
+                              expression: MemberAccessExprSyntax(
+                                base: DeclReferenceExprSyntax(baseName: .identifier("collection")),
+                                period: .periodToken(),
+                                declName: DeclReferenceExprSyntax(baseName: .identifier("rawValue"))
+                              ),
+                              trailingComma: .commaToken()
+                            ),
+                            LabeledExprSyntax(
+                              label: .identifier("action"),
+                              colon: .colonToken(),
+                              expression: MemberAccessExprSyntax(
+                                period: .periodToken(),
+                                name: .identifier(actionRaw)
+                              )
+                            ),
+                          ]),
+                          rightParen: .rightParenToken()
+                        )
+                      )
+                    ]),
+                    rightSquare: .rightSquareToken()
+                  )
+                )
+              )
+            ]),
+            rightBrace: .rightBraceToken()
+          )
+        )
+      ]
+    )
   }
 }

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -705,6 +705,24 @@ struct ScopesSetTests {
     #expect(!set.allowsRepo(collection: "com.example.anything", action: .update))
   }
 
+  @Test func repoWriteRequirementInitAndEquality() {
+    let a = RepoWriteRequirement(collection: "com.example.post", action: .create)
+    let b = RepoWriteRequirement(collection: "com.example.post", action: .create)
+    let c = RepoWriteRequirement(collection: "com.example.post", action: .delete)
+    #expect(a == b)
+    #expect(a != c)
+    #expect(a.collection == "com.example.post")
+    #expect(a.action == .create)
+  }
+
+  @Test func conformingTypeReportsRequirements() {
+    let op = SampleRepoOp(collection: "com.example.post", action: .create)
+    #expect(
+      op.repoWriteRequirements == [
+        RepoWriteRequirement(collection: "com.example.post", action: .create)
+      ])
+  }
+
   @Test func multipleScopesCombineForBroadCoverage() throws {
     let set = try ScopesSet([
       "atproto",
@@ -738,5 +756,13 @@ struct ScopesSetTests {
   @Test func rawScopesInitSkipsMalformedRawScopes() {
     let set = ScopesSet(rawScopes: ["", "bad scope", "emoji:☺️", "transition:generic"])
     #expect(set.rawOther == ["transition:generic"])
+  }
+}
+
+private struct SampleRepoOp: RepoWriteOperationDescribing {
+  let collection: String
+  let action: LexPermissionAction
+  var repoWriteRequirements: [RepoWriteRequirement] {
+    [RepoWriteRequirement(collection: collection, action: action)]
   }
 }

--- a/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
@@ -268,3 +268,129 @@ private struct PrebuiltScopesSession: OAuthSession {
   let audienceDid: DID
   let grantedScopes: ScopesSet
 }
+
+struct RepoScopeGuardEnforcementTests {
+  @Test func sufficientRepoScopePassesGuard() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "rpc:com.example.stub.repoWrite?aud=did:web:pds.example.com%23atproto_pds",
+      "repo:com.example.post?action=create",
+    ])
+    let client = MockClient(session: session)
+    _ = try await client.call(
+      StubRepoProcedure.self,
+      input: StubRepoInput(collection: "com.example.post", action: .create))
+  }
+
+  @Test func insufficientRepoScopeThrows() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "rpc:com.example.stub.repoWrite?aud=did:web:pds.example.com%23atproto_pds",
+    ])
+    let client = MockClient(session: session)
+    await #expect(
+      throws: OAuthScopeError.insufficientRepoScope(
+        collection: "com.example.post",
+        action: .create
+      )
+    ) {
+      _ = try await client.call(
+        StubRepoProcedure.self,
+        input: StubRepoInput(collection: "com.example.post", action: .create))
+    }
+  }
+
+  @Test func wrongActionRepoScopeThrows() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "rpc:com.example.stub.repoWrite?aud=did:web:pds.example.com%23atproto_pds",
+      "repo:com.example.post?action=update",
+    ])
+    let client = MockClient(session: session)
+    await #expect(
+      throws: OAuthScopeError.insufficientRepoScope(
+        collection: "com.example.post",
+        action: .create
+      )
+    ) {
+      _ = try await client.call(
+        StubRepoProcedure.self,
+        input: StubRepoInput(collection: "com.example.post", action: .create))
+    }
+  }
+
+  @Test func nonConformingInputSkipsRepoGuard() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "rpc:com.example.stub.procedure?aud=did:web:pds.example.com%23atproto_pds",
+    ])
+    let client = MockClient(session: session)
+    _ = try await client.call(StubProcedure.self, input: nil)
+  }
+
+  @Test func nilSessionSkipsRepoGuard() async throws {
+    let client = MockClient(session: nil)
+    _ = try await client.call(
+      StubRepoProcedure.self,
+      input: StubRepoInput(collection: "com.example.post", action: .create))
+  }
+
+  @Test func multipleRequirementsAllChecked() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "rpc:com.example.stub.repoWriteBatch?aud=did:web:pds.example.com%23atproto_pds",
+      "repo:com.example.post?action=create",
+    ])
+    let client = MockClient(session: session)
+    await #expect(
+      throws: OAuthScopeError.insufficientRepoScope(
+        collection: "com.example.other",
+        action: .create
+      )
+    ) {
+      _ = try await client.call(
+        StubRepoBatchProcedure.self,
+        input: StubRepoBatchInput(items: [
+          .init(collection: "com.example.post", action: "create"),
+          .init(collection: "com.example.other", action: "create"),
+        ]))
+    }
+  }
+}
+
+struct StubRepoInput: Codable, Sendable, Hashable, RepoWriteOperationDescribing {
+  let collection: String
+  let action: LexPermissionAction
+  var repoWriteRequirements: [RepoWriteRequirement] {
+    [RepoWriteRequirement(collection: collection, action: action)]
+  }
+}
+
+enum StubRepoProcedure: XRPCProcedure {
+  static let id = "com.example.stub.repoWrite"
+  static let contentType = "application/json"
+  typealias RequestBody = StubRepoInput
+  typealias ResponseBody = EmptyResponse
+  typealias Error = UnExpectedError
+}
+
+struct StubRepoBatchInput: Codable, Sendable, Hashable, RepoWriteOperationDescribing {
+  struct Item: Codable, Sendable, Hashable {
+    let collection: String
+    let action: String
+  }
+  let items: [Item]
+  var repoWriteRequirements: [RepoWriteRequirement] {
+    items.map {
+      RepoWriteRequirement(collection: $0.collection, action: LexPermissionAction(rawValue: $0.action))
+    }
+  }
+}
+
+enum StubRepoBatchProcedure: XRPCProcedure {
+  static let id = "com.example.stub.repoWriteBatch"
+  static let contentType = "application/json"
+  typealias RequestBody = StubRepoBatchInput
+  typealias ResponseBody = EmptyResponse
+  typealias Error = UnExpectedError
+}


### PR DESCRIPTION
This PR adds client-side OAuth repo scope enforcement for repository write procedures, so clients that expose an OAuth session can reject unauthorized record creates, updates, and deletes before they are sent. 