### PR TITLE
Decode XRPC responses without authoring constraints

### DIFF
--- a/Sources/SwiftAtproto/LexiconDecodingMode.swift
+++ b/Sources/SwiftAtproto/LexiconDecodingMode.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Controls whether generated lexicon models enforce authoring constraints while decoding.
+public enum LexiconDecodingMode: Sendable {
+  /// Enforces all generated constraints. This is the default for standalone decoders.
+  case strict
+  /// Accepts wire-compatible values even when they exceed authoring constraints.
+  case permissive
+
+  public static func shouldValidateConstraints(in decoder: any Decoder) -> Bool {
+    let mode = decoder.userInfo[.atprotoLexiconDecodingMode] as? Self ?? .strict
+    return mode == .strict
+  }
+}
+
+extension CodingUserInfoKey {
+  /// Selects the constraint validation behavior for generated lexicon models.
+  public static let atprotoLexiconDecodingMode = CodingUserInfoKey(
+    rawValue: "com.nnabeyang.swift-atproto.lexicon-decoding-mode"
+  )!
+}

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -77,6 +77,7 @@ extension _XRPCCallable {
         return data as! X.ResponseBody
       }
       let decoder = JSONDecoder()
+      decoder.userInfo[.atprotoLexiconDecodingMode] = LexiconDecodingMode.permissive
       return try decoder.decode(X.ResponseBody.self, from: data)
     } catch let error as UnExpectedError {
       throw X.Error(error: error)

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -779,6 +779,47 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
           )
         }
       }
