### PR TITLE
Bump swift-cid to 0.2.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2686acabf92d4a88b2088deb3bd3c13cead01bc7bc1aa1f957f503a58105fe12",
+  "originHash" : "c88911f4d330bbe35eabe8b8b77cb1ceb990021af0aa1423348b6555220afab6",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-libp2p/swift-cid",
       "state" : {
-        "revision" : "f2eb18409e87c0da057624b550a6c4a3e08de5c4",
-        "version" : "0.0.1"
+        "revision" : "4c38c05f6e6c3e67a518d00f9bd9188d5ab2baf2",
+        "version" : "0.2.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/nnabeyang/swift-cbor.git", exact: "0.1.0"),
-    .package(url: "https://github.com/swift-libp2p/swift-cid", exact: "0.0.1"),
+    .package(url: "https://github.com/swift-libp2p/swift-cid", exact: "0.2.2"),
     .package(url: "https://github.com/swift-libp2p/swift-multibase.git", exact: "0.2.3"),
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"604.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.3.1")),

--- a/Sources/SwiftAtproto/StringFormats/LexLink+LexiconStringFormat.swift
+++ b/Sources/SwiftAtproto/StringFormats/LexLink+LexiconStringFormat.swift
@@ -2,7 +2,7 @@ import CID
 
 extension LexLink: LexiconStringFormat {
   public init(string: String) throws {
-    self = try CID(string)
+    self = try LexLink(string)
   }
 
   public var rawValue: String { toBaseEncodedString }

--- a/Sources/SwiftAtproto/SwiftAtproto.swift
+++ b/Sources/SwiftAtproto/SwiftAtproto.swift
@@ -1,5 +1,8 @@
 import CID
 import Foundation
+import Multibase
+import Multicodec
+import Multihash
 import SwiftCbor
 
 public struct EmptyResponse: Codable, Sendable, Hashable {
@@ -122,50 +125,167 @@ extension String {
   }
 }
 
-public typealias LexLink = CID
-extension CID: @unchecked @retroactive Sendable {}
-extension CID: @retroactive Hashable {
-  public func hash(into hasher: inout Hasher) {
-    hasher.combine(self.rawData)
-  }
-}
+public struct LexLink: Sendable, Hashable, Codable, CborCodable, CustomStringConvertible {
+  public var cid: CID
 
-extension LexLink: @retroactive Codable {
-  static func dataEncodingStrategy(data: Data, encoder: any Encoder) throws {
-    let cid = try CID(data[1...])
-    var container = encoder.container(keyedBy: LexLink.CodingKeys.self)
-    try container.encode(cid.toBaseEncodedString, forKey: .link)
+  public init(_ cid: CID) {
+    self.cid = cid
   }
+
+  public init(_ s: String) throws {
+    self.cid = try CID(s)
+  }
+
+  public init(_ data: Data, base: BaseEncoding? = nil) throws {
+    self.cid = try CID(data, base: base)
+  }
+
+  public init(_ bytes: [UInt8], base: BaseEncoding? = nil) throws {
+    self.cid = try CID(bytes, base: base)
+  }
+
+  public var toBaseEncodedString: String { cid.toBaseEncodedString }
+
+  public var description: String { cid.description }
+
+  public var tag: UInt64 { 42 }
 
   enum CodingKeys: String, CodingKey {
     case link = "$link"
+  }
+
+  static func dataEncodingStrategy(data: Data, encoder: any Encoder) throws {
+    let cid = try CID(data[1...])
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(cid.toBaseEncodedString, forKey: .link)
   }
 
   public init(from decoder: Decoder) throws {
     do {
       let container = try decoder.container(keyedBy: CodingKeys.self)
       let link = try container.decode(String.self, forKey: .link)
-      self = try CID(link)
+      self.cid = try CID(link)
     } catch {
       let container = try decoder.singleValueContainer()
       let bytes = try [UInt8](container.decode(Data.self))
       guard bytes[0] == 0 else {
         throw error
       }
-      self = try CID(Data(bytes[1...]))
+      self.cid = try CID(Data(bytes[1...]))
     }
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     var bytes: [UInt8] = [0]
-    bytes.append(contentsOf: rawBuffer)
+    bytes.append(contentsOf: cid.rawBuffer)
     try container.encode(Data(bytes))
   }
-}
 
-extension LexLink: @retroactive CborCodable {
-  public var tag: UInt64 { 42 }
+  // MARK: Deprecated CID forwards (scheduled for removal in 0.44.0)
+
+  @available(*, deprecated, message: "Access via lexLink.cid.version. Scheduled for removal in 0.44.0.")
+  public var version: CIDVersion { cid.version }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.codec. Scheduled for removal in 0.44.0.")
+  public var codec: Codecs { cid.codec }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.multibase. Scheduled for removal in 0.44.0.")
+  public var multibase: BaseEncoding { cid.multibase }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.multihash. Scheduled for removal in 0.44.0.")
+  public var multihash: Multihash { cid.multihash }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.code. Scheduled for removal in 0.44.0.")
+  public var code: Int { cid.code }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.rawBuffer. Scheduled for removal in 0.44.0.")
+  public var rawBuffer: [UInt8] { cid.rawBuffer }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.rawData. Scheduled for removal in 0.44.0.")
+  public var rawData: Data { cid.rawData }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.prefix. Scheduled for removal in 0.44.0.")
+  public var prefix: [UInt8] { cid.prefix }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.toBaseEncodedString(_:). Scheduled for removal in 0.44.0.")
+  public func toBaseEncodedString(_ base: BaseEncoding) throws -> String { try cid.toBaseEncodedString(base) }
+
+  @available(*, deprecated, message: "Access via lexLink.cid.string(base:). Scheduled for removal in 0.44.0.")
+  public func string(base: BaseEncoding) throws -> String { try cid.string(base: base) }
+
+  @available(*, deprecated, message: "Use LexLink(lexLink.cid.convertedToV1()). Scheduled for removal in 0.44.0.")
+  public func convertedToV1() -> LexLink { LexLink(cid.convertedToV1()) }
+
+  @available(*, deprecated, message: "Use LexLink(try lexLink.cid.convertedToV0()). Scheduled for removal in 0.44.0.")
+  public func convertedToV0() throws -> LexLink { try LexLink(cid.convertedToV0()) }
+
+  @available(*, deprecated, message: "Mutate lexLink.cid directly. Scheduled for removal in 0.44.0.")
+  public mutating func toV1() { cid.toV1() }
+
+  @available(*, deprecated, message: "Mutate lexLink.cid directly. Scheduled for removal in 0.44.0.")
+  public mutating func toV0() throws { try cid.toV0() }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(v0WithMultihash:)). Scheduled for removal in 0.44.0.")
+  public init(v0WithMultihash multihash: [UInt8]) throws {
+    self.cid = try CID(v0WithMultihash: multihash)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(v0WithMultihash:)). Scheduled for removal in 0.44.0.")
+  public init(v0WithMultihash multihash: Data) throws {
+    self.cid = try CID(v0WithMultihash: multihash)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(v0WithMultihash:)). Scheduled for removal in 0.44.0.")
+  public init(v0WithMultihash multihash: Multihash) throws {
+    self.cid = try CID(v0WithMultihash: multihash)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(version:codec:hash:)). Scheduled for removal in 0.44.0.")
+  public init(version: CIDVersion, codec: Codecs, hash: String) throws {
+    self.cid = try CID(version: version, codec: codec, hash: hash)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(version:codec:hash:)). Scheduled for removal in 0.44.0.")
+  public init(version: CIDVersion, codec: Codecs, hash: Data) throws {
+    self.cid = try CID(version: version, codec: codec, hash: hash)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(version:codec:hash:)). Scheduled for removal in 0.44.0.")
+  public init(version: CIDVersion, codec: Codecs, hash: [UInt8]) throws {
+    self.cid = try CID(version: version, codec: codec, hash: hash)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(version:codec:multihash:)). Scheduled for removal in 0.44.0.")
+  public init(version: CIDVersion, codec: Codecs, multihash: Multihash) throws {
+    self.cid = try CID(version: version, codec: codec, multihash: multihash)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(version:codec:content:hashedWith:customByteLength:)). Scheduled for removal in 0.44.0.")
+  public init(
+    version: CIDVersion, codec: Codecs, content: [UInt8], hashedWith hashFunction: Codecs, customByteLength: Int? = nil
+  ) throws {
+    self.cid = try CID(
+      version: version, codec: codec, content: content, hashedWith: hashFunction, customByteLength: customByteLength)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(version:codec:content:hashedWith:customByteLength:)). Scheduled for removal in 0.44.0.")
+  public init(
+    version: CIDVersion, codec: Codecs, content: Data, hashedWith hashFunction: Codecs, customByteLength: Int? = nil
+  ) throws {
+    self.cid = try CID(
+      version: version, codec: codec, content: content, hashedWith: hashFunction, customByteLength: customByteLength)
+  }
+
+  @available(*, deprecated, message: "Use LexLink(try CID(version:codec:content:hashedWith:using:customByteLength:)). Scheduled for removal in 0.44.0.")
+  public init(
+    version: CIDVersion, codec: Codecs, content: String, hashedWith hashFunction: Codecs,
+    using encoding: String.Encoding = .utf8, customByteLength: Int? = nil
+  ) throws {
+    self.cid = try CID(
+      version: version, codec: codec, content: content, hashedWith: hashFunction, using: encoding,
+      customByteLength: customByteLength)
+  }
 }
 
 public struct LexBlob: Codable, Sendable, Hashable {

--- a/Tests/SwiftAtprotoTests/DRISLCBORTests.swift
+++ b/Tests/SwiftAtprotoTests/DRISLCBORTests.swift
@@ -6,6 +6,19 @@ import Testing
 
 @Suite("DRISL-CBOR profile")
 struct DRISLCBORTests {
+  @Test("LexLink round-trips with DAG-CBOR tag 42")
+  func lexLinkRoundTrip() throws {
+    let original = try LexLink("bafkreifzjut3te2nhyekklss27nh3k72ysco7y32koao5eei66wof36n5e")
+    let encoder = CborEncoder(allowedTags: [42])
+    let encoded = try encoder.encode(original)
+
+    #expect(Array(encoded.prefix(2)) == [0xd8, 0x2a])
+
+    let decoded = try CborDecoder(allowedTags: [42]).decode(LexLink.self, from: encoded)
+    #expect(decoded == original)
+    #expect(decoded.toBaseEncodedString == original.toBaseEncodedString)
+  }
+
   @Test("prefix decoding reports consumed bytes")
   func prefixDecode() throws {
     let decoder = ATProtoCbor.decoder()


### PR DESCRIPTION
This PR updates swift-cid from 0.0.1 to 0.2.2 and wraps LexLink in a native struct so it can continue providing Codable, CborCodable, Sendable, and Hashable behavior without retroactive conformances on CID. Deprecated forwarding APIs preserve compatibility while callers migrate to the underlying `cid` property. 