### PR TITLE
Make generated string enums Sendable

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/StringTypeDefinition.swift
@@ -56,7 +56,7 @@ struct StringTypeDefinition: Codable, SwiftCodeGeneratable {
           DeclModifierSyntax(name: .keyword(.indirect)),
         ],
         name: .lexIdentifier(name),
-        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Swift.String", "Codable", "Hashable"])
+        inheritanceClause: InheritanceClauseSyntax(typeNames: ["Swift.String", "Codable", "Hashable", "Sendable"])
       ) {
         for value in cases {
           EnumCaseDeclSyntax {


### PR DESCRIPTION
This PR makes closed Lexicon string enums conform to `Sendable`, so applications can safely pass generated models containing those values across tasks and actor boundaries. This brings them in line with generated models and `knownValues` enums, which already support Swift concurrency.