+      IfExprSyntax(
+        conditions: ConditionElementListSyntax {
+          PrefixOperatorExprSyntax(
+            operator: .prefixOperator("!"),
+            expression: FunctionCallExprSyntax(
+              callee: MemberAccessExprSyntax(
+                base: DeclReferenceExprSyntax(baseName: .identifier("LexiconDecodingMode")),
+                period: .periodToken(),
+                declName: DeclReferenceExprSyntax(baseName: .identifier("shouldValidateConstraints"))
+              )
+            ) {
+              LabeledExprSyntax(
+                label: .identifier("in"),
+                colon: .colonToken(),
+                expression: DeclReferenceExprSyntax(baseName: .identifier("decoder"))
+              )
+            }
+          )
+        }
+      ) {
+        SequenceExprSyntax {
+          DeclReferenceExprSyntax(baseName: .keyword(.self))
+          AssignmentExprSyntax(equal: .equalToken())
+          FunctionCallExprSyntax(
+            callee: MemberAccessExprSyntax(
+              base: DeclReferenceExprSyntax(baseName: .keyword(.Self)),
+              period: .periodToken(),
+              declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
+            )
+          ) {
+            for (key, _) in sortedProperties {
+              LabeledExprSyntax(
+                label: .lexIdentifier(key),
+                colon: .colonToken(),
+                expression: DeclReferenceExprSyntax(baseName: .lexIdentifier(key))
+              )
+            }
+          }
+        }
+        ReturnStmtSyntax()
+      }
       DoStmtSyntax(
         body: CodeBlockSyntax {
           SequenceExprSyntax {

--- a/Tests/SwiftAtprotoLexTests/ConstraintDecodingGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/ConstraintDecodingGenerationTests.swift
@@ -1,0 +1,47 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Constraint decoding generation")
+struct ConstraintDecodingGenerationTests {
+  @Test("constrained models support permissive decoding")
+  func constrainedModelsSupportPermissiveDecoding() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-constraint-decoding-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let input = root.appending(path: "input", directoryHint: .isDirectory)
+    let output = root.appending(path: "output", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    let fixture = """
+      {
+        "lexicon": 1,
+        "id": "com.example.constrained",
+        "defs": {
+          "main": {
+            "type": "object",
+            "required": ["value"],
+            "properties": {
+              "value": {"type": "string", "maxLength": 10}
+            }
+          }
+        }
+      }
+      """
+    try fixture.write(to: input.appending(path: "constrained.json"), atomically: true, encoding: .utf8)
+
+    try await SwiftAtprotoLex.main(outdir: output, path: input.path, generate: .client, pluginSource: .command)
+
+    let source = try String(contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+    let syntax = Parser.parse(source: source)
+
+    #expect(!syntax.hasError)
+    #expect(source.contains("if !LexiconDecodingMode.shouldValidateConstraints(in: decoder)"))
+    #expect(source.contains("self = Self.init(value: value)"))
+    #expect(source.contains("self = try Self.make(value: value)"))
+  }
+}

--- a/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconConstraintTests.swift
@@ -50,6 +50,10 @@ private struct ConstrainedRecord: Codable, Hashable, Sendable {
     let text = try keyedContainer.decode(String.self, forKey: .text)
     let limit = try keyedContainer.decodeIfPresent(Int.self, forKey: .limit)
     let tags = try keyedContainer.decodeIfPresent([String].self, forKey: .tags)
+    if !LexiconDecodingMode.shouldValidateConstraints(in: decoder) {
+      self.init(text: text, limit: limit, tags: tags)
+      return
+    }
     do {
       self = try Self.make(text: text, limit: limit, tags: tags)
     } catch let error as LexiconConstraintError {
@@ -168,6 +172,17 @@ final class LexiconConstraintTests: XCTestCase {
     let json = try JSONEncoder().encode(["text": "hello world"])
     let record = try JSONDecoder().decode(ConstrainedRecord.self, from: json)
     XCTAssertEqual(record.text, "hello world")
+  }
+
+  func testPermissiveDecodeAcceptsConstraintViolation() throws {
+    let tooLong = String(repeating: "a", count: 3001)
+    let json = try JSONEncoder().encode(["text": tooLong])
+    let decoder = JSONDecoder()
+    decoder.userInfo[.atprotoLexiconDecodingMode] = LexiconDecodingMode.permissive
+
+    let record = try decoder.decode(ConstrainedRecord.self, from: json)
+
+    XCTAssertEqual(record.text, tooLong)
   }
 
   func testKnownValuesOtherWithinLimitSucceeds() throws {

--- a/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
@@ -28,6 +28,22 @@ enum StubQuery: XRPCQuery {
   typealias Error = UnExpectedError
 }
 
+private struct DecoderModeResponse: Codable, Hashable, Sendable {
+  init(from decoder: any Decoder) throws {
+    guard !LexiconDecodingMode.shouldValidateConstraints(in: decoder) else {
+      throw DecodingError.dataCorrupted(
+        .init(codingPath: decoder.codingPath, debugDescription: "expected permissive decoding"))
+    }
+  }
+}
+
+private enum StubDecoderModeQuery: XRPCQuery {
+  static let id = "com.example.stub.decoderMode"
+  typealias Input = StubQueryInput
+  typealias ResponseBody = DecoderModeResponse
+  typealias Error = UnExpectedError
+}
+
 enum StubProcedure: XRPCProcedure {
   static let id = "com.example.stub.procedure"
   static let contentType = "application/json"
@@ -53,6 +69,12 @@ enum StubChatProcedure: XRPCProcedure {
 }
 
 struct ScopeGuardEnforcementTests {
+  @Test func xrpcResponseUsesPermissiveLexiconDecoding() async throws {
+    let client = MockClient(session: nil)
+
+    _ = try await client.call(StubDecoderModeQuery.self, input: StubQueryInput.Query())
+  }
+
   @Test func allowedProxiedQueryPassesGuard() async throws {
     let session = try sampleSession(scopes: [
       "atproto",


### PR DESCRIPTION
This PR introduces `LexiconDecodingMode` and threads a `permissive` value through the XRPC response path so generated Lexicon models accept payloads that exceed authoring constraints (such as `maxLength`, `maxGraphemes`, or array limits) when they come back from a server. 