### PR TITLE
Support Lexicon types that share names with Swift primitives

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ConstraintValidation.swift
@@ -270,7 +270,7 @@ extension FieldTypeDefinition {
         items.append(
           constraintGuardItem(
             lhs: FunctionCallExprSyntax(
-              callee: DeclReferenceExprSyntax(baseName: .identifier("Int"))
+              callee: Lex.refExpr("Swift.Int")
             ) {
               LabeledExprSyntax(
                 expression: MemberAccessExprSyntax(

--- a/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/HTTPAPITypeDefinition.swift
@@ -15,7 +15,7 @@ protocol HTTPAPITypeDefinition: Encodable, DecodableWithConfiguration, SwiftCode
 
 extension HTTPAPITypeDefinition {
   func rpcOutput(fname: String, defMap: ExtDefMap, prefix: String) -> ReturnClauseSyntax {
-    ReturnClauseSyntax(type: IdentifierTypeSyntax(name: output?.typeName(fname: fname, prefix: prefix, defMap: defMap, isOutput: true) ?? .identifier("Bool")))
+    ReturnClauseSyntax(type: Lex.typeSyntax(output?.typeName(fname: fname, prefix: prefix, defMap: defMap, isOutput: true) ?? "Swift.Bool"))
   }
 
   func makeErrorDeclaration(leadingTrivia: Trivia?, ts: TypeSchema, name typeName: String, type: String) -> any DeclSyntaxProtocol {
@@ -38,7 +38,7 @@ extension HTTPAPITypeDefinition {
             name: .lexIdentifier(error.name.camelCased()),
             parameterClause: EnumCaseParameterClauseSyntax(
               parameters: [
-                EnumCaseParameterSyntax(type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String"))))
+                EnumCaseParameterSyntax(type: OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String")))
               ]
             )
           )
@@ -52,13 +52,13 @@ extension HTTPAPITypeDefinition {
               EnumCaseParameterSyntax(
                 firstName: .identifier("error"),
                 colon: .colonToken(),
-                type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String"))),
+                type: OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String")),
                 trailingComma: .commaToken()
               ),
               EnumCaseParameterSyntax(
                 firstName: .identifier("message"),
                 colon: .colonToken(),
-                type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String")))
+                type: OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String"))
               ),
             ]
           )
@@ -164,7 +164,7 @@ extension HTTPAPITypeDefinition {
             pattern: IdentifierPatternSyntax(identifier: .identifier("error")),
             typeAnnotation: TypeAnnotationSyntax(
               colon: .colonToken(),
-              type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String")))
+              type: OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String"))
             ),
             accessorBlock: AccessorBlockSyntax(
               accessors: .getter(
@@ -239,7 +239,7 @@ extension HTTPAPITypeDefinition {
             pattern: IdentifierPatternSyntax(identifier: .identifier("message")),
             typeAnnotation: TypeAnnotationSyntax(
               colon: .colonToken(),
-              type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String")))
+              type: OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String"))
             ),
             accessorBlock: AccessorBlockSyntax(
               leftBrace: .leftBraceToken(),

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -105,7 +105,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
               pattern: IdentifierPatternSyntax(identifier: .identifier("type")),
               typeAnnotation: TypeAnnotationSyntax(
                 colon: .colonToken(),
-                type: IdentifierTypeSyntax(name: .identifier("String"))
+                type: Lex.typeSyntax("Swift.String")
               ),
               accessorBlock: AccessorBlockSyntax(
                 leftBrace: .leftBraceToken(),
@@ -145,7 +145,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
               colon: .colonToken(),
               type: DictionaryTypeSyntax(
                 leftSquare: .leftSquareToken(),
-                key: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String"))),
+                key: Lex.typeSyntax("Swift.String"),
                 colon: .colonToken(),
                 value: TypeSyntax(IdentifierTypeSyntax(name: .identifier("AnyCodable"))),
                 rightSquare: .rightSquareToken()
@@ -168,7 +168,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
         EnumDeclSyntax(
           leadingTrivia: .newlines(2),
           name: "CodingKeys",
-          inheritanceClause: InheritanceClauseSyntax(typeNames: ["String", "CodingKey"])
+          inheritanceClause: InheritanceClauseSyntax(typeNames: ["Swift.String", "CodingKey"])
         ) {
           if ts.isRecord {
             EnumCaseDeclSyntax {
@@ -314,7 +314,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                       content: DictionaryExprSyntax.Content(
                         DictionaryElementListSyntax([
                           DictionaryElementSyntax(
-                            key: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("String"))),
+                            key: Lex.refExpr("Swift.String"),
                             colon: .colonToken(),
                             value: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")))
                           )
@@ -705,7 +705,7 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
                   content: DictionaryExprSyntax.Content(
                     DictionaryElementListSyntax([
                       DictionaryElementSyntax(
-                        key: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("String"))),
+                        key: Lex.refExpr("Swift.String"),
                         colon: .colonToken(),
                         value: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("AnyCodable")))
                       )

--- a/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
@@ -60,7 +60,7 @@ extension PermissionSetTypeDefinition: SwiftCodeGeneratable {
       PatternBindingSyntax(
         pattern: IdentifierPatternSyntax(identifier: .identifier(ident)),
         typeAnnotation: TypeAnnotationSyntax(
-          type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String")))
+          type: OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String"))
         ),
         initializer: InitializerClauseSyntax(value: valueExpr)
       )

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -83,7 +83,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
             leftParen: .leftParenToken(),
             parameters: EnumCaseParameterListSyntax([
               EnumCaseParameterSyntax(
-                type: IdentifierTypeSyntax(name: .identifier("String"))
+                type: Lex.typeSyntax("Swift.String")
               )
             ]),
             rightParen: .rightParenToken()
@@ -125,12 +125,12 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         }()
         return Lex.typeSyntax(token)
       case .text:
-        return Lex.typeSyntax("String")
+        return Lex.typeSyntax("Swift.String")
       case .cbor, .car, .any, .mp4:
-        return Lex.typeSyntax("Data")
+        return Lex.typeSyntax("Foundation.Data")
       }
     }
-    return Lex.typeSyntax("Bool")
+    return Lex.typeSyntax("Swift.Bool")
   }
 
   func responseBody(fname: String, defMap: ExtDefMap, prefix: String) -> TypeSyntax {
@@ -151,9 +151,9 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         }()
         return Lex.typeSyntax(token)
       case .text:
-        return Lex.typeSyntax("String")
+        return Lex.typeSyntax("Swift.String")
       case .cbor, .car, .any, .mp4:
-        return Lex.typeSyntax("Data")
+        return Lex.typeSyntax("Foundation.Data")
       }
     }
     return Lex.typeSyntax("EmptyResponse")
@@ -164,10 +164,10 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     guard let input else { return arguments }
     switch input.encoding {
     case .cbor, .any, .car, .mp4:
-      let tname = "Data"
+      let tname = "Foundation.Data"
       arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
     case .text:
-      let tname = "String"
+      let tname = "Swift.String"
       arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
     case .json, .jsonl:
       let tname: String
@@ -185,15 +185,15 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     NilLiteralExprSyntax()
   }
 
-  func inputType(fname: String, defMap: ExtDefMap, prefix: String, binaryTypeName: String = "Data") -> ExprSyntax {
-    guard let token = input?.typeName(fname: fname, prefix: prefix, defMap: defMap, binaryTypeName: binaryTypeName, isOutput: false) else {
+  func inputType(fname: String, defMap: ExtDefMap, prefix: String, binaryTypeName: String = "Foundation.Data") -> ExprSyntax {
+    guard let typeName = input?.typeName(fname: fname, prefix: prefix, defMap: defMap, binaryTypeName: binaryTypeName, isOutput: false) else {
       return ExprSyntax(
         OptionalChainingExprSyntax(
-          expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("Bool"))),
+          expression: Lex.refExpr("Swift.Bool"),
           questionMark: .postfixQuestionMarkToken()
         ))
     }
-    return ExprSyntax(DeclReferenceExprSyntax(baseName: token))
+    return Lex.refExpr(typeName)
   }
 
   var isBinary: Bool {

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -110,9 +110,9 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         }
         return Lex.typeSyntax("\(prefix).\(outname)")
       case .text:
-        return Lex.typeSyntax("String")
+        return Lex.typeSyntax("Swift.String")
       case .cbor, .car, .any, .mp4:
-        return Lex.typeSyntax("Data")
+        return Lex.typeSyntax("Foundation.Data")
       }
     }
     return Lex.typeSyntax("EmptyResponse")
@@ -962,7 +962,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
               leftParen: .leftParenToken(),
               parameters: EnumCaseParameterListSyntax([
                 EnumCaseParameterSyntax(
-                  type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String")))
+                  type: Lex.typeSyntax("Swift.String")
                 )
               ]),
               rightParen: .rightParenToken()
@@ -983,7 +983,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                   FunctionParameterSyntax(
                     firstName: .identifier("rawValue"),
                     colon: .colonToken(),
-                    type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String")))
+                    type: Lex.typeSyntax("Swift.String")
                   )
                 ],
                 rightParen: .rightParenToken()
@@ -1075,7 +1075,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                 pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("rawValue"))),
                 typeAnnotation: TypeAnnotationSyntax(
                   colon: .colonToken(),
-                  type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String")))
+                  type: Lex.typeSyntax("Swift.String")
                 ),
                 accessorBlock: AccessorBlockSyntax(
                   leftBrace: .leftBraceToken(),

--- a/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
@@ -56,7 +56,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
           DeclModifierSyntax(name: .keyword(.indirect)),
         ],
         name: .lexIdentifier(name),
-        inheritanceClause: InheritanceClauseSyntax(typeNames: ["String", "Codable", "Hashable"])
+        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Swift.String", "Codable", "Hashable"])
       ) {
         for value in cases {
           EnumCaseDeclSyntax {
@@ -112,11 +112,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
                       )
                     ) {
                       LabeledExprSyntax(
-                        expression: MemberAccessExprSyntax(
-                          base: DeclReferenceExprSyntax(baseName: .identifier("String")),
-                          period: .periodToken(),
-                          declName: DeclReferenceExprSyntax(baseName: .keyword(.self))
-                        ))
+                        expression: MemberAccessExprSyntax(parts: [.identifier("Swift"), .identifier("String"), .keyword(.self)]))
                     }
                   )
                 )
@@ -242,7 +238,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
           parameterClause: EnumCaseParameterClauseSyntax(
             parameters: [
               EnumCaseParameterSyntax(
-                type: IdentifierTypeSyntax(name: .identifier("String"))
+                type: Lex.typeSyntax("Swift.String")
               )
             ]
           )
@@ -253,7 +249,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
         modifiers: [.init(name: .keyword(.public))],
         signature: FunctionSignatureSyntax(
           parameterClause: FunctionParameterClauseSyntax {
-            FunctionParameterSyntax(firstName: .identifier("rawValue"), type: IdentifierTypeSyntax(name: .identifier("String")))
+            FunctionParameterSyntax(firstName: .identifier("rawValue"), type: Lex.typeSyntax("Swift.String"))
           }
         )
       ) {
@@ -321,7 +317,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
             pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("rawValue"))),
             typeAnnotation: TypeAnnotationSyntax(
               colon: .colonToken(),
-              type: TypeSyntax(IdentifierTypeSyntax(name: .identifier("String")))
+              type: Lex.typeSyntax("Swift.String")
             ),
             accessorBlock: AccessorBlockSyntax(
               accessors: AccessorBlockSyntax.Accessors(
@@ -408,7 +404,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
                 equal: .equalToken(),
                 value: TryExprSyntax(
                   expression: FunctionCallExprSyntax(
-                    callee: DeclReferenceExprSyntax(baseName: .identifier("String"))
+                    callee: Lex.refExpr("Swift.String")
                   ) {
                     LabeledExprSyntax(
                       label: .identifier("from"),

--- a/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/UnionTypeDefinition.swift
@@ -74,7 +74,7 @@ struct UnionTypeDefinition: Codable, SwiftCodeGeneratable {
       EnumDeclSyntax(
         leadingTrivia: .newlines(2),
         name: "CodingKeys",
-        inheritanceClause: InheritanceClauseSyntax(typeNames: ["String", "CodingKey"])
+        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Swift.String", "CodingKey"])
       ) {
         EnumCaseDeclSyntax {
           EnumCaseElementSyntax(
@@ -125,7 +125,7 @@ struct UnionTypeDefinition: Codable, SwiftCodeGeneratable {
                 ) {
                   LabeledExprSyntax(
                     expression: MemberAccessExprSyntax(
-                      base: DeclReferenceExprSyntax(baseName: .identifier("String")),
+                      base: Lex.refExpr("Swift.String"),
                       name: .keyword(.self)
                     ))
                   LabeledExprSyntax(label: "forKey", colon: .colonToken(), expression: MemberAccessExprSyntax(name: "type"))

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -470,7 +470,7 @@ enum Lex {
               pattern: IdentifierPatternSyntax(identifier: .identifier("type")),
               typeAnnotation: TypeAnnotationSyntax(
                 colon: .colonToken(),
-                type: OptionalTypeSyntax(wrappedType: IdentifierTypeSyntax(name: .identifier("String")))
+                type: OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String"))
               ),
               accessorBlock: AccessorBlockSyntax(
                 leftBrace: .leftBraceToken(),

--- a/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
+++ b/Sources/SwiftAtprotoLex/SwiftSyntaxExtensions.swift
@@ -73,10 +73,12 @@ extension MemberTypeSyntax {
 }
 
 extension InheritanceClauseSyntax {
+  // Names may be dotted (e.g. `"Swift.String"`) — build a `MemberTypeSyntax`
+  // in that case so the raw type / protocol is emitted fully-qualified.
   package init(typeNames: [String]) {
     self.init {
       for name in typeNames {
-        InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier(name)))
+        InheritedTypeSyntax(type: Lex.typeSyntax(name))
       }
     }
   }

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -218,7 +218,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
       if applyStringFormat, let formatType = def.format?.swiftFormatTypeName {
         return ("INVALID", "FormatString<\(formatType)>")
       }
-      return ("INVALID", "String")
+      return ("INVALID", "Swift.String")
     }
     let tname: String =
       if dropPrefix, ts.prefix == prefix {
@@ -269,17 +269,17 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
   static func typeNameForField(name: String, k: String, v: TypeSchema, defMap: ExtDefMap, dropPrefix: Bool = true, applyStringFormat: Bool = true) -> String {
     switch v.type {
     case .boolean:
-      return "Bool"
+      return "Swift.Bool"
     case .blob:
       return "LexBlob"
     case .bytes:
-      return "Data"
+      return "Foundation.Data"
     case .string(let def):
       if def.isPrimitive {
         if applyStringFormat, let formatType = def.format?.swiftFormatTypeName {
           return "FormatString<\(formatType)>"
         }
-        return "String"
+        return "Swift.String"
       }
       if !dropPrefix {
         return "\(Lex.structNameFor(prefix: v.prefix)).\(name)_\(k.titleCased())"
@@ -288,7 +288,7 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
       }
     case .integer(let def):
       if def.isPrimitive {
-        return "Int"
+        return "Swift.Int"
       }
       if !dropPrefix {
         return "\(Lex.structNameFor(prefix: v.prefix)).\(name)_\(k.titleCased())"
@@ -643,7 +643,7 @@ struct OutputType: Encodable, DecodableWithConfiguration {
     description = try container.decodeIfPresent(String.self, forKey: .description)
   }
 
-  func typeName(fname: String, prefix: String, defMap: ExtDefMap, binaryTypeName: String = "Data", isOutput: Bool) -> TokenSyntax {
+  func typeName(fname: String, prefix: String, defMap: ExtDefMap, binaryTypeName: String = "Foundation.Data", isOutput: Bool) -> String {
     switch encoding {
     case .json, .jsonl:
       let token: String = {
@@ -658,11 +658,11 @@ struct OutputType: Encodable, DecodableWithConfiguration {
         }
         return "\(prefix).\(outname)"
       }()
-      return .identifier(token)
+      return token
     case .text:
-      return .identifier("String")
+      return "Swift.String"
     case .cbor, .car, .any, .mp4:
-      return .identifier(binaryTypeName)
+      return binaryTypeName
     }
   }
 


### PR DESCRIPTION
This PR allows Swift code generation to handle Lexicon types that share names with Swift and Foundation primitives, so generated models and API declarations remain unambiguous and compile correctly without requiring schema authors to rename their custom types.