### PR TITLE
fix: decouple code generation from lexicon disk layout

### DIFF
--- a/Sources/SourceControl/LexiconConfig.swift
+++ b/Sources/SourceControl/LexiconConfig.swift
@@ -66,20 +66,20 @@ public struct LexiconConfig: Encodable, DecodableWithConfiguration, Sendable {
 
 public struct LexiconDependency: Codable, Sendable {
   public struct Lexicon: Codable, Sendable {
-    public let prefix: String
+    /// Source-repo-relative directory that holds the lexicon JSON files. The
+    /// install step reads each JSON's `id`, joins it as `<id-as-path>.json`
+    /// onto `.lexicons/lexicons/`, and copies (or symlinks, for local deps)
+    /// the file there. No transformation of `path` beyond this is performed.
     public let path: String
+    /// Optional allowlist. When present, only the listed NSIDs are installed
+    /// (each expected to live at `<path>/<nsid-as-path>.json` in the source).
+    /// When absent, every `.json` file under `<path>` is discovered
+    /// recursively and installed based on its own `id`.
     public let nsIds: [NSID]?
 
-    public var rootPath: String {
-      if path.hasSuffix(prefixAsPath) {
-        let index = path.index(path.endIndex, offsetBy: -prefixAsPath.count)
-        return String(path[..<index]).trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-      }
-      return path  // 一致しない場合は path そのものを返すか、空にする
-    }
-
-    private var prefixAsPath: String {
-      prefix.replacingOccurrences(of: ".", with: "/")
+    public init(path: String, nsIds: [NSID]? = nil) {
+      self.path = path
+      self.nsIds = nsIds
     }
   }
 

--- a/Sources/SourceControl/LexiconsStore.swift
+++ b/Sources/SourceControl/LexiconsStore.swift
@@ -28,11 +28,6 @@ public struct LexiconsStore: Codable {
 }
 
 public struct ResolvedLexiconDependency: Codable {
-  public struct Lexicon: Codable {
-    public let prefix: String
-    public let path: String
-  }
-
   public struct SourceState: Codable {
     public let tag: String?
     public let revision: String

--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -50,14 +50,63 @@ func isLocalDependency(_ location: URL) -> Bool {
 
 public enum LexiconConfigError: Error, CustomStringConvertible, Equatable {
   case unsafeLexiconSubpath(field: String, value: String)
+  case missingNSID(nsId: String, path: String)
 
   public var description: String {
     switch self {
     case .unsafeLexiconSubpath(let field, let value):
       return
         "Invalid lexicon \(field) \"\(value)\": must be a relative path with no `..`, `.`, or absolute prefix."
+    case .missingNSID(let nsId, let path):
+      return
+        "NSID \"\(nsId)\" listed in `nsIds` was not found under `path: \"\(path)\"` — no lexicon JSON declares this `id`."
     }
   }
+}
+
+// Ensure the parent directory of `url` exists so a subsequent install call can
+// write into it without hitting ENOENT. `FileManager` short-circuits when the
+// directory is already present, so this is safe to call unconditionally.
+func ensureParentDirectoryExists(for url: URL) throws {
+  let parent = url.deletingLastPathComponent()
+  if !FileManager.default.fileExists(atPath: parent.path(percentEncoded: false)) {
+    try FileManager.default.createDirectory(at: parent, withIntermediateDirectories: true)
+  }
+}
+
+// Recursively enumerate every `*.json` file under `baseURL`. Symlinks are not
+// followed while walking (so a repo can't self-loop into `.git`), which
+// mirrors the enclosing walkLexicons contract.
+func collectLexiconJSONFiles(under baseURL: URL) throws -> [URL] {
+  guard
+    let enumerator = FileManager.default.enumerator(
+      at: baseURL,
+      includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
+      options: [.skipsHiddenFiles, .skipsPackageDescendants])
+  else {
+    return []
+  }
+  var results: [URL] = []
+  for case let fileURL as URL in enumerator {
+    let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+    if resourceValues.isRegularFile == true, fileURL.pathExtension == "json" {
+      results.append(fileURL)
+    }
+  }
+  // Sort so install ordering is deterministic across runs.
+  return results.sorted { $0.path < $1.path }
+}
+
+// Extract the top-level `id` string from a lexicon JSON without materializing
+// the full Codable graph — SourceControl doesn't own the lexicon schema, so we
+// keep the read defensive and skip files where `id` is missing or not a string.
+func readLexiconNSID(at url: URL) throws -> NSID? {
+  let data = try Data(contentsOf: url)
+  let object = try? JSONSerialization.jsonObject(with: data)
+  guard let dict = object as? [String: Any], let id = dict["id"] as? String else {
+    return nil
+  }
+  return NSID(rawValue: id)
 }
 
 // Reject `..`, `.`, and absolute paths in any lexicon-supplied sub-path so a
@@ -215,31 +264,39 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
     }
 
     for lexicon in dependency.lexicons {
-      let safePrefix = try validatedLexiconSubpath(
-        lexicon.prefix.replacingOccurrences(of: ".", with: "/"),
-        field: "prefix")
+      let safePath = try validatedLexiconSubpath(lexicon.path, field: "path")
+      let srcBaseURL = srcRootURL.appending(component: safePath)
+      // Walk `<path>` once and index every JSON by the NSID it declares. This
+      // lets both the allowlist (`nsIds`) and enumerate-everything modes look
+      // up sources by id — which in turn lets `path` point at either the
+      // lexicon root or an authority-scoped sub-directory without any config
+      // migration on the caller's side.
+      var idIndex: [String: URL] = [:]
+      for srcURL in try collectLexiconJSONFiles(under: srcBaseURL) {
+        guard let nsId = try readLexiconNSID(at: srcURL) else {
+          FileHandle.standardError.write(
+            Data(
+              "warning: skipping \(srcURL.path()): JSON does not carry a top-level `id` string.\n"
+                .utf8))
+          continue
+        }
+        idIndex[nsId.rawValue] = srcURL
+      }
+      let selected: [(NSID, URL)]
       if let nsIds = lexicon.nsIds {
-        let safeRootPath = try validatedLexiconSubpath(lexicon.rootPath, field: "rootPath")
-        let srcBaseURL = srcRootURL.appending(component: safeRootPath)
-        for nsId in nsIds {
-          let dest = nsId.url(from: lexiconsDirectory)
-          if !FileManager.default.fileExists(atPath: dest.deletingLastPathComponent().path(percentEncoded: false)) {
-            try FileManager.default.createDirectory(at: dest.deletingLastPathComponent(), withIntermediateDirectories: true)
+        selected = try nsIds.map { nsId in
+          guard let srcURL = idIndex[nsId.rawValue] else {
+            throw LexiconConfigError.missingNSID(nsId: nsId.rawValue, path: lexicon.path)
           }
-          try install(nsId.url(from: srcBaseURL), dest)
+          return (nsId, srcURL)
         }
       } else {
-        let safePath = try validatedLexiconSubpath(lexicon.path, field: "path")
-        let srcBaseURL = srcRootURL.appending(component: safePath)
-        for name in try FileManager.default.contentsOfDirectory(atPath: srcBaseURL.path()) {
-          let srcURL = srcBaseURL.appending(component: name)
-          let lexiconBaseDirectory = lexiconsDirectory.appending(component: safePrefix)
-          if !FileManager.default.fileExists(atPath: lexiconBaseDirectory.path()) {
-            try FileManager.default.createDirectory(at: lexiconBaseDirectory, withIntermediateDirectories: true)
-          }
-          let lexiconDirectory = lexiconBaseDirectory.appending(component: name)
-          try install(srcURL, lexiconDirectory)
-        }
+        selected = idIndex.keys.sorted().map { id in (NSID(rawValue: id), idIndex[id]!) }
+      }
+      for (nsId, srcURL) in selected {
+        let dest = nsId.url(from: lexiconsDirectory)
+        try ensureParentDirectoryExists(for: dest)
+        try install(srcURL, dest)
       }
     }
   }

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -11,7 +11,7 @@ public func main(outdir outdirBaseURL: URL, path: String, generate: GenerateOpti
   let url = URL(filePath: path)
 
   let fileURLs = collectJSONFileURLs(at: url)
-  let schemasMap = try await decodeSchemasByPrefix(from: fileURLs, baseURL: url)
+  let schemasMap = try await decodeSchemasByPrefix(from: fileURLs)
   let defMap = Lex.buildExtDefMap(schemasMap: schemasMap)
   try await writeSchemaCode(for: schemasMap, with: defMap, to: outdirBaseURL, generate: generate, pluginSource: pluginSource)
 }
@@ -19,9 +19,8 @@ public func main(outdir outdirBaseURL: URL, path: String, generate: GenerateOpti
 func collectJSONFileURLs(at baseURL: URL) -> [URL] {
   // `FileManager.enumerator` does not traverse symbolic links, so it would
   // miss local lexicon trees installed under `.lexicons/lexicons/` as symlinks.
-  // Walk the tree manually instead, resolving each entry's target while
-  // keeping the logical path rooted at `baseURL` so `prefix(baseURL:)` still
-  // works on the returned URLs.
+  // Walk the tree manually instead, resolving each entry's target so
+  // symlinked lexicon trees are discovered as if they were physically nested.
   var fileURLs = [URL]()
   var visited = Set<String>()
   walkLexicons(at: baseURL, visited: &visited, into: &fileURLs)
@@ -56,22 +55,47 @@ private func walkLexicons(at url: URL, visited: inout Set<String>, into result: 
   }
 }
 
-func decodeSchemasByPrefix(from fileURLs: [URL], baseURL: URL) async throws -> [String: [Schema]] {
+enum SchemaDecodeError: Error, CustomStringConvertible {
+  case duplicateNSID(id: String, firstPath: URL, secondPath: URL)
+
+  var description: String {
+    switch self {
+    case .duplicateNSID(let id, let firstPath, let secondPath):
+      return "duplicate NSID \(id) loaded from both \(firstPath.path) and \(secondPath.path)"
+    }
+  }
+}
+
+func decodeSchemasByPrefix(from fileURLs: [URL]) async throws -> [String: [Schema]] {
   let decoder = JSONDecoder()
-  return try await withThrowingTaskGroup(of: Schema.self) { group in
+  let entries: [(URL, Schema)] = try await withThrowingTaskGroup(of: (URL, Schema).self) { group in
     for fileURL in fileURLs {
       group.addTask {
         let data = try Data(contentsOf: fileURL)
-        let prefix = fileURL.prefix(baseURL: baseURL)
-        return try decoder.decode(Schema.self, from: data, configuration: prefix)
+        let schema = try decoder.decode(Schema.self, from: data)
+        return (fileURL, schema)
       }
     }
-    var schemasMap = [String: [Schema]]()
-    for try await schema in group {
-      schemasMap[schema.prefix, default: []].append(schema)
+    var out: [(URL, Schema)] = []
+    for try await pair in group {
+      out.append(pair)
     }
-    return schemasMap
+    return out
   }
+  // Sort so duplicate-NSID errors report a stable "first" / "second" pair
+  // regardless of task completion order.
+  let sortedEntries = entries.sorted { $0.0.path < $1.0.path }
+
+  var seen: [String: URL] = [:]
+  var schemasMap: [String: [Schema]] = [:]
+  for (fileURL, schema) in sortedEntries {
+    if let firstPath = seen[schema.id] {
+      throw SchemaDecodeError.duplicateNSID(id: schema.id, firstPath: firstPath, secondPath: fileURL)
+    }
+    seen[schema.id] = fileURL
+    schemasMap[schema.prefix, default: []].append(schema)
+  }
+  return schemasMap
 }
 
 func createOutputDirectory(for prefix: String, baseURL: URL) throws {
@@ -262,15 +286,6 @@ class EnumDeclSyntaxNode {
       }
     }
     return roots.values.sorted { $0.name < $1.name }
-  }
-}
-
-extension URL {
-  fileprivate func prefix(baseURL: URL) -> String {
-    precondition(path.hasPrefix(baseURL.path))
-    let relativeCount = pathComponents.count - baseURL.pathComponents.count
-    let url = relativeCount >= 4 ? deletingLastPathComponent() : self
-    return url.deletingLastPathComponent().path.dropFirst(baseURL.path.count + 1).replacingOccurrences(of: "/", with: ".")
   }
 }
 

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -11,7 +11,16 @@ struct TypeInfo {
   let type: TypeSchema
 }
 
-final class Schema: Encodable, DecodableWithConfiguration, Sendable {
+final class Schema: Encodable, Decodable, Sendable {
+  /// NSID authority portion of `id`. Derived from the JSON's `id` field
+  /// rather than the file system layout, so a lexicon vendored under an
+  /// unrelated directory (e.g. `sh/tangled/com/atproto/repo/strongRef.json`
+  /// for canonical `com.atproto.repo.strongRef`) still generates types under
+  /// the correct Swift namespace. The last two segments are the collection
+  /// and record name, camel-cased into a single Swift identifier
+  /// (`com.atproto.repo.strongRef` → prefix `com.atproto`, name
+  /// `RepoStrongRef`), so `prefix` drops the final two segments when the id
+  /// has four or more and the final one otherwise.
   let prefix: String
   let lexicon: Int
   let id: String
@@ -27,19 +36,28 @@ final class Schema: Encodable, DecodableWithConfiguration, Sendable {
     case defs
   }
 
-  init(from decoder: any Decoder, configuration prefix: String) throws {
+  init(from decoder: any Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.lexicon = try container.decode(Int.self, forKey: .lexicon)
-    self.id = try container.decode(String.self, forKey: .id)
+    let id = try container.decode(String.self, forKey: .id)
+    self.id = id
     self.revision = try container.decodeIfPresent(Int.self, forKey: .revision)
     self.description = try container.decodeIfPresent(String.self, forKey: .description)
+    let prefix = Self.derivePrefix(from: id)
+    self.prefix = prefix
     let nestedContainer = try container.nestedContainer(keyedBy: AnyCodingKeys.self, forKey: .defs)
     var defs = [String: TypeSchema]()
     for key in nestedContainer.allKeys {
       defs[key.stringValue] = try nestedContainer.decode(TypeSchema.self, forKey: key, configuration: .init(prefix: prefix, id: id, defName: key.stringValue))
     }
     self.defs = defs
-    self.prefix = prefix
+  }
+
+  static func derivePrefix(from id: String) -> String {
+    let segments = id.split(separator: ".")
+    guard segments.count >= 2 else { return "" }
+    let dropCount = segments.count >= 4 ? 2 : 1
+    return segments.dropLast(dropCount).joined(separator: ".")
   }
 
   func allTypes(prefix: String) -> [String: TypeSchema] {
@@ -138,6 +156,8 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
     case type
   }
 
+  /// NSID authority + collection portion of the owning schema's `id`.
+  /// See `Schema.prefix` for the derivation.
   let prefix: String
   let id: String
   let defName: String

--- a/Tests/SourceControlTests/LocalLexiconInstallTests.swift
+++ b/Tests/SourceControlTests/LocalLexiconInstallTests.swift
@@ -16,19 +16,6 @@
       return url
     }
 
-    /// Sets up a fake project skeleton with `.atproto.json` containing `body` and an
-    /// empty source tree at `lex-src/`. Returns the configuration URL and the source root.
-    private static func makeProject(_ body: String) throws -> (config: URL, source: URL) {
-      let root = try makeTempRoot()
-      let project = root.appendingPathComponent("proj", isDirectory: true)
-      let source = root.appendingPathComponent("lex-src", isDirectory: true)
-      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
-      try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
-      let configURL = project.appendingPathComponent(".atproto.json")
-      try body.write(to: configURL, atomically: true, encoding: .utf8)
-      return (configURL, source)
-    }
-
     private static func writeLexicon(at url: URL, id: String) throws {
       try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
       try Data(#"{"lexicon":1,"id":"\#(id)","defs":{}}"#.utf8).write(to: url)
@@ -36,14 +23,20 @@
 
     // Tests ------------------------------------------------------------------
 
-    @Test func localFileSchemeInstallsSymlinks() throws {
+    @Test func localFileSchemeInstallsSymlinksPerFile() throws {
+      // Without an nsIds allowlist the installer walks `<path>` recursively,
+      // reads each JSON's `id`, and symlinks the individual file to its
+      // canonical `<lexiconsDirectory>/<id-as-path>.json` location — file-level
+      // rather than directory-level, so a new file added to the source tree
+      // requires a re-run to appear (documented behavior change from the
+      // pre-`prefix`-removal SourceControl).
       let root = try Self.makeTempRoot()
       defer { try? FileManager.default.removeItem(at: root) }
       let project = root.appendingPathComponent("proj", isDirectory: true)
       let source = root.appendingPathComponent("lex-src", isDirectory: true)
       try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
-      let lexFile = source.appendingPathComponent("lexicons/app/bsky/feed/post.json")
-      try Self.writeLexicon(at: lexFile, id: "app.bsky.feed.post")
+      let lexFile = source.appendingPathComponent("lexicons/com/example/feed/post.json")
+      try Self.writeLexicon(at: lexFile, id: "com.example.feed.post")
 
       let configURL = project.appendingPathComponent(".atproto.json")
       let body = """
@@ -51,7 +44,7 @@
           "generate": ["client"],
           "dependencies": [{
             "location": "file://\(source.path)",
-            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "lexicons": [{ "path": "lexicons" }],
             "state": { "tag": "local" }
           }]
         }
@@ -60,16 +53,183 @@
 
       _ = try main(configurationURL: configURL, outdir: nil)
 
-      // For non-nsIds the installer symlinks each top-level entry of
-      // `lexicon.path`. With `path: "lexicons/app/bsky"` the only entry is `feed`,
-      // so a directory symlink lives at `.lexicons/lexicons/app/bsky/feed`.
-      let installedDir = project.appendingPathComponent(".lexicons/lexicons/app/bsky/feed")
-      let attrs = try FileManager.default.attributesOfItem(atPath: installedDir.path)
+      let installed = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/post.json")
+      let attrs = try FileManager.default.attributesOfItem(atPath: installed.path)
       #expect(attrs[.type] as? FileAttributeType == .typeSymbolicLink)
-      let target = try FileManager.default.destinationOfSymbolicLink(atPath: installedDir.path)
-      #expect(target.hasSuffix("lexicons/app/bsky/feed"))
-      // The file is reachable through the symlink.
-      #expect(FileManager.default.fileExists(atPath: installedDir.appendingPathComponent("post.json").path))
+      let target = try FileManager.default.destinationOfSymbolicLink(atPath: installed.path)
+      #expect(target.hasSuffix("lexicons/com/example/feed/post.json"))
+      #expect(FileManager.default.fileExists(atPath: installed.path))
+    }
+
+    @Test func destinationDerivedFromIdIgnoresSourceLayout() throws {
+      // A lexicon can live at any path on disk and still install to its
+      // canonical NSID location — this locks in the "install layout is derived
+      // from the JSON `id`, not the file system" contract.
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      // Intentionally place the file under a mis-nested directory tree.
+      let lexFile = source.appendingPathComponent("lexicons/wrong/place/for/canonical.json")
+      try Self.writeLexicon(at: lexFile, id: "com.example.repo.strongRef")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "path": "lexicons" }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      let installed = project.appendingPathComponent(".lexicons/lexicons/com/example/repo/strongRef.json")
+      #expect(FileManager.default.fileExists(atPath: installed.path))
+      // The mis-nested source path must NOT appear as a shadow entry.
+      let shadow = project.appendingPathComponent(".lexicons/lexicons/wrong")
+      #expect(!FileManager.default.fileExists(atPath: shadow.path))
+    }
+
+    @Test func nsIdsAllowlistInstallsListedFilesOnly() throws {
+      // With `nsIds`, only the listed NSIDs are installed. Each JSON under
+      // `<path>` is indexed by its declared `id`, so `path` can point at
+      // either the lexicon root or an authority-scoped sub-directory — both
+      // resolve to the same install destination.
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/post.json"), id: "com.example.feed.post")
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/like.json"), id: "com.example.feed.like")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{
+              "path": "lexicons",
+              "nsIds": ["com.example.feed.post"]
+            }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      let installedPost = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/post.json")
+      let installedLike = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/like.json")
+      #expect(FileManager.default.fileExists(atPath: installedPost.path))
+      #expect(!FileManager.default.fileExists(atPath: installedLike.path))
+    }
+
+    @Test func nsIdsAllowlistWorksWithAuthorityScopedPath() throws {
+      // A `path` pointing at an authority-scoped sub-directory (as pre-existing
+      // `.atproto.json` files often do) must resolve NSIDs by looking inside
+      // that sub-directory, so `path: "lexicons/com/example"` combined with
+      // `nsIds: ["com.example.feed.post"]` finds the file at
+      // `<path>/feed/post.json` without doubling the authority segments.
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/post.json"), id: "com.example.feed.post")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{
+              "path": "lexicons/com/example",
+              "nsIds": ["com.example.feed.post"]
+            }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      let installed = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/post.json")
+      #expect(FileManager.default.fileExists(atPath: installed.path))
+    }
+
+    @Test func nsIdsAllowlistErrorsWhenEntryHasNoMatchingFile() throws {
+      // A typo or missing lexicon in `nsIds` should surface a
+      // `LexiconConfigError.missingNSID`, not the low-level "file couldn't be
+      // opened" NSError the old path-join installer used to raise.
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/post.json"), id: "com.example.feed.post")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{
+              "path": "lexicons",
+              "nsIds": ["com.example.feed.doesNotExist"]
+            }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      #expect(throws: LexiconConfigError.missingNSID(nsId: "com.example.feed.doesNotExist", path: "lexicons")) {
+        _ = try main(configurationURL: configURL, outdir: nil)
+      }
+    }
+
+    @Test func legacyPrefixFieldIsAcceptedAndIgnored() throws {
+      // `.atproto.json` from before the `prefix` removal must continue to
+      // parse. The value is discarded; install destinations still come from
+      // each JSON's `id`.
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/post.json"), id: "com.example.feed.post")
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "prefix": "com.example", "path": "lexicons" }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      // Install continues to derive dest from the JSON `id` — the legacy
+      // `prefix: "com.example"` field is silently ignored by the decoder.
+      let installed = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/post.json")
+      #expect(FileManager.default.fileExists(atPath: installed.path))
     }
 
     @Test func rejectsLexiconPathWithParentTraversal() throws {
@@ -88,7 +248,7 @@
           "generate": ["client"],
           "dependencies": [{
             "location": "file://\(source.path)",
-            "lexicons": [{ "prefix": "evil", "path": "../escape" }],
+            "lexicons": [{ "path": "../escape" }],
             "state": { "tag": "local" }
           }]
         }
@@ -98,52 +258,14 @@
       #expect(throws: (any Error).self) {
         _ = try main(configurationURL: configURL, outdir: nil)
       }
-      // The escape file must never appear under .lexicons/lexicons/.
-      let installed = project.appendingPathComponent(".lexicons/lexicons/evil/secret.json")
+      let installed = project.appendingPathComponent(".lexicons/lexicons/secret.json")
       #expect(!FileManager.default.fileExists(atPath: installed.path))
     }
 
-    @Test func rejectsRootPathWithParentTraversal() throws {
-      let root = try Self.makeTempRoot()
-      defer { try? FileManager.default.removeItem(at: root) }
-      let project = root.appendingPathComponent("proj", isDirectory: true)
-      let source = root.appendingPathComponent("lex-src", isDirectory: true)
-      let escape = root.appendingPathComponent("escape", isDirectory: true)
-      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
-      try FileManager.default.createDirectory(at: source, withIntermediateDirectories: true)
-      // nsIds path joins as `<rootPath>/<nsid_components>.json`. So if rootPath
-      // is `../escape` and we point nsId at `secret`, the source URL becomes
-      // `<source>/../escape/secret.json`.
-      try Self.writeLexicon(at: escape.appendingPathComponent("secret.json"), id: "secret")
-
-      let configURL = project.appendingPathComponent(".atproto.json")
-      // `path: "../escape/evil"` makes rootPath="../escape" (strips the prefix-as-path).
-      let body = """
-        {
-          "generate": ["client"],
-          "dependencies": [{
-            "location": "file://\(source.path)",
-            "lexicons": [{
-              "prefix": "evil",
-              "path": "../escape/evil",
-              "nsIds": ["secret"]
-            }],
-            "state": { "tag": "local" }
-          }]
-        }
-        """
-      try body.write(to: configURL, atomically: true, encoding: .utf8)
-
-      #expect(throws: (any Error).self) {
-        _ = try main(configurationURL: configURL, outdir: nil)
-      }
-    }
-
     @Test func rejectsAbsoluteLexiconPath() throws {
-      // Create a sibling `etc` directory inside the source root so that an
-      // absolute `/etc` path would, if URL append silently stripped the leading
-      // slash, point at real content. We assert the install rejects the path
-      // explicitly rather than relying on the missing-directory side effect.
+      // Ensure an absolute `/etc` path can't slip through when URL append
+      // silently strips the leading slash. `validatedLexiconSubpath` should
+      // reject it up front.
       let root = try Self.makeTempRoot()
       defer { try? FileManager.default.removeItem(at: root) }
       let project = root.appendingPathComponent("proj", isDirectory: true)
@@ -157,7 +279,7 @@
           "generate": ["client"],
           "dependencies": [{
             "location": "file://\(source.path)",
-            "lexicons": [{ "prefix": "evil", "path": "/etc" }],
+            "lexicons": [{ "path": "/etc" }],
             "state": { "tag": "local" }
           }]
         }
@@ -167,8 +289,7 @@
       #expect(throws: (any Error).self) {
         _ = try main(configurationURL: configURL, outdir: nil)
       }
-      // The secret must never leak into the project's lexicons directory.
-      let leaked = project.appendingPathComponent(".lexicons/lexicons/evil/secret.json")
+      let leaked = project.appendingPathComponent(".lexicons/lexicons/secret.json")
       #expect(!FileManager.default.fileExists(atPath: leaked.path))
     }
 
@@ -185,14 +306,14 @@
       let project = root.appendingPathComponent("proj", isDirectory: true)
       let source = root.appendingPathComponent("lex-src", isDirectory: true)
       try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
-      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/app/bsky/feed/post.json"), id: "app.bsky.feed.post")
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/post.json"), id: "com.example.feed.post")
 
       let configBody = """
         {
           "generate": ["client"],
           "dependencies": [{
             "location": "file://\(source.path)",
-            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "lexicons": [{ "path": "lexicons" }],
             "state": { "revision": "stale-sha" }
           }]
         }
@@ -200,8 +321,6 @@
       let configURL = project.appendingPathComponent(".atproto.json")
       try configBody.write(to: configURL, atomically: true, encoding: .utf8)
 
-      // Pre-seed the lockfile with the *same* originHash as the config above
-      // and a revision that lies (`"stale-sha"` instead of `"local"`).
       let configData = try Data(contentsOf: configURL)
       let originHash = SHA256.hash(data: configData).map { String(format: "%02x", $0) }.joined()
       let staleLockfile = """
@@ -211,14 +330,13 @@
           "module": "Sources/Out",
           "dependencies": [{
             "location": "file://\(source.path)",
-            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "lexicons": [{ "path": "lexicons" }],
             "state": { "revision": "stale-sha" }
           }]
         }
         """
       let lockfileURL = project.appendingPathComponent(".atproto-lock.json")
       try staleLockfile.write(to: lockfileURL, atomically: true, encoding: .utf8)
-      // The fast-path also requires `.lexicons/lexicons/` to exist on disk.
       try FileManager.default.createDirectory(
         at: project.appendingPathComponent(".lexicons/lexicons", isDirectory: true),
         withIntermediateDirectories: true)
@@ -231,15 +349,15 @@
     }
 
     @Test func uppercaseFileSchemeIsTreatedAsLocal() throws {
-      // Mirrors `localFileSchemeInstallsSymlinks` but with a `FILE://` scheme to
-      // pin the case-insensitive contract between misc.swift and
+      // Mirrors `localFileSchemeInstallsSymlinksPerFile` but with a `FILE://`
+      // scheme to pin the case-insensitive contract between misc.swift and
       // RepositoryLocation.parse (which already lowercases).
       let root = try Self.makeTempRoot()
       defer { try? FileManager.default.removeItem(at: root) }
       let project = root.appendingPathComponent("proj", isDirectory: true)
       let source = root.appendingPathComponent("lex-src", isDirectory: true)
       try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
-      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/app/bsky/feed/post.json"), id: "app.bsky.feed.post")
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/post.json"), id: "com.example.feed.post")
 
       let configURL = project.appendingPathComponent(".atproto.json")
       let body = """
@@ -247,7 +365,7 @@
           "generate": ["client"],
           "dependencies": [{
             "location": "FILE://\(source.path)",
-            "lexicons": [{ "prefix": "app.bsky", "path": "lexicons/app/bsky" }],
+            "lexicons": [{ "path": "lexicons" }],
             "state": { "tag": "local" }
           }]
         }
@@ -256,8 +374,8 @@
 
       _ = try main(configurationURL: configURL, outdir: nil)
 
-      let installedDir = project.appendingPathComponent(".lexicons/lexicons/app/bsky/feed")
-      let attrs = try FileManager.default.attributesOfItem(atPath: installedDir.path)
+      let installed = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/post.json")
+      let attrs = try FileManager.default.attributesOfItem(atPath: installed.path)
       #expect(attrs[.type] as? FileAttributeType == .typeSymbolicLink)
     }
   }

--- a/Tests/SwiftAtprotoLexTests/DuplicateNSIDTests.swift
+++ b/Tests/SwiftAtprotoLexTests/DuplicateNSIDTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import XCTest
+
+@testable import SwiftAtprotoLex
+
+final class DuplicateNSIDTests: XCTestCase {
+  private func makeTempDir() throws -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent("swift-atproto-dup-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func minimalStrongRef(id: String) -> Data {
+    """
+    {
+      "lexicon": 1,
+      "id": "\(id)",
+      "description": "A URI with a content-hash fingerprint.",
+      "defs": {
+        "main": {
+          "type": "object",
+          "required": ["uri", "cid"],
+          "properties": {
+            "uri": {"type": "string", "format": "at-uri"},
+            "cid": {"type": "string", "format": "cid"}
+          }
+        }
+      }
+    }
+    """.data(using: .utf8)!
+  }
+
+  func testDuplicateNSIDFailsFast() async throws {
+    let root = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let canonicalDir = root.appending(path: "com/atproto/repo")
+    try FileManager.default.createDirectory(at: canonicalDir, withIntermediateDirectories: true)
+    let canonical = canonicalDir.appending(path: "strongRef.json")
+    try minimalStrongRef(id: "com.atproto.repo.strongRef").write(to: canonical)
+
+    let vendoredDir = root.appending(path: "sh/tangled/com/atproto/repo")
+    try FileManager.default.createDirectory(at: vendoredDir, withIntermediateDirectories: true)
+    let vendored = vendoredDir.appending(path: "strongRef.json")
+    try minimalStrongRef(id: "com.atproto.repo.strongRef").write(to: vendored)
+
+    let fileURLs = collectJSONFileURLs(at: root)
+    do {
+      _ = try await decodeSchemasByPrefix(from: fileURLs)
+      XCTFail("expected SchemaDecodeError.duplicateNSID")
+    } catch let SchemaDecodeError.duplicateNSID(id, firstPath, secondPath) {
+      XCTAssertEqual(id, "com.atproto.repo.strongRef")
+      // `sortedEntries` orders by URL path, so the canonical layout (which
+      // sorts lexicographically before the vendored one) is reported first.
+      XCTAssertTrue(firstPath.path.contains("/com/atproto/repo/"))
+      XCTAssertFalse(firstPath.path.contains("/sh/tangled/"))
+      XCTAssertTrue(secondPath.path.contains("/sh/tangled/com/atproto/repo/"))
+    }
+  }
+}

--- a/Tests/SwiftAtprotoLexTests/MisplacedNSIDGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/MisplacedNSIDGenerationTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import XCTest
+
+@testable import SwiftAtprotoLex
+
+final class MisplacedNSIDGenerationTests: XCTestCase {
+  private func makeTempDir() throws -> URL {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+      .appendingPathComponent("swift-atproto-misplaced-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+  }
+
+  private func writeMinimalStrongRef(to fileURL: URL) throws {
+    let json = """
+      {
+        "lexicon": 1,
+        "id": "com.atproto.repo.strongRef",
+        "description": "A URI with a content-hash fingerprint.",
+        "defs": {
+          "main": {
+            "type": "object",
+            "required": ["uri", "cid"],
+            "properties": {
+              "uri": {"type": "string", "format": "at-uri"},
+              "cid": {"type": "string", "format": "cid"}
+            }
+          }
+        }
+      }
+      """
+    try json.write(to: fileURL, atomically: true, encoding: .utf8)
+  }
+
+  func testVendoredNSIDGeneratesUnderCanonicalNamespace() async throws {
+    let root = try makeTempDir()
+    defer { try? FileManager.default.removeItem(at: root) }
+    let input = root.appending(path: "input")
+    let output = root.appending(path: "output")
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    let vendoredDir = input.appending(path: "jp/example/com/atproto/repo")
+    try FileManager.default.createDirectory(at: vendoredDir, withIntermediateDirectories: true)
+    try writeMinimalStrongRef(to: vendoredDir.appending(path: "strongRef.json"))
+
+    try await SwiftAtprotoLex.main(outdir: output, path: input.path, generate: .client, pluginSource: .command)
+
+    let clientURL = output.appending(path: "XRPCAPIClient.swift")
+    let source = try String(contentsOf: clientURL, encoding: .utf8)
+
+    XCTAssertFalse(source.contains("enum Jp "), "top-level `Jp` shadow enum must not be emitted")
+    XCTAssertFalse(source.contains("Jp.Example"), "`Jp.Example` extension target must not appear")
+    XCTAssertTrue(source.contains("public enum Com "), "canonical `Com` namespace must be emitted")
+    XCTAssertTrue(source.contains("extension Com.Atproto "), "extension must attach to canonical `Com.Atproto`")
+    XCTAssertTrue(source.contains("RepoStrongRef"), "canonical `RepoStrongRef` type must be emitted")
+  }
+}

--- a/Tests/SwiftAtprotoLexTests/SchemaPrefixTests.swift
+++ b/Tests/SwiftAtprotoLexTests/SchemaPrefixTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import XCTest
+
+@testable import SwiftAtprotoLex
+
+final class SchemaPrefixTests: XCTestCase {
+  func testDerivePrefixKeepsAuthorityForFourSegmentIds() {
+    XCTAssertEqual(Schema.derivePrefix(from: "com.atproto.repo.strongRef"), "com.atproto")
+    XCTAssertEqual(Schema.derivePrefix(from: "app.bsky.feed.like"), "app.bsky")
+    XCTAssertEqual(Schema.derivePrefix(from: "sh.tangled.repo.knots"), "sh.tangled")
+  }
+
+  func testDerivePrefixDropsSingleSegmentForShortIds() {
+    XCTAssertEqual(Schema.derivePrefix(from: "sh.tangled.string"), "sh.tangled")
+    XCTAssertEqual(Schema.derivePrefix(from: "com.example"), "com")
+  }
+
+  func testDerivePrefixDropsTwoSegmentsForDeeperIds() {
+    XCTAssertEqual(Schema.derivePrefix(from: "sh.tangled.git.temp.getEntry"), "sh.tangled.git")
+  }
+
+  func testDerivePrefixHandlesShortIds() {
+    XCTAssertEqual(Schema.derivePrefix(from: "atproto"), "")
+    XCTAssertEqual(Schema.derivePrefix(from: ""), "")
+  }
+
+  func testSchemaDecodeDerivesPrefixFromId() throws {
+    let json = """
+      {
+        "lexicon": 1,
+        "id": "com.atproto.repo.strongRef",
+        "description": "A URI with a content-hash fingerprint.",
+        "defs": {
+          "main": {
+            "type": "object",
+            "required": ["uri", "cid"],
+            "properties": {
+              "uri": {"type": "string", "format": "at-uri"},
+              "cid": {"type": "string", "format": "cid"}
+            }
+          }
+        }
+      }
+      """.data(using: .utf8)!
+    let schema = try JSONDecoder().decode(Schema.self, from: json)
+    XCTAssertEqual(schema.id, "com.atproto.repo.strongRef")
+    XCTAssertEqual(schema.prefix, "com.atproto")
+    XCTAssertEqual(schema.defs["main"]?.prefix, "com.atproto")
+    XCTAssertEqual(schema.defs["main"]?.id, "com.atproto.repo.strongRef")
+  }
+}


### PR DESCRIPTION
Before this PR, generating Swift code from a `.atproto.json` dependency required the on-disk directory structure of each lexicon to line up with the NSID declared inside every JSON file. When the two disagreed — for example, when a third-party dependency vendored a canonical AT Protocol lexicon under an unrelated authority's directory — the generator produced a shadow Swift namespace under the wrong authority and hid the real top-level type, which broke every downstream target that referred to the canonical name.

This PR makes the generator read the `id` field of every lexicon JSON and use that as the sole source of truth for both the emitted Swift namespace and the installed on-disk location under `.lexicons/lexicons/`. A lexicon whose file path does not match its declared NSID now still generates and installs canonically, so mixing vendored and canonical dependencies no longer needs any manual coaxing, and canonical layouts (where NSID and path agree) continue to produce byte-identical generated code.