### PR TITLE
Match include scopes against Lexicon permission sets

### DIFF
--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -371,7 +371,7 @@ public struct ScopesSet: Hashable, Sendable {
   public let includeScopes: [IncludeScope]
   public let rawOther: Set<String>
 
-  public init(_ scopes: [String]) throws {
+  public init(_ scopes: [String], permissionSets: [any LexPermissionSet.Type] = []) throws {
     var rpc: [RpcScope] = []
     var repo: [RepoScope] = []
     var include: [IncludeScope] = []
@@ -392,13 +392,14 @@ public struct ScopesSet: Hashable, Sendable {
         other.insert(scope)
       }
     }
+    try Self.expandIncludes(include, permissionSets: permissionSets, into: &rpc, repo: &repo)
     self.rpcScopes = rpc
     self.repoScopes = repo
     self.includeScopes = include
     self.rawOther = other
   }
 
-  public init(rawScopes scopes: [String]) {
+  public init(rawScopes scopes: [String], permissionSets: [any LexPermissionSet.Type] = []) {
     var rpc: [RpcScope] = []
     var repo: [RepoScope] = []
     var include: [IncludeScope] = []
@@ -419,10 +420,39 @@ public struct ScopesSet: Hashable, Sendable {
         other.insert(scope)
       }
     }
+    try? Self.expandIncludes(include, permissionSets: permissionSets, into: &rpc, repo: &repo)
     self.rpcScopes = rpc
     self.repoScopes = repo
     self.includeScopes = include
     self.rawOther = other
+  }
+
+  private static func expandIncludes(
+    _ includes: [IncludeScope],
+    permissionSets: [any LexPermissionSet.Type],
+    into rpc: inout [RpcScope],
+    repo: inout [RepoScope]
+  ) throws {
+    guard !permissionSets.isEmpty, !includes.isEmpty else { return }
+    let registry = Dictionary(
+      permissionSets.map { ($0.id, $0) },
+      uniquingKeysWith: { first, _ in first }
+    )
+    for include in includes {
+      guard let psType = registry[include.nsid] else { continue }
+      let expanded = try include.expand(psType)
+      for scopeStr in expanded {
+        let syntax = OAuthScopeSyntax.parse(scopeStr)
+        switch syntax.prefix {
+        case "rpc":
+          rpc.append(try RpcScope(string: scopeStr))
+        case "repo":
+          repo.append(try RepoScope(string: scopeStr))
+        default:
+          break
+        }
+      }
+    }
   }
 
   public var hasAtprotoScope: Bool {

--- a/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/OAuthScopeTests.swift
@@ -766,3 +766,135 @@ private struct SampleRepoOp: RepoWriteOperationDescribing {
     [RepoWriteRequirement(collection: collection, action: action)]
   }
 }
+
+struct IncludeScopeMatchTests {
+  @Test func includeWithoutRegistryDoesNotMatch() throws {
+    let set = try ScopesSet([
+      "atproto",
+      "include:com.example.auth.scope?aud=did:web:pds.example.com%23atproto_pds",
+    ])
+    #expect(set.includeScopes.count == 1)
+    #expect(!set.allowsRpc(lxm: "com.example.auth.foo", aud: "did:web:pds.example.com#atproto_pds"))
+  }
+
+  @Test func includeWithRegistryAllowsRpc() throws {
+    let set = try ScopesSet(
+      [
+        "atproto",
+        "include:com.example.auth.scope?aud=did:web:pds.example.com%23atproto_pds",
+      ],
+      permissionSets: [SampleAuthPermissionSet.self]
+    )
+    #expect(
+      set.allowsRpc(lxm: "com.example.auth.foo", aud: "did:web:pds.example.com#atproto_pds"))
+    #expect(
+      set.allowsRpc(lxm: "com.example.auth.bar", aud: "did:web:pds.example.com#atproto_pds"))
+  }
+
+  @Test func includeWithRegistryAllowsRepo() throws {
+    let set = try ScopesSet(
+      [
+        "atproto",
+        "include:com.example.auth.scope?aud=did:web:pds.example.com%23atproto_pds",
+      ],
+      permissionSets: [SampleAuthPermissionSet.self]
+    )
+    #expect(set.allowsRepo(collection: "com.example.auth.record", action: .create))
+    #expect(!set.allowsRepo(collection: "com.example.auth.record", action: .delete))
+  }
+
+  @Test func includeWithMismatchedAudFromRegistryIsRejected() throws {
+    let set = try ScopesSet(
+      [
+        "atproto",
+        "include:com.example.auth.scope?aud=did:web:pds.example.com%23atproto_pds",
+      ],
+      permissionSets: [SampleAuthPermissionSet.self]
+    )
+    #expect(
+      !set.allowsRpc(lxm: "com.example.auth.foo", aud: "did:web:other.example.com#atproto_pds"))
+  }
+
+  @Test func unknownIncludeNsidSilentlySkipped() throws {
+    let set = try ScopesSet(
+      ["include:com.unknown.scope?aud=did:web:pds.example.com%23atproto_pds"],
+      permissionSets: [SampleAuthPermissionSet.self]
+    )
+    #expect(set.includeScopes.count == 1)
+    #expect(!set.allowsRpc(lxm: "com.unknown.foo", aud: "did:web:pds.example.com#atproto_pds"))
+  }
+
+  @Test func rawScopesInitAcceptsRegistry() {
+    let set = ScopesSet(
+      rawScopes: [
+        "atproto",
+        "include:com.example.auth.scope?aud=did:web:pds.example.com%23atproto_pds",
+        "garbage:invalid",
+      ],
+      permissionSets: [SampleAuthPermissionSet.self]
+    )
+    #expect(set.hasAtprotoScope)
+    #expect(
+      set.allowsRpc(lxm: "com.example.auth.foo", aud: "did:web:pds.example.com#atproto_pds"))
+  }
+
+  @Test func throwingInitPropagatesRegisteredPermissionSetExpansionErrors() {
+    #expect(
+      throws: OAuthScopeError.nsidOutsideAuthority(
+        parent: "com.example.bad.scope",
+        other: "com.other.auth.foo"
+      )
+    ) {
+      _ = try ScopesSet(
+        [
+          "atproto",
+          "include:com.example.bad.scope?aud=did:web:pds.example.com%23atproto_pds",
+        ],
+        permissionSets: [BrokenAuthPermissionSet.self]
+      )
+    }
+  }
+
+  @Test func rawScopesInitSkipsRegisteredPermissionSetExpansionErrors() {
+    let set = ScopesSet(
+      rawScopes: [
+        "atproto",
+        "include:com.example.bad.scope?aud=did:web:pds.example.com%23atproto_pds",
+      ],
+      permissionSets: [BrokenAuthPermissionSet.self]
+    )
+    #expect(set.includeScopes.count == 1)
+    #expect(!set.allowsRpc(lxm: "com.other.auth.foo", aud: "did:web:pds.example.com#atproto_pds"))
+  }
+}
+
+private enum SampleAuthPermissionSet: LexPermissionSet {
+  static let id = "com.example.auth.scope"
+  static let title: String? = "Sample Auth"
+  static let detail: String? = nil
+  static let permissions: [LexPermission] = [
+    LexPermission(
+      resource: .rpc,
+      inheritAud: true,
+      lxm: ["com.example.auth.foo", "com.example.auth.bar"]
+    ),
+    LexPermission(
+      resource: .repo,
+      action: [.create],
+      collection: ["com.example.auth.record"]
+    ),
+  ]
+}
+
+private enum BrokenAuthPermissionSet: LexPermissionSet {
+  static let id = "com.example.bad.scope"
+  static let title: String? = nil
+  static let detail: String? = nil
+  static let permissions: [LexPermission] = [
+    LexPermission(
+      resource: .rpc,
+      inheritAud: true,
+      lxm: ["com.other.auth.foo"]
+    )
+  ]
+}


### PR DESCRIPTION
This PR lets OAuth include scopes participate in client-side scope checks by expanding them through registered Lexicon permission-set definitions. 