### PR TITLE
Validate query parameters against Lexicon constraints

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -36,6 +36,13 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     try container.encodeIfPresent(errors, forKey: .errors)
   }
 
+  /// Whether any query parameter carries a Lexicon constraint. Drives both the
+  /// generation of `Input.Query.make(...)` and every call site that must route
+  /// through it, so the two can never disagree.
+  var paramsHaveConstraints: Bool {
+    (parameters?.sortedProperties ?? []).contains { $0.1.hasConstraints }
+  }
+
   private func queries(ts: TypeSchema, fname: String, defMap: ExtDefMap, prefix: String) -> [PatternBindingSyntax] {
     var queries = [PatternBindingSyntax]()
     guard let parameters else { return queries }
@@ -277,7 +284,6 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
           )
         }
         let requiredParams = Set(parameters?.required ?? [])
-        let paramsHaveConstraints = (parameters?.sortedProperties ?? []).contains { $0.1.hasConstraints }
         InitializerDeclSyntax(
           leadingTrivia: [.newlines(2)],
           modifiers: [DeclModifierSyntax(name: .keyword(.public))],

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -727,9 +727,8 @@ extension Lex {
           initializer: InitializerClauseSyntax(
             equal: .equalToken(),
             value: {
-              let paramsHaveConstraints = (def.parameters?.sortedProperties ?? []).contains { $0.1.hasConstraints }
               let callee: ExprSyntax =
-                paramsHaveConstraints
+                def.paramsHaveConstraints
                 ? ExprSyntax(
                   MemberAccessExprSyntax(
                     parts: prefix.lexIdentifierSegments + [
@@ -753,7 +752,7 @@ extension Lex {
                   )
                 }
               }
-              return paramsHaveConstraints ? ExprSyntax(TryExprSyntax(expression: call)) : ExprSyntax(call)
+              return def.paramsHaveConstraints ? ExprSyntax(TryExprSyntax(expression: call)) : ExprSyntax(call)
             }()
           )
         )

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -445,14 +445,24 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
                     LabeledExprSyntax(
                       label: .identifier("input"),
                       colon: .colonToken(),
-                      expression: ExprSyntax(
-                        FunctionCallExprSyntax(
-                          callee: ExprSyntax(
+                      expression: {
+                        // Route through the validating factory whenever the
+                        // Lexicon puts constraints on the parameters, so an
+                        // out-of-range value fails before the request is sent.
+                        let callee: ExprSyntax =
+                          def.paramsHaveConstraints
+                          ? ExprSyntax(
+                            MemberAccessExprSyntax(
+                              parts: prefixIdentifiers + [
+                                .identifier(typeName), .identifier("Input"), .identifier("Query"), .identifier("make"),
+                              ]
+                            ))
+                          : ExprSyntax(
                             MemberAccessExprSyntax(
                               period: .periodToken(),
                               declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))
                             ))
-                        ) {
+                        let call = FunctionCallExprSyntax(callee: callee) {
                           if let properties = def.parameters?.sortedProperties {
                             for (name, _) in properties {
                               LabeledExprSyntax(
@@ -463,7 +473,8 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
                             }
                           }
                         }
-                      )
+                        return def.paramsHaveConstraints ? ExprSyntax(TryExprSyntax(expression: call)) : ExprSyntax(call)
+                      }()
                     )
                   }
                 )

--- a/Tests/SwiftAtprotoLexTests/QueryConstraintValidationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/QueryConstraintValidationTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Query constraint validation generation")
+struct QueryConstraintValidationTests {
+  private func generateClient(fixtures: [String: String]) async throws -> String {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-query-constraints-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let input = root.appending(path: "input", directoryHint: .isDirectory)
+    let output = root.appending(path: "output", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    for (name, contents) in fixtures {
+      try contents.write(to: input.appending(path: name), atomically: true, encoding: .utf8)
+    }
+
+    try await SwiftAtprotoLex.main(outdir: output, path: input.path, generate: .client, pluginSource: .command)
+    return try String(contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+  }
+
+  private var constrainedFixture: String {
+    """
+    {
+      "lexicon": 1,
+      "id": "com.example.constrainedQuery",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": {
+            "type": "params",
+            "required": ["actor"],
+            "properties": {
+              "actor": {"type": "string"},
+              "limit": {"type": "integer", "minimum": 1, "maximum": 100}
+            }
+          },
+          "output": {
+            "encoding": "application/json",
+            "schema": {"type": "object", "properties": {"cursor": {"type": "string"}}}
+          }
+        }
+      }
+    }
+    """
+  }
+
+  private var plainFixture: String {
+    """
+    {
+      "lexicon": 1,
+      "id": "com.example.plainQuery",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": {
+            "type": "params",
+            "properties": {
+              "cursor": {"type": "string"}
+            }
+          },
+          "output": {
+            "encoding": "application/json",
+            "schema": {"type": "object", "properties": {"cursor": {"type": "string"}}}
+          }
+        }
+      }
+    }
+    """
+  }
+
+  @Test("constrained query clients construct input through the validating factory")
+  func constrainedQueryClientsValidateInput() async throws {
+    let source = try await generateClient(fixtures: [
+      "constrained.json": constrainedFixture,
+      "plain.json": plainFixture,
+    ])
+    let syntax = Parser.parse(source: source)
+
+    #expect(!syntax.hasError)
+    #expect(
+      source.contains(
+        "input: try Com.Example.ConstrainedQuery.Input.Query.make(actor: actor, limit: limit)"
+      ))
+    #expect(source.contains("throw LexiconConstraintError.integerBelowMinimum(\"limit\", minimum: 1)"))
+    #expect(source.contains("throw LexiconConstraintError.integerAboveMaximum(\"limit\", maximum: 100)"))
+  }
+
+  @Test("unconstrained query clients keep the plain initializer")
+  func unconstrainedQueryClientsKeepInit() async throws {
+    let source = try await generateClient(fixtures: ["plain.json": plainFixture])
+    let syntax = Parser.parse(source: source)
+
+    #expect(!syntax.hasError)
+    #expect(source.contains("input: .init(cursor: cursor)"))
+    #expect(!source.contains("Input.Query.make("))
+  }
+}

--- a/Tests/SwiftAtprotoTests/XRPCQueryConstraintTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCQueryConstraintTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+/// Mirrors the shape the generator emits for a query whose Lexicon puts
+/// `minimum` / `maximum` on a parameter: a validating `make(...)` factory next
+/// to the plain memberwise initializer.
+private struct ConstrainedQueryInput: XRPCQueryInput {
+  struct Query: XRPCInputQuery {
+    var limit: Int?
+
+    init(limit: Int? = nil) {
+      self.limit = limit
+    }
+
+    static func make(limit: Int? = nil) throws -> Self {
+      if let limit {
+        guard limit >= 1 else {
+          throw LexiconConstraintError.integerBelowMinimum("limit", minimum: 1)
+        }
+        guard limit <= 100 else {
+          throw LexiconConstraintError.integerAboveMaximum("limit", maximum: 100)
+        }
+      }
+      return Self.init(limit: limit)
+    }
+
+    var asParameters: Parameters? { ["limit": .integer(limit)] }
+  }
+
+  var query: Query
+}
+
+private enum ConstrainedQuery: XRPCQuery {
+  static let id = "com.example.constrained.query"
+  typealias Input = ConstrainedQueryInput
+  typealias ResponseBody = EmptyResponse
+  typealias Error = UnExpectedError
+}
+
+private final class ResponseCounter: @unchecked Sendable {
+  var callCount = 0
+}
+
+private struct CountingClient: @unchecked Sendable, _XRPCCallable {
+  let counter: ResponseCounter
+
+  func getProxy(nsid _: String) -> String? { nil }
+
+  func response(_: XRPCRequestComponents) async throws -> Data {
+    counter.callCount += 1
+    return Data("{}".utf8)
+  }
+
+  /// The body the generator emits for `ConstrainedQuery`.
+  func constrainedQuery(limit: Int? = nil) async throws -> ConstrainedQuery.ResponseBody {
+    try await call(ConstrainedQuery.self, input: try ConstrainedQueryInput.Query.make(limit: limit))
+  }
+}
+
+struct XRPCQueryConstraintTests {
+  @Test func inRangeLimitReachesTheNetwork() async throws {
+    let counter = ResponseCounter()
+    let client = CountingClient(counter: counter)
+
+    _ = try await client.constrainedQuery(limit: 100)
+
+    #expect(counter.callCount == 1)
+  }
+
+  /// Input construction happens outside `call(_:input:)`, so the constraint
+  /// failure surfaces as a `LexiconConstraintError` rather than being funneled
+  /// through the endpoint's `XRPCError` mapping, and no request is sent.
+  @Test func limitAboveMaximumThrowsBeforeSendingTheRequest() async throws {
+    let counter = ResponseCounter()
+    let client = CountingClient(counter: counter)
+
+    let error = await #expect(throws: LexiconConstraintError.self) {
+      _ = try await client.constrainedQuery(limit: 101)
+    }
+    guard case .integerAboveMaximum(let field, let maximum) = error else {
+      Issue.record("expected integerAboveMaximum, got \(String(describing: error))")
+      return
+    }
+    #expect(field == "limit")
+    #expect(maximum == 100)
+    #expect(counter.callCount == 0)
+  }
+
+  @Test func limitBelowMinimumThrowsBeforeSendingTheRequest() async throws {
+    let counter = ResponseCounter()
+    let client = CountingClient(counter: counter)
+
+    let error = await #expect(throws: LexiconConstraintError.self) {
+      _ = try await client.constrainedQuery(limit: 0)
+    }
+    guard case .integerBelowMinimum(let field, let minimum) = error else {
+      Issue.record("expected integerBelowMinimum, got \(String(describing: error))")
+      return
+    }
+    #expect(field == "limit")
+    #expect(minimum == 1)
+    #expect(counter.callCount == 0)
+  }
+}


### PR DESCRIPTION
Generated query clients now enforce the constraints a Lexicon declares on its parameters, such as the per-endpoint `limit` maximum, which previously applied only on the server side. A value outside the declared range fails before the request is sent rather than being passed through to the server, so callers no longer need to reimplement each endpoint's limits themselves.

https://claude.ai/code/session_01FFb51AkqRR81d1C9QZndkD