### PR TITLE
Apply OAuth scope guards per resource type

### DIFF
--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public enum OAuthScope {
   public static let atproto = "atproto"
+  public static let transitionGeneric = "transition:generic"
 }
 
 public struct RepoWriteRequirement: Hashable, Sendable {
@@ -588,9 +589,16 @@ public struct ScopesSet: Hashable, Sendable {
     rawOther.contains(OAuthScope.atproto)
   }
 
+  public var hasTransitionGeneric: Bool {
+    rawOther.contains(OAuthScope.transitionGeneric)
+  }
+
   public func allowsRpc(lxm: String, aud: String) -> Bool {
-    guard hasAtprotoScope else {
+    guard hasAtprotoScope || hasTransitionGeneric else {
       return false
+    }
+    if hasTransitionGeneric, lxm != "*", !lxm.hasPrefix("chat.bsky.") {
+      return true
     }
     for scope in rpcScopes {
       let lxmMatches = scope.lxm.contains(lxm) || scope.lxm.contains("*")
@@ -603,8 +611,11 @@ public struct ScopesSet: Hashable, Sendable {
   }
 
   public func allowsRepo(collection: String, action: LexPermissionAction) -> Bool {
-    guard hasAtprotoScope else {
+    guard hasAtprotoScope || hasTransitionGeneric else {
       return false
+    }
+    if hasTransitionGeneric {
+      return true
     }
     for scope in repoScopes {
       let collMatches = scope.collection.contains(collection) || scope.collection.contains("*")
@@ -617,8 +628,11 @@ public struct ScopesSet: Hashable, Sendable {
   }
 
   public func allowsBlob(mime: String) -> Bool {
-    guard hasAtprotoScope else {
+    guard hasAtprotoScope || hasTransitionGeneric else {
       return false
+    }
+    if hasTransitionGeneric {
+      return true
     }
     for scope in blobScopes where scope.allows(mime: mime) {
       return true

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -29,6 +29,7 @@ public enum OAuthScopeError: Error, Hashable, Sendable {
   case unsupportedResource(String)
   case insufficientScope(lxm: String, aud: String)
   case insufficientRepoScope(collection: String, action: LexPermissionAction)
+  case insufficientBlobScope(mime: String)
 }
 
 public struct RpcScope: CustomStringConvertible, Hashable, Sendable {

--- a/Sources/SwiftAtproto/XRPCBlobUpload.swift
+++ b/Sources/SwiftAtproto/XRPCBlobUpload.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+public struct XRPCBlobUpload: Codable, Sendable, Hashable {
+  public let data: Data
+  public let mimeType: String
+
+  public init(data: Data, mimeType: String) {
+    self.data = data
+    self.mimeType = mimeType
+  }
+}

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -6,6 +6,7 @@ extension HTTPField.Name {
 }
 
 public protocol _XRPCCallable: Sendable {
+  var oauthSession: (any OAuthSession)? { get }
   func getProxy(nsid: String) -> String?
   func response(_ requestComponents: XRPCRequestComponents) async throws -> Data
   func call<X: XRPCQuery>(_ request: X.Type, input: X.Input.Query) async throws -> X.ResponseBody
@@ -13,9 +14,13 @@ public protocol _XRPCCallable: Sendable {
 }
 
 extension _XRPCCallable {
+  public var oauthSession: (any OAuthSession)? { nil }
+}
+
+extension _XRPCCallable {
   public func call<X: XRPCQuery>(_ query: X.Type, input: X.Input.Query) async throws -> X.ResponseBody {
     let proxy = getProxy(nsid: X.id)
-    try enforceScopeGuard(X.self, proxy: proxy)
+    try enforceRpcScopeGuard(X.self, proxy: proxy)
     var request = try constructRequest(query, input: input)
     if let proxy {
       request.headers[.atprotoProxy] = proxy
@@ -25,8 +30,9 @@ extension _XRPCCallable {
 
   public func call<X: XRPCProcedure>(_ procedure: X.Type, input: X.RequestBody?) async throws -> X.ResponseBody {
     let proxy = getProxy(nsid: X.id)
-    try enforceScopeGuard(X.self, proxy: proxy)
+    try enforceRpcScopeGuard(X.self, proxy: proxy)
     try enforceRepoScopeGuard(input as? any RepoWriteOperationDescribing)
+    try enforceBlobScopeGuard(input as? XRPCBlobUpload)
     var request = try constructRequest(procedure, input: input)
     if let proxy {
       request.headers[.atprotoProxy] = proxy
@@ -34,22 +40,30 @@ extension _XRPCCallable {
     return try await send(procedure, for: request)
   }
 
-  private func enforceScopeGuard<X: XRPCRequest>(_: X.Type, proxy: String?) throws {
-    guard let session = (self as? ATPClientProtocol)?.oauthSession else { return }
+  private func enforceRpcScopeGuard<X: XRPCRequest>(_: X.Type, proxy: String?) throws {
+    guard let session = oauthSession else { return }
+    guard let proxy else { return }
     let lxm = X.requiredRpcLxm()
-    let aud = proxy ?? "\(session.audienceDid.rawValue)#atproto_pds"
-    guard session.grantedScopes.allowsRpc(lxm: lxm, aud: aud) else {
-      throw OAuthScopeError.insufficientScope(lxm: lxm, aud: aud)
+    guard session.grantedScopes.allowsRpc(lxm: lxm, aud: proxy) else {
+      throw OAuthScopeError.insufficientScope(lxm: lxm, aud: proxy)
     }
   }
 
   private func enforceRepoScopeGuard(_ op: (any RepoWriteOperationDescribing)?) throws {
-    guard let session = (self as? ATPClientProtocol)?.oauthSession else { return }
+    guard let session = oauthSession else { return }
     guard let op else { return }
     for req in op.repoWriteRequirements {
       guard session.grantedScopes.allowsRepo(collection: req.collection, action: req.action) else {
         throw OAuthScopeError.insufficientRepoScope(collection: req.collection, action: req.action)
       }
+    }
+  }
+
+  private func enforceBlobScopeGuard(_ upload: XRPCBlobUpload?) throws {
+    guard let session = oauthSession else { return }
+    guard let upload else { return }
+    guard session.grantedScopes.allowsBlob(mime: upload.mimeType) else {
+      throw OAuthScopeError.insufficientBlobScope(mime: upload.mimeType)
     }
   }
 
@@ -89,19 +103,24 @@ extension _XRPCCallable {
     input: X.RequestBody?,
   ) throws -> XRPCRequestComponents {
     var headerFields = HTTPFields()
-    headerFields[.contentType] = X.contentType
     let encoder = JSONEncoder()
     encoder.dataEncodingStrategy = .xrpc
     encoder.outputFormatting = [.withoutEscapingSlashes]
-    let body: Data =
-      switch input {
-      case let data as Data:
-        data
-      case .none:
-        Data()
-      default:
-        try encoder.encode(input)
-      }
+    let body: Data
+    switch input {
+    case let upload as XRPCBlobUpload:
+      headerFields[.contentType] = upload.mimeType
+      body = upload.data
+    case let data as Data:
+      headerFields[.contentType] = X.contentType
+      body = data
+    case .none:
+      headerFields[.contentType] = X.contentType
+      body = Data()
+    default:
+      headerFields[.contentType] = X.contentType
+      body = try encoder.encode(input)
+    }
 
     return .init(
       nsId: X.id,

--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -8,8 +8,6 @@ public protocol ATPClientProtocol: _XRPCCallable {
   func getAuthorization(endpoint: String) -> String?
 
   func refreshSession() async -> Bool
-
-  var oauthSession: (any OAuthSession)? { get }
 }
 
 public protocol _XRPCClientProtocol: ATPClientProtocol {
@@ -20,7 +18,6 @@ public protocol _XRPCClientProtocol: ATPClientProtocol {
 
 extension ATPClientProtocol {
   public func getProxy(nsid _: String) -> String? { nil }
-  public var oauthSession: (any OAuthSession)? { nil }
 }
 
 public protocol XRPCError: Error, LocalizedError, Decodable, Sendable {

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -126,7 +126,9 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         return Lex.typeSyntax(token)
       case .text:
         return Lex.typeSyntax("Swift.String")
-      case .cbor, .car, .any, .mp4:
+      case .any:
+        return Lex.typeSyntax("SwiftAtproto.XRPCBlobUpload")
+      case .cbor, .car, .mp4:
         return Lex.typeSyntax("Foundation.Data")
       }
     }
@@ -163,7 +165,10 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     var arguments = [FunctionParameterSyntax]()
     guard let input else { return arguments }
     switch input.encoding {
-    case .cbor, .any, .car, .mp4:
+    case .any:
+      let tname = "SwiftAtproto.XRPCBlobUpload"
+      arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
+    case .cbor, .car, .mp4:
       let tname = "Foundation.Data"
       arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
     case .text:

--- a/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
@@ -36,36 +36,53 @@ enum StubProcedure: XRPCProcedure {
   typealias Error = UnExpectedError
 }
 
+enum StubBlobProcedure: XRPCProcedure {
+  static let id = "com.example.stub.uploadBlob"
+  static let contentType = "*/*"
+  typealias RequestBody = XRPCBlobUpload
+  typealias ResponseBody = EmptyResponse
+  typealias Error = UnExpectedError
+}
+
 struct ScopeGuardEnforcementTests {
-  @Test func allowedQueryPassesGuard() async throws {
+  @Test func allowedProxiedQueryPassesGuard() async throws {
     let session = try sampleSession(scopes: [
       "atproto",
-      "rpc:com.example.stub.query?aud=did:web:pds.example.com%23atproto_pds",
+      "rpc:com.example.stub.query?aud=did:web:api.example.com%23svc_appview",
     ])
-    let client = MockClient(session: session)
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
     _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
   }
 
-  @Test func disallowedQueryThrowsInsufficientScope() async throws {
+  @Test func disallowedProxiedQueryThrowsInsufficientScope() async throws {
     let session = try sampleSession(scopes: ["atproto"])
-    let client = MockClient(session: session)
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
     await #expect(
       throws: OAuthScopeError.insufficientScope(
         lxm: "com.example.stub.query",
-        aud: "did:web:pds.example.com#atproto_pds"
+        aud: "did:web:api.example.com#svc_appview"
       )
     ) {
       _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
     }
   }
 
-  @Test func disallowedProcedureThrowsInsufficientScope() async throws {
+  @Test func disallowedProxiedProcedureThrowsInsufficientScope() async throws {
     let session = try sampleSession(scopes: ["atproto"])
-    let client = MockClient(session: session)
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
     await #expect(
       throws: OAuthScopeError.insufficientScope(
         lxm: "com.example.stub.procedure",
-        aud: "did:web:pds.example.com#atproto_pds"
+        aud: "did:web:api.example.com#svc_appview"
       )
     ) {
       _ = try await client.call(StubProcedure.self, input: nil)
@@ -97,32 +114,38 @@ struct ScopeGuardEnforcementTests {
       "atproto",
       "rpc:com.example.stub.query?aud=*",
     ])
-    let client = MockClient(session: session)
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
     _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
   }
 
   @Test func wildcardLxmMatches() async throws {
     let session = try sampleSession(scopes: [
       "atproto",
-      "rpc:*?aud=did:web:pds.example.com%23atproto_pds",
+      "rpc:*?aud=did:web:api.example.com%23svc_appview",
     ])
-    let client = MockClient(session: session)
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
     _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
   }
 
-  @Test func audienceMismatchThrows() async throws {
-    let session = try sampleSession(
-      audienceDidString: "did:web:other.example.com",
-      scopes: [
-        "atproto",
-        "rpc:com.example.stub.query?aud=did:web:pds.example.com%23atproto_pds",
-      ]
+  @Test func proxyAudienceMismatchThrows() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "rpc:com.example.stub.query?aud=did:web:other.example.com%23svc_appview",
+    ])
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
     )
-    let client = MockClient(session: session)
     await #expect(
       throws: OAuthScopeError.insufficientScope(
         lxm: "com.example.stub.query",
-        aud: "did:web:other.example.com#atproto_pds"
+        aud: "did:web:api.example.com#svc_appview"
       )
     ) {
       _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
@@ -158,6 +181,93 @@ struct ScopeGuardEnforcementTests {
     ) {
       _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
     }
+  }
+}
+
+struct DirectPDSScopeGuardTests {
+  @Test func directPDSQueryDoesNotRequireRpcScope() async throws {
+    let session = try sampleSession(scopes: ["atproto"])
+    let client = MockClient(session: session)
+    _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
+  }
+
+  @Test func directPDSProcedureDoesNotRequireRpcScope() async throws {
+    let session = try sampleSession(scopes: ["atproto"])
+    let client = MockClient(session: session)
+    _ = try await client.call(StubProcedure.self, input: nil)
+  }
+
+  @Test func directPDSQueryPassesEvenWhenRpcScopeAbsent() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "repo:com.example.post?action=create",
+    ])
+    let client = MockClient(session: session)
+    _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
+  }
+}
+
+struct BlobScopeGuardEnforcementTests {
+  @Test func blobUploadWithMatchingMimePasses() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "blob:image/*",
+    ])
+    let client = MockClient(session: session)
+    _ = try await client.call(
+      StubBlobProcedure.self,
+      input: XRPCBlobUpload(data: Data("payload".utf8), mimeType: "image/png"))
+  }
+
+  @Test func blobUploadWithoutBlobScopeThrows() async throws {
+    let session = try sampleSession(scopes: ["atproto"])
+    let client = MockClient(session: session)
+    await #expect(
+      throws: OAuthScopeError.insufficientBlobScope(mime: "image/png")
+    ) {
+      _ = try await client.call(
+        StubBlobProcedure.self,
+        input: XRPCBlobUpload(data: Data("payload".utf8), mimeType: "image/png"))
+    }
+  }
+
+  @Test func blobUploadWithNonMatchingMimeThrows() async throws {
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "blob:video/*",
+    ])
+    let client = MockClient(session: session)
+    await #expect(
+      throws: OAuthScopeError.insufficientBlobScope(mime: "image/png")
+    ) {
+      _ = try await client.call(
+        StubBlobProcedure.self,
+        input: XRPCBlobUpload(data: Data("payload".utf8), mimeType: "image/png"))
+    }
+  }
+
+  @Test func blobUploadRoutesMimeAsContentType() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "blob:image/*",
+    ])
+    let client = MockClient(session: session, recorder: recorder)
+    let payload = Data("payload".utf8)
+    _ = try await client.call(
+      StubBlobProcedure.self,
+      input: XRPCBlobUpload(data: payload, mimeType: "image/png"))
+
+    let request = try #require(recorder.lastRequest)
+    #expect(request.headers[.contentType] == "image/png")
+    #expect(request.body == payload)
+  }
+
+  @Test func nilSessionSkipsBlobGuard() async throws {
+    let client = MockClient(session: nil)
+    _ = try await client.call(
+      StubBlobProcedure.self,
+      input: XRPCBlobUpload(data: Data("payload".utf8), mimeType: "image/png"))
   }
 }
 
@@ -222,7 +332,7 @@ struct EndToEndOAuthScopeGuardTests {
     ]
     let include = try IncludeScope(
       nsid: "com.example.stub.scope",
-      aud: "did:web:pds.example.com#atproto_pds"
+      aud: "did:web:api.example.com#svc_appview"
     )
     let expandedScopes = try include.expand(permissions)
     let grantedScopes = try ScopesSet(["atproto"] + expandedScopes)
@@ -231,14 +341,17 @@ struct EndToEndOAuthScopeGuardTests {
       audienceDid: try DID(string: "did:web:pds.example.com"),
       grantedScopes: grantedScopes
     )
-    let client = MockClient(session: session)
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
 
     _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
 
     await #expect(
       throws: OAuthScopeError.insufficientScope(
         lxm: "com.example.stub.procedure",
-        aud: "did:web:pds.example.com#atproto_pds"
+        aud: "did:web:api.example.com#svc_appview"
       )
     ) {
       _ = try await client.call(StubProcedure.self, input: nil)
@@ -249,14 +362,17 @@ struct EndToEndOAuthScopeGuardTests {
     let grantedScopes = ScopesSet(rawScopes: [
       "atproto",
       "transition:generic",
-      "rpc:com.example.stub.query?aud=did:web:pds.example.com%23atproto_pds",
+      "rpc:com.example.stub.query?aud=did:web:api.example.com%23svc_appview",
     ])
     let session = PrebuiltScopesSession(
       sessionDid: try DID(string: "did:web:user.example.com"),
       audienceDid: try DID(string: "did:web:pds.example.com"),
       grantedScopes: grantedScopes
     )
-    let client = MockClient(session: session)
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
     _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
     #expect(grantedScopes.hasAtprotoScope)
     #expect(grantedScopes.rawOther.contains("transition:generic"))
@@ -273,7 +389,6 @@ struct RepoScopeGuardEnforcementTests {
   @Test func sufficientRepoScopePassesGuard() async throws {
     let session = try sampleSession(scopes: [
       "atproto",
-      "rpc:com.example.stub.repoWrite?aud=did:web:pds.example.com%23atproto_pds",
       "repo:com.example.post?action=create",
     ])
     let client = MockClient(session: session)
@@ -283,10 +398,7 @@ struct RepoScopeGuardEnforcementTests {
   }
 
   @Test func insufficientRepoScopeThrows() async throws {
-    let session = try sampleSession(scopes: [
-      "atproto",
-      "rpc:com.example.stub.repoWrite?aud=did:web:pds.example.com%23atproto_pds",
-    ])
+    let session = try sampleSession(scopes: ["atproto"])
     let client = MockClient(session: session)
     await #expect(
       throws: OAuthScopeError.insufficientRepoScope(
@@ -303,7 +415,6 @@ struct RepoScopeGuardEnforcementTests {
   @Test func wrongActionRepoScopeThrows() async throws {
     let session = try sampleSession(scopes: [
       "atproto",
-      "rpc:com.example.stub.repoWrite?aud=did:web:pds.example.com%23atproto_pds",
       "repo:com.example.post?action=update",
     ])
     let client = MockClient(session: session)
@@ -320,10 +431,7 @@ struct RepoScopeGuardEnforcementTests {
   }
 
   @Test func nonConformingInputSkipsRepoGuard() async throws {
-    let session = try sampleSession(scopes: [
-      "atproto",
-      "rpc:com.example.stub.procedure?aud=did:web:pds.example.com%23atproto_pds",
-    ])
+    let session = try sampleSession(scopes: ["atproto"])
     let client = MockClient(session: session)
     _ = try await client.call(StubProcedure.self, input: nil)
   }
@@ -338,7 +446,6 @@ struct RepoScopeGuardEnforcementTests {
   @Test func multipleRequirementsAllChecked() async throws {
     let session = try sampleSession(scopes: [
       "atproto",
-      "rpc:com.example.stub.repoWriteBatch?aud=did:web:pds.example.com%23atproto_pds",
       "repo:com.example.post?action=create",
     ])
     let client = MockClient(session: session)

--- a/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
@@ -387,6 +387,24 @@ private final class RequestRecorder: @unchecked Sendable {
   var lastRequest: XRPCRequestComponents?
 }
 
+private struct OAuthOnlyCallable: @unchecked Sendable, _XRPCCallable {
+  let oauthSession: (any OAuthSession)?
+  let proxy: String?
+  let recorder: RequestRecorder?
+
+  init(session: (any OAuthSession)?, proxy: String? = nil, recorder: RequestRecorder? = nil) {
+    self.oauthSession = session
+    self.proxy = proxy
+    self.recorder = recorder
+  }
+
+  func getProxy(nsid _: String) -> String? { proxy }
+  func response(_ request: XRPCRequestComponents) async throws -> Data {
+    recorder?.lastRequest = request
+    return Data("{}".utf8)
+  }
+}
+
 struct EndToEndOAuthScopeGuardTests {
   @Test func permissionSetExpandedScopesGateXrpcCalls() async throws {
     let permissions = [
@@ -566,4 +584,109 @@ enum StubRepoBatchProcedure: XRPCProcedure {
   typealias RequestBody = StubRepoBatchInput
   typealias ResponseBody = EmptyResponse
   typealias Error = UnExpectedError
+}
+
+struct OAuthOnlyCallableGuardTests {
+  @Test func disallowedProxiedRpcThrowsAndSkipsRequest() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: ["atproto"])
+    let client = OAuthOnlyCallable(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview",
+      recorder: recorder
+    )
+    await #expect(
+      throws: OAuthScopeError.insufficientScope(
+        lxm: "com.example.stub.query",
+        aud: "did:web:api.example.com#svc_appview"
+      )
+    ) {
+      _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
+    }
+    #expect(recorder.lastRequest == nil)
+  }
+
+  @Test func allowedProxiedRpcSendsRequest() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "rpc:com.example.stub.query?aud=did:web:api.example.com%23svc_appview",
+    ])
+    let client = OAuthOnlyCallable(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview",
+      recorder: recorder
+    )
+    _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
+    #expect(recorder.lastRequest != nil)
+  }
+
+  @Test func disallowedRepoWriteThrowsAndSkipsRequest() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: ["atproto"])
+    let client = OAuthOnlyCallable(session: session, recorder: recorder)
+    await #expect(
+      throws: OAuthScopeError.insufficientRepoScope(
+        collection: "com.example.post",
+        action: .create
+      )
+    ) {
+      _ = try await client.call(
+        StubRepoProcedure.self,
+        input: StubRepoInput(collection: "com.example.post", action: .create))
+    }
+    #expect(recorder.lastRequest == nil)
+  }
+
+  @Test func disallowedBlobUploadThrowsAndSkipsRequest() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: ["atproto"])
+    let client = OAuthOnlyCallable(session: session, recorder: recorder)
+    await #expect(
+      throws: OAuthScopeError.insufficientBlobScope(mime: "image/png")
+    ) {
+      _ = try await client.call(
+        StubBlobProcedure.self,
+        input: XRPCBlobUpload(data: Data("payload".utf8), mimeType: "image/png"))
+    }
+    #expect(recorder.lastRequest == nil)
+  }
+
+  @Test func nilSessionSkipsAllGuards() async throws {
+    let recorder = RequestRecorder()
+    let client = OAuthOnlyCallable(session: nil, recorder: recorder)
+    _ = try await client.call(
+      StubBlobProcedure.self,
+      input: XRPCBlobUpload(data: Data("payload".utf8), mimeType: "image/png"))
+    #expect(recorder.lastRequest != nil)
+  }
+
+  @Test func transitionGenericAllowsRepoWriteOnCallableClient() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: ["transition:generic"])
+    let client = OAuthOnlyCallable(session: session, recorder: recorder)
+    _ = try await client.call(
+      StubRepoProcedure.self,
+      input: StubRepoInput(collection: "com.example.post", action: .create))
+    #expect(recorder.lastRequest != nil)
+  }
+
+  @Test func transitionGenericDeniesChatBskyRpcOnCallableClient() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: ["transition:generic"])
+    let client = OAuthOnlyCallable(
+      session: session,
+      proxy: "did:web:chat.example.com#svc_chat",
+      recorder: recorder
+    )
+    await #expect(
+      throws: OAuthScopeError.insufficientScope(
+        lxm: "chat.bsky.convo.sendMessage",
+        aud: "did:web:chat.example.com#svc_chat"
+      )
+    ) {
+      _ = try await client.call(StubChatProcedure.self, input: nil)
+    }
+    #expect(recorder.lastRequest == nil)
+  }
 }

--- a/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
@@ -44,6 +44,14 @@ enum StubBlobProcedure: XRPCProcedure {
   typealias Error = UnExpectedError
 }
 
+enum StubChatProcedure: XRPCProcedure {
+  static let id = "chat.bsky.convo.sendMessage"
+  static let contentType = "application/json"
+  typealias RequestBody = EmptyResponse
+  typealias ResponseBody = EmptyResponse
+  typealias Error = UnExpectedError
+}
+
 struct ScopeGuardEnforcementTests {
   @Test func allowedProxiedQueryPassesGuard() async throws {
     let session = try sampleSession(scopes: [
@@ -271,6 +279,64 @@ struct BlobScopeGuardEnforcementTests {
   }
 }
 
+struct TransitionGenericTests {
+  @Test func transitionGenericAllowsProxiedRpcExceptChatBsky() async throws {
+    let session = try sampleSession(scopes: ["transition:generic"])
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:api.example.com#svc_appview"
+    )
+    _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
+  }
+
+  @Test func transitionGenericDeniesChatBskyRpc() async throws {
+    let session = try sampleSession(scopes: ["transition:generic"])
+    let client = MockClient(
+      session: session,
+      proxy: "did:web:chat.example.com#svc_chat"
+    )
+    await #expect(
+      throws: OAuthScopeError.insufficientScope(
+        lxm: "chat.bsky.convo.sendMessage",
+        aud: "did:web:chat.example.com#svc_chat"
+      )
+    ) {
+      _ = try await client.call(StubChatProcedure.self, input: nil)
+    }
+  }
+
+  @Test func transitionGenericAllowsRepoWrite() async throws {
+    let session = try sampleSession(scopes: ["transition:generic"])
+    let client = MockClient(session: session)
+    _ = try await client.call(
+      StubRepoProcedure.self,
+      input: StubRepoInput(collection: "com.example.post", action: .create))
+  }
+
+  @Test func transitionGenericAllowsBlobUpload() async throws {
+    let session = try sampleSession(scopes: ["transition:generic"])
+    let client = MockClient(session: session)
+    _ = try await client.call(
+      StubBlobProcedure.self,
+      input: XRPCBlobUpload(data: Data("payload".utf8), mimeType: "image/png"))
+  }
+
+  @Test func atprotoAloneDoesNotBypassRepoScope() async throws {
+    let session = try sampleSession(scopes: ["atproto"])
+    let client = MockClient(session: session)
+    await #expect(
+      throws: OAuthScopeError.insufficientRepoScope(
+        collection: "com.example.post",
+        action: .create
+      )
+    ) {
+      _ = try await client.call(
+        StubRepoProcedure.self,
+        input: StubRepoInput(collection: "com.example.post", action: .create))
+    }
+  }
+}
+
 private func sampleSession(
   audienceDidString: String = "did:web:pds.example.com",
   scopes: [String]
@@ -375,7 +441,7 @@ struct EndToEndOAuthScopeGuardTests {
     )
     _ = try await client.call(StubQuery.self, input: StubQueryInput.Query())
     #expect(grantedScopes.hasAtprotoScope)
-    #expect(grantedScopes.rawOther.contains("transition:generic"))
+    #expect(grantedScopes.hasTransitionGeneric)
   }
 }
 


### PR DESCRIPTION
This PR narrows the OAuth scope guard added in 0.42.0 so it applies per resource type: `rpc:` is only required for calls that set an `atproto-proxy` target, direct PDS requests are covered by `repo:` and `blob:` alone, and `com.atproto.repo.uploadBlob` gains a new `XRPCBlobUpload` input carrying the payload and its MIME type so the runtime routes the actual `Content-Type` and verifies it against the granted `BlobScope.accept` patterns. Legacy sessions holding `transition:generic` continue to authorize all resources except `chat.bsky.*` RPCs, matching the reference implementation's `ScopePermissionsTransition`. Note: the generated `uploadBlob` signature now takes `SwiftAtproto.XRPCBlobUpload` instead of `Foundation.Data`; callers should wrap payloads with the appropriate MIME type at the call site.