### PR TITLE
docs: generate documentation from DocC catalogs and doc comments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,10 @@ jobs:
               - 'Package.swift'
               - 'Package.resolved'
               - '.github/workflows/**'
+              - '.spi.yml'
               - '.swift-format'
               - 'format.sh'
+              - 'scripts/**'
 
   test-apple-platforms:
     needs: changes
@@ -89,13 +91,33 @@ jobs:
       - name: Run SwiftPM tests
         run: swift test
 
+  # Builds the DocC catalogs the Swift Package Index publishes, so a broken
+  # catalog or an unresolvable documentation link fails here rather than
+  # silently degrading the hosted documentation.
+  documentation:
+    needs: changes
+    if: >-
+      needs.changes.outputs.code == 'true'
+      || github.event_name == 'push'
+      || github.event_name == 'workflow_dispatch'
+    name: Build documentation
+    runs-on: macOS-26
+    timeout-minutes: 30
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.5.app
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build DocC documentation
+        run: ./scripts/build-documentation.sh --strict
+
   # Single always-running umbrella check. Set this as the only required
   # status check in branch protection so docs-only PRs (which skip the
   # test jobs) can still merge. Renaming this job requires updating
   # branch protection in the GitHub UI.
   ci-required:
     name: CI Required
-    needs: [test-apple-platforms, test-linux]
+    needs: [test-apple-platforms, test-linux, documentation]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -103,9 +125,11 @@ jobs:
         run: |
           apple="${{ needs.test-apple-platforms.result }}"
           linux="${{ needs.test-linux.result }}"
+          docs="${{ needs.documentation.result }}"
           echo "test-apple-platforms: $apple"
           echo "test-linux: $linux"
-          for r in "$apple" "$linux"; do
+          echo "documentation: $docs"
+          for r in "$apple" "$linux" "$docs"; do
             case "$r" in
               success|skipped) ;;
               *) echo "Required job did not pass (result=$r)"; exit 1 ;;

--- a/.spi.yml
+++ b/.spi.yml
@@ -12,3 +12,4 @@ builder:
     - documentation_targets:
         - SwiftAtproto
         - ATProtoCrypto
+        - swift-atproto

--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,14 @@
+# Swift Package Index manifest.
+#
+# `documentation_targets` makes the Swift Package Index build and host this
+# package's DocC documentation. The first entry is the landing (default)
+# target. See https://swiftpackageindex.com/swiftpackageindex/spimanifest/documentation/spimanifest/commonusecases
+#
+# `scripts/build-documentation.sh` reads this file so that a local build uses
+# the same target list and documentation parameters as the index does.
+version: 1
+builder:
+  configs:
+    - documentation_targets:
+        - SwiftAtproto
+        - ATProtoCrypto

--- a/CommandLineTool/Documentation.docc/swift_atproto.md
+++ b/CommandLineTool/Documentation.docc/swift_atproto.md
@@ -1,0 +1,77 @@
+# ``swift_atproto``
+
+Generate Swift code from AT Protocol Lexicon files.
+
+@Metadata {
+  @DisplayName("swift-atproto")
+}
+
+## Overview
+
+`swift-atproto` reads an `.atproto.json` configuration, fetches the Lexicon JSON
+it depends on, and writes type-safe Swift sources for XRPC clients and servers.
+
+You normally do not run it yourself. The `Generate Source Code` command plugin
+and the `ATProtoGenerator` build tool plugin both invoke this executable, and
+the plugins are the supported entry points because they arrange package
+permissions for network access and for writing into the package directory.
+
+```bash
+swift package --disable-experimental-prebuilts plugin \
+  --allow-writing-to-package-directory \
+  --allow-network-connections all:443 \
+  swift-atproto
+```
+
+Drop `--disable-experimental-prebuilts` on Swift 6.2.4 and earlier.
+
+## Running the command directly
+
+Invoking the executable is useful when debugging generation, since it reports
+errors without the plugin sandbox in between.
+
+```bash
+swift run swift-atproto --atproto-configuration .atproto.json
+```
+
+### Options
+
+- term `--atproto-configuration <path>`:
+  The `.atproto.json` to read. Required. Its directory is treated as the
+  package root, which is what `--outdir` is resolved against when the
+  configuration supplies a relative `module`.
+
+- term `--outdir <path>`:
+  Where to write the generated sources. Defaults to the `module` directory named
+  by the configuration, resolved against the configuration's own directory.
+
+- term `--fetch-only`:
+  Fetch the Lexicon files and stop without generating anything. This is what the
+  `ATProtoLexiconFetcher` plugin runs.
+
+- term `--version`:
+  Print the version and exit.
+
+There is also a hidden `--plugin-source` option. It exists so the build tool
+plugin can tell the command it is not being run interactively, and it is not
+meant for manual use; `--help-hidden` lists it.
+
+## What it generates
+
+For each configured Lexicon namespace the command writes:
+
+- `UnknownATPValue.swift` — the enum that dispatches a decoded `$type` back to
+  its generated record type.
+- `XRPCAPIClient.swift` — the client-side call methods.
+- `XRPCAPIProtocol.swift` — the server-side protocol, when `generate` includes
+  `"server"`.
+
+Generated files carry a `// DO NOT EDIT` header. Change the Lexicon or the
+configuration and regenerate rather than editing them.
+
+## Configuration
+
+See the project README for the `.atproto.json` schema. The field that differs
+between entry points is `module`: the command plugin uses it to choose a
+destination inside your source tree, while the build tool plugin ignores it and
+writes into SwiftPM's plugin work directory.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ Add `"module": "Sources/Lexicon"` (or the path of your choice) to the same JSON 
 }
 ```
 
+## Documentation
+
+API documentation is built and hosted by the Swift Package Index, for the
+default branch as well as for releases.
+
+Each target's articles and landing page live in its `Documentation.docc`
+catalog (for example `Sources/SwiftAtproto/Documentation.docc`), and the target
+list the index publishes is declared in `.spi.yml`.
+
+To build the same documentation locally, reading its target list and parameters
+from `.spi.yml`:
+
+```bash
+# Build every published target; --strict treats DocC warnings as errors.
+./scripts/build-documentation.sh --strict
+
+# Browse one target while editing it.
+./scripts/build-documentation.sh --preview SwiftAtproto
+```
+
+The generated documentation is not committed; the Swift Package Index rebuilds
+it from source.
+
 ## Apps Using
 
 - [Soyokaze](https://apps.apple.com/app/soyokaze/id6738971639) — Bluesky client for iOS

--- a/Sources/ATProtoCrypto/Did.swift
+++ b/Sources/ATProtoCrypto/Did.swift
@@ -6,14 +6,26 @@ import Multibase
   import Foundation
 #endif
 
+/// A lookup that found no matching entry in a DID document.
 public enum DIDError: Error {
+  /// No verification method matched the requested id.
   case notFound
 }
 
+/// A parsed Decentralized Identifier.
+///
+/// The wire string is kept verbatim in ``raw`` and the three parsed components
+/// are exposed separately. A value that is only a fragment — `"#atproto"` —
+/// parses with an empty ``proto`` and ``value``, which is how a DID document's
+/// relative references are represented.
 public struct DID: Codable {
+  /// The identifier exactly as it was written.
   public let raw: String
+  /// The DID method, such as `plc` or `web`.
   public let proto: String
+  /// The method-specific identifier following the method.
   public let value: String
+  /// The `#`-prefixed fragment, or an empty string when there is none.
   public let fragment: String
 
   private enum CodingKeys: String, CodingKey {
@@ -23,6 +35,10 @@ public struct DID: Codable {
     case fragment
   }
 
+  /// Parses a DID.
+  ///
+  /// - Throws: `DecodingError.dataCorrupted` when `raw` is neither a bare
+  ///   fragment nor three colon-separated parts beginning with `did`.
   public init(raw: String) throws(DecodingError) {
     self.raw = raw
     guard !raw.hasPrefix("#") else {
@@ -57,11 +73,16 @@ public struct DID: Codable {
   }
 }
 
+/// A DID document: the keys and service endpoints an identity publishes.
 public struct Document: Codable {
   public let context: [String]
+  /// The DID this document describes.
   public let id: DID
+  /// The handles and other identifiers this DID claims.
   public let alsoKnownAs: [String]?
+  /// The public keys this identity publishes.
   public let verificationMethod: [VerificationMethod]
+  /// The services this identity publishes, such as its PDS.
   public let service: [Service]
 
   private enum CodingKeys: String, CodingKey {
@@ -72,6 +93,12 @@ public struct Document: Codable {
     case service
   }
 
+  /// Decodes the public key of a verification method.
+  ///
+  /// `id` may be a full method id, a `#fragment` resolved against this
+  /// document's own DID, or an empty string to take the first method.
+  ///
+  /// - Throws: ``DIDError/notFound`` when no method matches.
   public func getPublicKey(id: String) throws -> PublicKey {
     for vm in verificationMethod {
       if id.isEmpty || id == vm.id || (id.hasPrefix("#") && "\(self.id.raw)\(id)" == vm.id) {
@@ -82,20 +109,35 @@ public struct Document: Codable {
   }
 }
 
+/// A service endpoint published by a ``Document``.
 public struct Service: Codable {
+  /// The service identifier, usually a fragment such as
+  /// `#atproto_pds`.
   public let id: DID
+  /// The service type, such as `AtprotoPersonalDataServer`.
   public let type: String
+  /// The endpoint URL.
   public let serviceEndpoint: String
 }
 
+/// A public key published by a ``Document``.
 public struct VerificationMethod: Codable {
+  /// The method identifier, usually the DID followed by a fragment such as
+  /// `#atproto`.
   public let id: String
+  /// The key type, which selects the curve unless it is
+  /// ``VerificationKeyType/multiKey``.
   public let type: VerificationKeyType
+  /// The DID that controls this key.
   public let controller: String
   // Not Supported publicKeyJwk key
   // public let publicKeyJwk: PublicKeyJWK?
   public let publicKeyMultibase: String?
 
+  /// The `type` a DID document gives a verification method.
+  ///
+  /// ``multiKey`` carries the curve in the encoded key itself; the other cases
+  /// name it directly and map onto ``KeyType``.
   public enum VerificationKeyType: String, Codable {
     case multiKey = "Multikey"
     case secp256k1 = "EcdsaSecp256k1VerificationKey2019"
@@ -103,6 +145,11 @@ public struct VerificationMethod: Codable {
     case ed25519 = "Ed25519VerificationKey2020"
   }
 
+  /// Decodes this method's key.
+  ///
+  /// - Throws: `CocoaError.featureUnsupported` when the method publishes no
+  ///   `publicKeyMultibase` — a JWK-only method, for instance — or names a type
+  ///   this module cannot decode.
   public var publicKey: PublicKey {
     get throws {
       guard let publicKeyMultibase else {

--- a/Sources/ATProtoCrypto/Documentation.docc/ATProtoCrypto.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/ATProtoCrypto.md
@@ -1,0 +1,45 @@
+# ``ATProtoCrypto``
+
+Signing keys and DID identifiers for the AT Protocol.
+
+## Overview
+
+`ATProtoCrypto` covers the cryptographic side of AT Protocol identity: the
+three key types the protocol recognizes, their `did:key` and multibase
+encodings, signature verification, and the DID document types that publish
+them.
+
+It is independent of the XRPC runtime in `SwiftAtproto` — nothing here makes
+network requests. Resolving a DID to a document is the caller's job; this module
+parses the result and gets a usable ``PublicKey`` out of it.
+
+```swift
+let key = try PrivateKey(type: .p256)
+let signature = try key.sign(message)
+key.publicKey.isValidSignature(signature: signature, for: message)  // true
+key.publicKey.did                                                   // "did:key:z..."
+```
+
+## Topics
+
+### Keys
+
+- <doc:SigningAndVerifying>
+- ``KeyType``
+- ``PrivateKey``
+- ``PublicKey``
+
+### Identifiers
+
+- ``DID``
+- ``DIDError``
+
+### DID documents
+
+- ``Document``
+- ``VerificationMethod``
+- ``Service``
+
+### Errors
+
+- ``VarintError``

--- a/Sources/ATProtoCrypto/Documentation.docc/Articles/SigningAndVerifying.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/Articles/SigningAndVerifying.md
@@ -1,0 +1,77 @@
+# Signing and verifying
+
+Create a key, sign with it, and recover a public key from what a DID document
+publishes.
+
+## Overview
+
+``KeyType`` names the three algorithms AT Protocol identities use. Its raw
+values are the W3C verification method type names that appear verbatim in a DID
+document, which is what lets a document's `type` field select an algorithm:
+
+| Case | Raw value |
+|------|-----------|
+| ``KeyType/secp256k1`` | `EcdsaSecp256k1VerificationKey2019` |
+| ``KeyType/p256`` | `EcdsaSecp256r1VerificationKey2019` |
+| ``KeyType/ed25519`` | `Ed25519VerificationKey2020` |
+
+`secp256k1` and `p256` are the two curves AT Protocol uses for repository
+signing keys. `ed25519` is supported for reading identities that publish one.
+
+## Creating and storing a key
+
+``PrivateKey/init(type:)`` generates a new key.
+``PrivateKey/init(type:rawValue:)`` restores one from bytes previously obtained
+from ``PrivateKey/rawRepresentation``, which is the form to persist — the type
+is not encoded in the bytes, so store it alongside them.
+
+```swift
+let key = try PrivateKey(type: .secp256k1)
+let bytes = key.rawRepresentation
+// later
+let restored = try PrivateKey(type: .secp256k1, rawValue: bytes)
+```
+
+## Signing
+
+``PrivateKey/sign(_:)`` returns a signature in the encoding the AT Protocol
+expects for that curve: a compact 64-byte ECDSA signature for `secp256k1` and
+`p256`, and the Ed25519 signature for `ed25519`.
+
+``PublicKey/isValidSignature(signature:for:)`` verifies one. `secp256k1`
+signatures are normalized to low-S before verification, so a high-S signature
+produced elsewhere still validates. The method returns `false` for a malformed
+signature rather than throwing, so a single call covers both "wrong signature"
+and "not a signature at all".
+
+## Public key encodings
+
+``PrivateKey/publicKey`` derives the public half. Two encodings matter:
+
+- ``PublicKey/multibaseString`` is the base58btc multibase form, with the
+  multicodec prefix for the key's curve. This is the value a DID document
+  publishes as `publicKeyMultibase`.
+- ``PublicKey/did`` is the `did:key:` identifier, which is
+  ``PublicKey/multibaseString`` with the `did:key:` prefix.
+
+``PublicKey/publicKeyFromMultibaseString(string:)`` reverses the first one,
+reading the multicodec prefix to decide the curve. `secp256k1` keys are accepted
+in both compressed and uncompressed form and are normalized to compressed.
+
+## Reading a key out of a DID document
+
+``Document`` is the parsed DID document. ``Document/getPublicKey(id:)`` finds a
+verification method and decodes its key. It accepts a full method id, a
+`#fragment` that is resolved against the document's own DID, or an empty string
+to take the first method:
+
+```swift
+let document = try JSONDecoder().decode(Document.self, from: data)
+let signingKey = try document.getPublicKey(id: "#atproto")
+```
+
+``VerificationMethod/publicKey`` does the same decoding for a single method. A
+`Multikey` method carries the multicodec prefix in its value, so its curve comes
+from the value itself; the three curve-specific types name the curve in
+``VerificationMethod/type`` instead. A method with no `publicKeyMultibase` —
+such as one publishing a JWK — is not supported and throws.

--- a/Sources/ATProtoCrypto/Key.swift
+++ b/Sources/ATProtoCrypto/Key.swift
@@ -8,16 +8,26 @@ import secp256k1
   import Foundation
 #endif
 
+/// A signing algorithm an AT Protocol identity can use.
+///
+/// The raw values are the W3C verification method type names that appear
+/// verbatim in a DID document, so a document's `type` field maps straight onto
+/// a case. See <doc:SigningAndVerifying>.
 public enum KeyType: String {
   case secp256k1 = "EcdsaSecp256k1VerificationKey2019"
   case p256 = "EcdsaSecp256r1VerificationKey2019"
   case ed25519 = "Ed25519VerificationKey2020"
 }
 
+/// A signing key.
+///
+/// See <doc:SigningAndVerifying>.
 public struct PrivateKey {
+  /// The algorithm this key signs with.
   public let type: KeyType
   let raw: Raw
 
+  /// Generates a new key of the given type.
   public init(type: KeyType) throws {
     self.type = type
     switch type {
@@ -30,6 +40,9 @@ public struct PrivateKey {
     }
   }
 
+  /// Restores a key from bytes previously read from ``rawRepresentation``.
+  ///
+  /// The type is not encoded in the bytes, so it has to be supplied separately.
   public init(type: KeyType, rawValue: Data) throws {
     self.type = type
     switch type {
@@ -42,6 +55,8 @@ public struct PrivateKey {
     }
   }
 
+  /// The key material, in the form to persist and pass back to
+  /// ``init(type:rawValue:)``.
   public var rawRepresentation: Data {
     switch raw {
     case .ed25519(let raw):
@@ -53,6 +68,7 @@ public struct PrivateKey {
     }
   }
 
+  /// The public half of this key.
   public var publicKey: PublicKey {
     switch raw {
     case .ed25519(let raw):
@@ -64,6 +80,10 @@ public struct PrivateKey {
     }
   }
 
+  /// Signs `data`.
+  ///
+  /// The result is a compact 64-byte ECDSA signature for ``KeyType/secp256k1``
+  /// and ``KeyType/p256``, and the Ed25519 signature for ``KeyType/ed25519``.
   public func sign(_ data: Data) throws -> Data {
     switch raw {
     case .ed25519(let raw):
@@ -82,16 +102,25 @@ public struct PrivateKey {
   }
 }
 
+/// A failure to decode the multicodec varint prefix of a multibase key.
 public enum VarintError: Error {
   case overflow
   case notMinimalFound
   case underflow
 }
 
+/// A verification key, obtained from a ``PrivateKey`` or decoded from what a
+/// DID document publishes.
+///
+/// See <doc:SigningAndVerifying>.
 public struct PublicKey {
   let type: KeyType
   let raw: Raw
 
+  /// Wraps an already-decoded key.
+  ///
+  /// Prefer ``publicKeyFromMultibaseString(string:)`` or
+  /// ``PrivateKey/publicKey``.
   public init(type: KeyType, raw: Raw) {
     self.type = type
     self.raw = raw
@@ -108,10 +137,15 @@ public struct PublicKey {
     }
   }
 
+  /// The base58btc multibase encoding of this key, prefixed with the
+  /// multicodec code for its curve.
+  ///
+  /// This is the value a DID document publishes as `publicKeyMultibase`.
   public var multibaseString: String {
     BaseEncoding.base58btc.encode(data: varEncode(pref: prefix, body: rawBytes))
   }
 
+  /// The key material, compressed for ``KeyType/secp256k1``.
   public var rawBytes: Data {
     switch raw {
     case .ed25519(let key):
@@ -182,6 +216,11 @@ public struct PublicKey {
     }
   }
 
+  /// Decodes a key from its multibase form, taking the curve from the
+  /// multicodec prefix.
+  ///
+  /// A `secp256k1` key is accepted in either compressed or uncompressed form
+  /// and is normalized to compressed.
   public static func publicKeyFromMultibaseString(string: String) throws -> PublicKey {
     let data = try Multibase.BaseEncoding.decode(string).data
     let (prefix, raw) = try varDecode(buf: data)
@@ -204,6 +243,10 @@ public struct PublicKey {
     }
   }
 
+  /// Whether `signature` is a valid signature of `message` under this key.
+  ///
+  /// A `secp256k1` signature is normalized to low-S before verification.
+  /// Returns `false` rather than throwing when the signature is malformed.
   public func isValidSignature(signature: any DataProtocol, for message: any DataProtocol) -> Bool {
     switch raw {
     case .ed25519(let raw):
@@ -218,6 +261,7 @@ public struct PublicKey {
     }
   }
 
+  /// The `did:key:` identifier for this key.
   public var did: String {
     "did:key:\(multibaseString)"
   }

--- a/Sources/SwiftAtproto/AnyCodable.swift
+++ b/Sources/SwiftAtproto/AnyCodable.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+/// A JSON value of unknown shape, decoded without losing anything.
+///
+/// Used for a Lexicon `unknown` value that carries no `$type`, and for the
+/// unrecognized fields of an ``UnknownRecord``, so both re-encode as they
+/// arrived. See <doc:DecodingLexiconRecords>.
 public struct AnyCodable: @unchecked Sendable {
   enum BoxType {
     case encodable(_AnyBaseBox)
@@ -203,6 +208,7 @@ extension _ConcreateCodableBox: _AnyHashableBox where Base: Encodable & Hashable
   }
 }
 
+/// A coding key for keys that are not known ahead of time.
 public struct AnyCodingKeys: CodingKey {
   public var stringValue: String
   public var intValue: Int?

--- a/Sources/SwiftAtproto/AuthInfo.swift
+++ b/Sources/SwiftAtproto/AuthInfo.swift
@@ -1,10 +1,19 @@
 import Foundation
 
+/// Mutable session credentials held by a client.
+///
+/// Equality compares only the two tokens, so a value counts as unchanged while
+/// the session is still the same one.
 public protocol XRPCAuth: AnyObject, Sendable, Equatable, Hashable {
+  /// The token sent as the `Authorization` bearer for ordinary calls.
   var accessJwt: String { get set }
+  /// The token used to obtain a new ``accessJwt``.
   var refreshJwt: String { get set }
+  /// The account's handle.
   var handle: String { get set }
+  /// The account's DID.
   var did: String { get set }
+  /// The PDS endpoint for this account, when known.
   var serviceEndPoint: URL? { get set }
 }
 

--- a/Sources/SwiftAtproto/DIDDocument+Verified.swift
+++ b/Sources/SwiftAtproto/DIDDocument+Verified.swift
@@ -80,6 +80,12 @@ extension DIDDocument {
   }
 }
 
+/// Resolves a handle to the DID that claims it.
+///
+/// Confirming a handle requires both directions: the ``DIDDocument`` has to
+/// list the handle in `alsoKnownAs`, and resolving the handle has to lead back
+/// to the same DID.
 public protocol DIDHandleResolver: Sendable {
+  /// Returns the DID `handle` resolves to.
   func resolveDID(handle: Handle) async throws -> DID
 }

--- a/Sources/SwiftAtproto/DIDDocument.swift
+++ b/Sources/SwiftAtproto/DIDDocument.swift
@@ -1,3 +1,7 @@
+/// A W3C DID document describing an AT Protocol identity.
+///
+/// Resolving one is how a handle is confirmed against a DID and how an
+/// account's PDS endpoint and signing keys are discovered.
 public struct DIDDocument: Codable, Sendable, Hashable {
   public let context: [String]
   public let did: FormatString<DID>
@@ -28,6 +32,7 @@ public struct DIDDocument: Codable, Sendable, Hashable {
   }
 }
 
+/// A public key published by a ``DIDDocument``.
 public struct DocVerificationMethod: Codable, Sendable, Hashable {
   public let id: String
   public let type: String
@@ -42,6 +47,8 @@ public struct DocVerificationMethod: Codable, Sendable, Hashable {
   }
 }
 
+/// A service endpoint published by a ``DIDDocument``, such as the account's
+/// PDS.
 public struct DocService: Codable, Sendable, Hashable {
   public let id: String
   public let type: String

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/DecodingLexiconRecords.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/DecodingLexiconRecords.md
@@ -1,0 +1,55 @@
+# Decoding Lexicon records
+
+Choose whether authoring constraints are enforced, and handle records whose type
+you do not know.
+
+## Overview
+
+A Lexicon can constrain a field beyond its type: a maximum string length, a
+grapheme count, an array size, an integer range. Generated models can check
+those constraints while decoding, but whether they *should* depends on which
+side of the wire you are on.
+
+## Strict and permissive
+
+``LexiconDecodingMode`` selects the behavior, and is passed through
+`Decoder.userInfo` under the `CodingUserInfoKey.atprotoLexiconDecodingMode`
+key this module adds:
+
+- ``LexiconDecodingMode/strict`` enforces every generated constraint and throws
+  ``LexiconConstraintError``. This is the default when no mode is set, which
+  makes a bare `JSONDecoder()` validating by default.
+- ``LexiconDecodingMode/permissive`` accepts wire-compatible values even when
+  they exceed an authoring constraint.
+
+Responses decoded by `_XRPCCallable.call(_:input:)` use
+``LexiconDecodingMode/permissive`` deliberately. Constraints describe what a
+client should *create*; a record already published by another implementation
+that exceeds one is still a record you have to display. Validate your own input
+before sending it, and stay permissive about what you receive.
+
+```swift
+let decoder = JSONDecoder()
+decoder.userInfo[.atprotoLexiconDecodingMode] = LexiconDecodingMode.strict
+let record = try decoder.decode(MyRecord.self, from: data)
+```
+
+## Unknown record types
+
+An `unknown` field can hold any record. Code generation emits a single enum
+conforming to ``UnknownATPValueProtocol`` that maps every `$type` it knows to
+the matching ``ATProtoRecord``. Decoding dispatches on `$type`:
+
+- A known `$type` decodes into its generated model.
+- An unknown `$type` decodes into ``UnknownRecord``, which keeps `$type` and the
+  remaining fields as ``AnyCodable`` so the value re-encodes unchanged.
+- A value with no `$type` decodes as ``AnyCodable``.
+
+This is what lets a client built against one Lexicon snapshot round-trip records
+introduced after it was generated.
+
+## Binary values
+
+``LexBlob`` carries a blob reference — its ``LexLink`` CID, MIME type, and size
+— rather than the bytes themselves. Uploading bytes is a separate procedure
+call; see ``XRPCBlobUpload`` in <doc:MakingXRPCCalls>.

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/LexiconStringFormats.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/LexiconStringFormats.md
@@ -1,0 +1,66 @@
+# Lexicon string formats
+
+Keep the wire string, and interpret it only when you need a value.
+
+## Overview
+
+A Lexicon `string` field can declare a `format` such as `did`, `handle`,
+`at-uri`, or `datetime`. Each of those maps to a type conforming to
+``LexiconStringFormat``, which validates a string and exposes the canonical form
+as ``LexiconStringFormat/rawValue``.
+
+Generated models do not store those types directly. They store
+``FormatString``, which is generic over the format:
+
+```swift
+public struct FormatString<T: LexiconStringFormat>: RawRepresentable, Codable, Hashable, Sendable
+```
+
+## Why the raw string is preserved
+
+``FormatString`` decodes and encodes as a plain `String` and keeps the wire
+value verbatim. A record that arrives with a value this library would reject
+still round-trips byte-for-byte, and a record signed by another implementation
+keeps its signature valid.
+
+Interpretation is separate and failable:
+
+- ``FormatString/typed`` parses strictly and returns `nil` when the value does
+  not satisfy the format.
+- ``FormatString/typedLenient`` parses with the format's relaxed rules, for
+  formats that define one.
+
+Equality and hashing use ``FormatString/rawValue``, not the parsed value.
+Two values that mean the same instant but differ in spelling are not equal as
+``FormatString``s; compare ``FormatString/typed`` to compare by value.
+
+```swift
+let createdAt: FormatString<Date> = record.createdAt
+
+createdAt.rawValue          // exactly what the server sent
+createdAt.typed             // Date?, strict AT Protocol datetime
+createdAt.typedLenient      // Date?, accepts the relaxed spelling
+```
+
+## Strict and lenient
+
+``LexiconStringFormat`` has two initializers. `init(string:)` is always strict.
+`init(string:strict:)` defaults to calling the strict one, so identifier formats
+that have no relaxed reading — ``DID``, ``Handle``, ``NSID``, ``TID``,
+``RecordKey`` — behave identically either way.
+
+`Date` is the format where the distinction matters. The AT Protocol datetime
+grammar is narrower than ISO 8601: strict parsing requires the full form the
+spec mandates, while lenient parsing accepts the older spellings that existing
+records contain. Because decoding a response uses
+``LexiconDecodingMode/permissive``, a value that only parses leniently still
+arrives intact and is yours to interpret.
+
+## Validation is about shape
+
+These types check that a string is well-formed, not that it refers to anything.
+``Handle`` verifies the DNS-like label grammar and length limits without
+resolving the handle or canonicalizing an internationalized domain;
+``DID`` checks method syntax without dereferencing the identifier. Confirming
+that a handle belongs to a DID is a separate step — see ``DIDDocument`` and
+``DIDHandleResolver``.

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
@@ -1,0 +1,70 @@
+# Making XRPC calls
+
+Implement one transport method and get every generated request as a type-safe
+call.
+
+## Overview
+
+Generated request types describe *what* to send: an ``XRPCQuery`` carries its
+parameters in a query string, an ``XRPCProcedure`` carries an encoded body, and
+both declare the response body they decode into. They say nothing about *how*
+bytes travel, which is what a client supplies.
+
+## Conform to a client protocol
+
+`_XRPCCallable` is the smallest thing a client can be. Its only unimplemented
+requirement is `_XRPCCallable.response(_:)`, which turns request components
+into raw response `Data`:
+
+```swift
+func response(_ requestComponents: XRPCRequestComponents) async throws -> Data
+```
+
+Everything else follows from it. The protocol extension implements
+`_XRPCCallable.call(_:input:)` for queries and procedures, so once
+`_XRPCCallable.response(_:)` exists every generated method is callable.
+
+``ATPClientProtocol`` refines it for clients that talk to a single service. It
+adds ``ATPClientProtocol/serviceEndpoint``, a `JSONDecoder`, and the session
+hooks — ``ATPClientProtocol/getAuthorization(endpoint:)``,
+``ATPClientProtocol/tokenIsExpired(error:)``, and
+``ATPClientProtocol/refreshSession()`` — that a transport needs in order to
+attach credentials and retry once after a refresh.
+
+## Build the request
+
+``XRPCRequestComponents`` is the whole request in transport-neutral form: the
+NSID, query items, `HTTPFields` headers, method, and an optional body. Its
+``XRPCRequestComponents/relativePath`` is `/xrpc/<nsid>`, which you join to your
+service endpoint.
+
+Queries are encoded as percent-escaped query items and sent as `GET`.
+Procedures are sent as `POST`; the body is the JSON encoding of the input,
+except for two cases that pass through unchanged — a `Data` input, and an
+``XRPCBlobUpload``, whose `mimeType` becomes the `Content-Type` header.
+
+Responses are decoded with the AT Protocol data encoding strategy and with
+``LexiconDecodingMode/permissive``, so a server that exceeds an authoring
+constraint does not break decoding. See <doc:DecodingLexiconRecords>.
+
+## Route through a proxy
+
+`_XRPCCallable.getProxy(nsid:)` is asked for the target service before each
+call. Returning a non-`nil` value sets the `atproto-proxy` header, which is how
+a request reaches an AppView or labeler other than the user's PDS. The default
+implementation on ``ATPClientProtocol`` returns `nil`, meaning no proxying.
+
+## Scope enforcement
+
+When `_XRPCCallable.oauthSession` is `nil` no scope checking happens — a
+legacy session sends whatever it is asked to send. When a session is present,
+its `grantedScopes` are checked before the request leaves the process and an
+``OAuthScopeError`` is thrown instead of making a call that would be rejected:
+
+- Every proxied call checks `rpc` scope for the method's NSID and audience.
+- An input conforming to ``RepoWriteOperationDescribing`` checks `repo` scope
+  for each collection and action it declares.
+- An ``XRPCBlobUpload`` input checks `blob` scope for its MIME type.
+
+Note that the `rpc` check only runs for calls that carry a proxy audience.
+See <doc:OAuthScopes>.

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/OAuthScopes.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/OAuthScopes.md
@@ -1,0 +1,56 @@
+# OAuth scopes
+
+Parse granted scopes once, then let the client refuse calls the session cannot
+make.
+
+## Overview
+
+An AT Protocol OAuth session grants a set of scope strings. ``ScopesSet`` parses
+them into the four structured kinds — ``RpcScope``, ``RepoScope``,
+``BlobScope``, and ``IncludeScope`` — and keeps anything else, such as
+``OAuthScope/atproto`` or ``OAuthScope/transitionGeneric``, as raw strings.
+
+```swift
+let scopes = try ScopesSet(grantedScopeStrings, permissionSets: [MyAppPermissions.self])
+```
+
+Two initializers exist because the two situations differ. ``ScopesSet/init(_:permissionSets:)``
+throws on a malformed scope, which is what you want when validating your own
+authorization request. ``ScopesSet/init(rawScopes:permissionSets:)`` silently
+drops what it cannot parse, which is what you want for a token issued by a
+server that may know scopes this library does not.
+
+## Include scopes are expanded at construction
+
+``IncludeScope`` names a permission set by NSID rather than listing permissions.
+Constructing a ``ScopesSet`` expands each include against the
+``LexPermissionSet`` types you pass in, adding the resulting `rpc` and `repo`
+scopes to the set. An include may only grant permissions under its own
+authority: a permission naming an NSID outside the include's namespace is
+rejected.
+
+## Checking a grant
+
+``ScopesSet`` answers the three questions a request can raise:
+
+- ``ScopesSet/allowsRpc(lxm:aud:)`` — may this method be called against this
+  audience?
+- ``ScopesSet/allowsRepo(collection:action:)`` — may this collection be written
+  with this action?
+- ``ScopesSet/allowsBlob(mime:)`` — may a blob of this MIME type be uploaded?
+
+``ScopesSet/hasAtprotoScope`` and ``ScopesSet/hasTransitionGeneric`` report the
+two broad grants that bypass the structured checks.
+
+## Enforcement in the client
+
+You rarely call those methods yourself. A client that returns a session from
+`_XRPCCallable.oauthSession` gets the checks applied automatically before each
+request, throwing ``OAuthScopeError`` rather than sending a call the server
+would reject. A client that returns `nil` — a legacy app-password session — is
+not scope-checked at all.
+
+For a procedure input to be repo-checked it must describe its own writes by
+conforming to ``RepoWriteOperationDescribing``, returning one
+``RepoWriteRequirement`` per collection and ``LexPermissionAction`` it performs.
+See <doc:MakingXRPCCalls>.

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/Subscriptions.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/Subscriptions.md
@@ -1,0 +1,48 @@
+# Subscribing to event streams
+
+Consume a Lexicon subscription as an `AsyncThrowingStream`, over the WebSocket
+transport of your choice.
+
+## Overview
+
+Lexicon `subscription` methods become ``XRPCSubscription`` types. A client that
+conforms to ``XRPCSubscriptionCallable`` calls
+``XRPCSubscriptionCallable/subscribe(_:input:)`` and receives decoded messages:
+
+```swift
+for try await message in client.subscribe(ComAtprotoSyncSubscribeRepos.self, input: .init(cursor: nil)) {
+  handle(message)
+}
+```
+
+Cancelling the task that consumes the stream tears the connection down.
+
+## Supplying a transport
+
+This module does not open sockets. ``XRPCSubscriptionTransport`` is the seam:
+given an ``XRPCWebSocketRequest`` it returns an ``XRPCWebSocketConnection``,
+which is an `AsyncThrowingStream` of ``XRPCWebSocketMessage`` values plus a
+close operation. Backing it with `URLSessionWebSocketTask` on Apple platforms
+and with a NIO-based client on Linux is the usual arrangement.
+
+``ATPClientProtocol`` already implements
+``XRPCSubscriptionCallable/prepareSubscriptionRequest(_:)`` for you: it appends
+`xrpc/<nsid>` to the service endpoint, rewrites the scheme from `https` to `wss`
+(or `http` to `ws`), attaches the query items, and adds the `Authorization`
+header from ``ATPClientProtocol/getAuthorization(endpoint:)``.
+
+## Frame handling
+
+``XRPCSubscriptionConfiguration`` bounds the stream. `maximumFrameBytes`
+(2 MiB by default) rejects an oversized frame with
+``XRPCSubscriptionStreamError/frameTooLarge(limit:)``, and `bufferCapacity`
+(16 by default) caps how many messages are buffered for a slow consumer.
+
+AT Protocol event streams are binary. A text frame is a protocol violation and
+terminates the stream with ``XRPCSubscriptionStreamError/textFrame``.
+
+## Scope enforcement
+
+Like unary calls, a subscription made through a client with an OAuth session is
+checked against its granted `rpc` scope before connecting when the call carries
+a proxy audience. See <doc:OAuthScopes>.

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -1,0 +1,124 @@
+# ``SwiftAtproto``
+
+Type-safe XRPC communication for the AT Protocol.
+
+## Overview
+
+`SwiftAtproto` is the runtime half of this package. It does not know about any
+particular Lexicon: it defines the protocols that generated code conforms to,
+the wire representations shared by every request, and the identifier types that
+Lexicon string formats map onto.
+
+The other half is code generation. `SwiftAtprotoLex` reads Lexicon JSON and
+emits one `XRPCRequest` type per Lexicon method plus the client extensions that
+call them. Those generated types conform to ``XRPCQuery`` and ``XRPCProcedure``
+from this module, so the request and response bodies are checked at compile
+time while the transport stays yours to implement.
+
+To send requests you supply a single method — how to turn an
+``XRPCRequestComponents`` value into response `Data` — and get every generated
+call for free. See <doc:MakingXRPCCalls>.
+
+```swift
+let posts = try await client.call(
+  AppBskyFeedGetPosts.self,
+  input: .init(uris: [postURI])
+)
+```
+
+## Topics
+
+### Essentials
+
+- <doc:MakingXRPCCalls>
+- ``XRPCRequest``
+- ``ATProtoRecord``
+
+### Requests and responses
+
+- ``XRPCQuery``
+- ``XRPCQueryInput``
+- ``XRPCInputQuery``
+- ``XRPCProcedure``
+- ``XRPCRequestComponents``
+- ``XRPCBlobUpload``
+- ``EmptyResponse``
+- ``Parameters``
+- ``ParamElement``
+
+### Clients
+
+- ``ATPClientProtocol``
+- ``XRPCAuth``
+
+### Lexicon string formats
+
+- <doc:LexiconStringFormats>
+- ``FormatString``
+- ``LexiconStringFormat``
+- ``AtIdentifier``
+- ``DID``
+- ``Handle``
+- ``NSID``
+- ``ATURI``
+- ``TID``
+- ``RecordKey``
+- ``URI``
+- ``Language``
+- ``AtprotoDatetimeFormatStyle``
+- ``AtprotoDatetimeParseStrategy``
+
+### OAuth scopes
+
+- <doc:OAuthScopes>
+- ``OAuthScope``
+- ``OAuthSession``
+- ``ScopesSet``
+- ``RpcScope``
+- ``RepoScope``
+- ``BlobScope``
+- ``IncludeScope``
+- ``LexPermission``
+- ``LexPermissionSet``
+- ``LexPermissionAction``
+- ``LexPermissionResource``
+- ``RepoWriteOperationDescribing``
+- ``RepoWriteRequirement``
+
+### Event streams
+
+- <doc:Subscriptions>
+- ``XRPCSubscription``
+- ``XRPCSubscriptionCallable``
+- ``XRPCSubscriptionTransport``
+- ``XRPCSubscriptionConfiguration``
+- ``XRPCSubscriptionRequestComponents``
+- ``XRPCWebSocketConnection``
+- ``XRPCWebSocketRequest``
+- ``XRPCWebSocketMessage``
+
+### Decoding records
+
+- <doc:DecodingLexiconRecords>
+- ``LexiconDecodingMode``
+- ``UnknownATPValueProtocol``
+- ``UnknownRecord``
+- ``AnyCodable``
+- ``LexBlob``
+- ``LexLink``
+
+### Identity documents
+
+- ``DIDDocument``
+- ``DocService``
+- ``DocVerificationMethod``
+- ``DIDHandleResolver``
+
+### Errors
+
+- ``XRPCError``
+- ``UnExpectedError``
+- ``LexiconConstraintError``
+- ``LexiconStringFormatError``
+- ``OAuthScopeError``
+- ``XRPCSubscriptionStreamError``

--- a/Sources/SwiftAtproto/LexPermission.swift
+++ b/Sources/SwiftAtproto/LexPermission.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// One permission declared by a Lexicon permission set.
+///
+/// Expanding an ``IncludeScope`` turns these into the `rpc` and `repo` scope
+/// strings they grant. See <doc:OAuthScopes>.
 public struct LexPermission: Codable, Hashable, Sendable {
   public let resource: LexPermissionResource
   public let aud: String?
@@ -25,6 +29,7 @@ public struct LexPermission: Codable, Hashable, Sendable {
   }
 }
 
+/// The resource kind a ``LexPermission`` applies to: `rpc`, `repo`, or `blob`.
 public struct LexPermissionResource: RawRepresentable, Codable, Hashable, Sendable {
   public let rawValue: String
 
@@ -46,6 +51,7 @@ public struct LexPermissionResource: RawRepresentable, Codable, Hashable, Sendab
   public static let blob = Self(rawValue: "blob")
 }
 
+/// A repository write action: `create`, `update`, or `delete`.
 public struct LexPermissionAction: RawRepresentable, Codable, Hashable, Sendable {
   public let rawValue: String
 
@@ -67,9 +73,17 @@ public struct LexPermissionAction: RawRepresentable, Codable, Hashable, Sendable
   public static let delete = Self(rawValue: "delete")
 }
 
+/// A named set of permissions, generated from a Lexicon `permission-set`.
+///
+/// Pass conforming types to ``ScopesSet/init(_:permissionSets:)`` so an
+/// ``IncludeScope`` naming ``id`` can be expanded. See <doc:OAuthScopes>.
 public protocol LexPermissionSet {
+  /// The NSID an ``IncludeScope`` refers to this set by.
   static var id: String { get }
+  /// A short human-readable name, for a consent screen.
   static var title: String? { get }
+  /// A longer human-readable description, for a consent screen.
   static var detail: String? { get }
+  /// The permissions this set grants.
   static var permissions: [LexPermission] { get }
 }

--- a/Sources/SwiftAtproto/LexiconConstraintError.swift
+++ b/Sources/SwiftAtproto/LexiconConstraintError.swift
@@ -1,5 +1,9 @@
 import Foundation
 
+/// A value that violates a constraint its Lexicon declares.
+///
+/// Thrown only while decoding in ``LexiconDecodingMode/strict``; see
+/// <doc:DecodingLexiconRecords>. Each case names the field it applies to.
 public enum LexiconConstraintError: Error {
   case stringTooLong(_ field: String, limit: Int)
   case stringTooShort(_ field: String, minimum: Int)

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -1,12 +1,23 @@
 import Foundation
 
+/// The scope strings that are not structured resources.
+///
+/// Both are broad grants: ``ScopesSet`` treats them as prerequisites for any
+/// structured check, and ``transitionGeneric`` satisfies most checks outright.
+/// See <doc:OAuthScopes>.
 public enum OAuthScope {
+  /// The base scope every AT Protocol OAuth session carries.
   public static let atproto = "atproto"
+  /// The transitional scope granting broad access, retained for compatibility
+  /// with sessions issued before granular scopes.
   public static let transitionGeneric = "transition:generic"
 }
 
+/// One repository write a procedure performs, checked against `repo` scope.
 public struct RepoWriteRequirement: Hashable, Sendable {
+  /// The NSID of the collection being written.
   public let collection: String
+  /// The kind of write.
   public let action: LexPermissionAction
 
   public init(collection: String, action: LexPermissionAction) {
@@ -15,10 +26,21 @@ public struct RepoWriteRequirement: Hashable, Sendable {
   }
 }
 
+/// A procedure input that declares the repository writes it performs.
+///
+/// A client with an OAuth session checks these against the granted `repo`
+/// scope before sending the request. An input that does not conform is not
+/// repo-checked. See <doc:OAuthScopes>.
 public protocol RepoWriteOperationDescribing: Sendable {
+  /// One requirement per collection and action this operation writes.
   var repoWriteRequirements: [RepoWriteRequirement] { get }
 }
 
+/// A scope string that could not be parsed, or a call the granted scopes do
+/// not permit.
+///
+/// The `insufficient*` cases are thrown by the client before a request is sent;
+/// the rest come from parsing scopes or expanding an ``IncludeScope``.
 public enum OAuthScopeError: Error, Hashable, Sendable {
   case invalidSyntax(String)
   case invalidResource(String)
@@ -33,8 +55,12 @@ public enum OAuthScopeError: Error, Hashable, Sendable {
   case insufficientBlobScope(mime: String)
 }
 
+/// An `rpc` scope: permission to call specific methods against a specific
+/// audience.
 public struct RpcScope: CustomStringConvertible, Hashable, Sendable {
+  /// The service this scope applies to, or `*` for any.
   public let aud: String
+  /// The method NSIDs this scope permits, or `*` for any.
   public let lxm: [String]
 
   public init(aud: String, lxm: [String]) throws {
@@ -125,8 +151,11 @@ public struct RpcScope: CustomStringConvertible, Hashable, Sendable {
   }
 }
 
+/// A `repo` scope: permission to write specific collections.
 public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
+  /// The collection NSIDs this scope permits, or `*` for any.
   public let collection: [String]
+  /// The write actions this scope permits.
   public let action: [LexPermissionAction]
 
   public static let defaultActions: [LexPermissionAction] = [.create, .update, .delete]
@@ -223,7 +252,10 @@ public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
   }
 }
 
+/// A `blob` scope: permission to upload specific MIME types.
 public struct BlobScope: CustomStringConvertible, Hashable, Sendable {
+  /// The accepted MIME patterns, which may use a `*` subtype such as
+  /// `image/*`.
   public let accept: [String]
 
   public init(accept: [String]) throws {
@@ -275,6 +307,7 @@ public struct BlobScope: CustomStringConvertible, Hashable, Sendable {
     return OAuthScopeSyntax(prefix: "blob", params: params).description
   }
 
+  /// Whether this scope accepts the given MIME type.
   public func allows(mime: String) -> Bool {
     guard Self.isValidMime(mime) else {
       return false
@@ -342,8 +375,16 @@ public struct BlobScope: CustomStringConvertible, Hashable, Sendable {
   }
 }
 
+/// An `include` scope: a reference to a permission set rather than a list of
+/// permissions.
+///
+/// ``ScopesSet`` expands each include at construction, adding the resulting
+/// `rpc` and `repo` scopes. An include may only grant permissions under its own
+/// authority. See <doc:OAuthScopes>.
 public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
+  /// The NSID of the permission set being included.
   public let nsid: String
+  /// The audience the expanded permissions apply to, when the include pins one.
   public let aud: String?
 
   public init(nsid: String, aud: String? = nil) throws {
@@ -405,6 +446,7 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
     return OAuthScopeSyntax(prefix: "include", positional: nsid, params: params).description
   }
 
+  /// Whether `otherNsid` falls under this include's namespace authority.
   public func isParentAuthorityOf(_ otherNsid: String) -> Bool {
     if otherNsid == "*" { return false }
     guard let groupPrefixEnd = nsid.lastIndex(of: ".") else {
@@ -423,6 +465,10 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
     return true
   }
 
+  /// Expands a permission set type into the scope strings it grants.
+  ///
+  /// - Throws: ``OAuthScopeError/nsidOutsideAuthority(parent:other:)`` when a
+  ///   permission names an NSID outside this include's authority.
   public func expand<PS: LexPermissionSet>(_ permissionSet: PS.Type) throws -> [String] {
     guard PS.id == nsid else {
       throw OAuthScopeError.invalidSyntax(
@@ -431,6 +477,7 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
     return try expand(permissionSet.permissions)
   }
 
+  /// Expands permissions into the scope strings they grant.
   public func expand(_ permissions: [LexPermission]) throws -> [String] {
     var scopes: [String] = []
     for permission in permissions {
@@ -486,13 +533,28 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
   }
 }
 
+/// The scopes granted to an OAuth session, parsed into structured resources.
+///
+/// Constructing this expands every ``IncludeScope`` against the permission sets
+/// passed in. See <doc:OAuthScopes>.
 public struct ScopesSet: Hashable, Sendable {
+  /// The granted `rpc` scopes, including those from expanded includes.
   public let rpcScopes: [RpcScope]
+  /// The granted `repo` scopes, including those from expanded includes.
   public let repoScopes: [RepoScope]
+  /// The granted `blob` scopes.
   public let blobScopes: [BlobScope]
+  /// The `include` scopes as written, before expansion.
   public let includeScopes: [IncludeScope]
+  /// Granted scopes that are not structured resources, such as
+  /// ``OAuthScope/atproto``.
   public let rawOther: Set<String>
 
+  /// Parses granted scopes, rejecting any that are malformed.
+  ///
+  /// Use this to validate scopes you control. For a token issued by a server
+  /// that may use scopes this library does not know, use
+  /// ``init(rawScopes:permissionSets:)``.
   public init(_ scopes: [String], permissionSets: [any LexPermissionSet.Type] = []) throws {
     var rpc: [RpcScope] = []
     var repo: [RepoScope] = []
@@ -525,6 +587,7 @@ public struct ScopesSet: Hashable, Sendable {
     self.rawOther = other
   }
 
+  /// Parses granted scopes, silently dropping any that cannot be parsed.
   public init(rawScopes scopes: [String], permissionSets: [any LexPermissionSet.Type] = []) {
     var rpc: [RpcScope] = []
     var repo: [RepoScope] = []
@@ -585,14 +648,18 @@ public struct ScopesSet: Hashable, Sendable {
     }
   }
 
+  /// Whether the base ``OAuthScope/atproto`` scope was granted, which every
+  /// structured check requires.
   public var hasAtprotoScope: Bool {
     rawOther.contains(OAuthScope.atproto)
   }
 
+  /// Whether the broad ``OAuthScope/transitionGeneric`` scope was granted.
   public var hasTransitionGeneric: Bool {
     rawOther.contains(OAuthScope.transitionGeneric)
   }
 
+  /// Whether this session may call `lxm` against the service `aud`.
   public func allowsRpc(lxm: String, aud: String) -> Bool {
     guard hasAtprotoScope || hasTransitionGeneric else {
       return false
@@ -610,6 +677,7 @@ public struct ScopesSet: Hashable, Sendable {
     return false
   }
 
+  /// Whether this session may perform `action` on `collection`.
   public func allowsRepo(collection: String, action: LexPermissionAction) -> Bool {
     guard hasAtprotoScope || hasTransitionGeneric else {
       return false
@@ -627,6 +695,7 @@ public struct ScopesSet: Hashable, Sendable {
     return false
   }
 
+  /// Whether this session may upload a blob of type `mime`.
   public func allowsBlob(mime: String) -> Bool {
     guard hasAtprotoScope || hasTransitionGeneric else {
       return false

--- a/Sources/SwiftAtproto/OAuthSession.swift
+++ b/Sources/SwiftAtproto/OAuthSession.swift
@@ -1,7 +1,15 @@
 import Foundation
 
+/// An authenticated OAuth session whose granted scopes gate outgoing calls.
+///
+/// A client returning a session from `_XRPCCallable.oauthSession` has every
+/// request checked against ``grantedScopes`` before it is sent. See
+/// <doc:OAuthScopes>.
 public protocol OAuthSession: Sendable {
+  /// The DID of the account this session authenticates.
   var sessionDid: DID { get }
+  /// The DID of the service this session was issued for.
   var audienceDid: DID { get }
+  /// The scopes the authorization server granted.
   var grantedScopes: ScopesSet { get }
 }

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -1,34 +1,34 @@
 import Foundation
 
-// A dedicated AT URI type for the lexicon `at-uri` string format. There is no natural Foundation type
-// (`URL` rejects the `at://` scheme and normalizes), so this is a self-contained, range-based parser.
-//
-// Scope: this implements ONLY the *restricted* (Lexicon) AT URI syntax in strict mode, per the
-// AT Protocol AT URI spec (https://atproto.com/specs/at-uri-scheme):
-//
-//   AT-URI     = "at://" AUTHORITY [ "/" COLLECTION [ "/" RKEY ] ] [ "#" FRAGMENT ]
-//   AUTHORITY  = HANDLE | DID
-//   COLLECTION = NSID
-//   RKEY       = RECORD-KEY
-//
-// This is the form used by lexicon `at-uri` fields and covers essentially all real AT URIs. The
-// general AT URI syntax (multi-segment paths, query strings) is intentionally NOT supported. A parse
-// mode for the lenient variant (relaxed record key, trailing slash, query) may be added to this same
-// type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
-// separate addition if a concrete need arises.
-//
-// DID / Handle / NSID / RecordKey / AtIdentifier component validators live in their dedicated
-// identifier-type files. Only the JSON Pointer fragment validator remains here.
+/// A dedicated AT URI type for the lexicon `at-uri` string format. There is no natural Foundation type
+/// (`URL` rejects the `at://` scheme and normalizes), so this is a self-contained, range-based parser.
+///
+/// Scope: this implements ONLY the *restricted* (Lexicon) AT URI syntax in strict mode, per the
+/// AT Protocol AT URI spec (https://atproto.com/specs/at-uri-scheme):
+///
+///   AT-URI     = "at://" AUTHORITY [ "/" COLLECTION [ "/" RKEY ] ] [ "#" FRAGMENT ]
+///   AUTHORITY  = HANDLE | DID
+///   COLLECTION = NSID
+///   RKEY       = RECORD-KEY
+///
+/// This is the form used by lexicon `at-uri` fields and covers essentially all real AT URIs. The
+/// general AT URI syntax (multi-segment paths, query strings) is intentionally NOT supported. A parse
+/// mode for the lenient variant (relaxed record key, trailing slash, query) may be added to this same
+/// type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
+/// separate addition if a concrete need arises.
+///
+/// DID / Handle / NSID / RecordKey / AtIdentifier component validators live in their dedicated
+/// identifier-type files. Only the JSON Pointer fragment validator remains here.
 public struct ATURI: LexiconStringFormat {
-  // The original wire string, kept verbatim (no normalization).
+  /// The original wire string, kept verbatim (no normalization).
   public let rawValue: String
-  // Required authority: a DID or a handle, dispatched via `AtIdentifier`.
+  /// Required authority: a DID or a handle, dispatched via `AtIdentifier`.
   public let authority: AtIdentifier
-  // Optional collection NSID.
+  /// Optional collection NSID.
   public let collection: NSID?
-  // Optional record key (trailing path segment).
+  /// Optional record key (trailing path segment).
   public let rkey: RecordKey?
-  // Optional JSON Pointer fragment (without the leading "#").
+  /// Optional JSON Pointer fragment (without the leading "#").
   public let fragment: String?
 
   public init(string: String) throws {

--- a/Sources/SwiftAtproto/StringFormats/AtIdentifier.swift
+++ b/Sources/SwiftAtproto/StringFormats/AtIdentifier.swift
@@ -1,9 +1,9 @@
 import Foundation
 
-// Type for the lexicon `at-identifier` string format: either a DID or a Handle. Per the AT
-// Protocol Identifier spec (https://atproto.com/specs/at-identifier), inputs starting with `did:`
-// are validated as DIDs; everything else is validated as a Handle. Wire bytes round-trip via
-// `rawValue` byte-for-byte.
+/// Type for the lexicon `at-identifier` string format: either a DID or a Handle. Per the AT
+/// Protocol Identifier spec (https://atproto.com/specs/at-identifier), inputs starting with `did:`
+/// are validated as DIDs; everything else is validated as a Handle. Wire bytes round-trip via
+/// `rawValue` byte-for-byte.
 public enum AtIdentifier: LexiconStringFormat {
   case did(DID)
   case handle(Handle)

--- a/Sources/SwiftAtproto/StringFormats/AtprotoDatetimeFormatStyle.swift
+++ b/Sources/SwiftAtproto/StringFormats/AtprotoDatetimeFormatStyle.swift
@@ -1,8 +1,8 @@
 import Foundation
 
-// Canonical AT Protocol datetime: UTC, millisecond precision; lossy for sub-millisecond instants and
-// zone offsets. Formatted in the proleptic Gregorian calendar (consistent with parsing) rather than
-// via `ISO8601Format`, which applies the Julian cutover before 1582.
+/// Canonical AT Protocol datetime: UTC, millisecond precision; lossy for sub-millisecond instants and
+/// zone offsets. Formatted in the proleptic Gregorian calendar (consistent with parsing) rather than
+/// via `ISO8601Format`, which applies the Julian cutover before 1582.
 public struct AtprotoDatetimeFormatStyle: FormatStyle {
   public init() {}
 

--- a/Sources/SwiftAtproto/StringFormats/AtprotoDatetimeParseStrategy.swift
+++ b/Sources/SwiftAtproto/StringFormats/AtprotoDatetimeParseStrategy.swift
@@ -1,5 +1,11 @@
 import Foundation
 
+/// Parses an AT Protocol `datetime` string into a `Date`.
+///
+/// The grammar is narrower than ISO 8601. Strict parsing requires the form the
+/// spec mandates; ``lenient`` parsing also accepts the older spellings that
+/// existing records contain. Reach it as `.atprotoDatetime` or
+/// `.atprotoDatetimeLenient` rather than constructing it directly.
 public struct AtprotoDatetimeParseStrategy: ParseStrategy {
   static let maxLength = 64
 

--- a/Sources/SwiftAtproto/StringFormats/DID.swift
+++ b/Sources/SwiftAtproto/StringFormats/DID.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-// Type for the lexicon `did` string format: Decentralized Identifier per W3C DID spec
-// (https://www.w3.org/TR/did-core/) with atproto restrictions per the AT Protocol DID spec
-// (https://atproto.com/specs/did).
-//
-// Wire-shape validation only: ASCII grammar `^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$`,
-// total length <= 2048 byte. No `%xx` decoding (verbatim wire preservation). No semantic
-// resolution (registered-method resolvers live elsewhere — e.g. `ATProtoCrypto`).
+/// Type for the lexicon `did` string format: Decentralized Identifier per W3C DID spec
+/// (https://www.w3.org/TR/did-core/) with atproto restrictions per the AT Protocol DID spec
+/// (https://atproto.com/specs/did).
+///
+/// Wire-shape validation only: ASCII grammar `^did:[a-z]+:[a-zA-Z0-9._:%-]*[a-zA-Z0-9._-]$`,
+/// total length <= 2048 byte. No `%xx` decoding (verbatim wire preservation). No semantic
+/// resolution (registered-method resolvers live elsewhere — e.g. `ATProtoCrypto`).
 public struct DID: LexiconStringFormat {
-  // The original wire string, kept verbatim.
+  /// The original wire string, kept verbatim.
   public let rawValue: String
 
   public init(string: String) throws {
@@ -18,9 +18,9 @@ public struct DID: LexiconStringFormat {
     rawValue = string
   }
 
-  // The DID method (the lowercase ASCII segment between the first two colons). For `did:plc:abc`
-  // this is `"plc"`; for `did:web:example.com` this is `"web"`. Always non-empty since `rawValue`
-  // was admitted by the parser.
+  /// The DID method (the lowercase ASCII segment between the first two colons). For `did:plc:abc`
+  /// this is `"plc"`; for `did:web:example.com` this is `"web"`. Always non-empty since `rawValue`
+  /// was admitted by the parser.
   public var method: String {
     let afterPrefix = rawValue.dropFirst(4)  // drop "did:"
     let end = afterPrefix.firstIndex(of: ":") ?? afterPrefix.endIndex
@@ -29,10 +29,10 @@ public struct DID: LexiconStringFormat {
 }
 
 extension DID {
-  // An open, extensible tag for the DID method. Use `switch` with `case .plc` / `case .web` /
-  // `default` for dispatch; unknown methods survive as `KnownMethod(rawValue:)` values so
-  // constructing a DID with a future or unregistered method never fails and never gets silently
-  // downgraded. `knownMethod.rawValue == method` always.
+  /// An open, extensible tag for the DID method. Use `switch` with `case .plc` / `case .web` /
+  /// `default` for dispatch; unknown methods survive as `KnownMethod(rawValue:)` values so
+  /// constructing a DID with a future or unregistered method never fails and never gets silently
+  /// downgraded. `knownMethod.rawValue == method` always.
   public struct KnownMethod: RawRepresentable, Hashable, Sendable {
     public let rawValue: String
     public init(rawValue: String) { self.rawValue = rawValue }

--- a/Sources/SwiftAtproto/StringFormats/FormatString.swift
+++ b/Sources/SwiftAtproto/StringFormats/FormatString.swift
@@ -1,21 +1,34 @@
 import Foundation
 
-// Equality and hashing use `rawValue` (the wire string), not the parsed value; compare `typed` to
-// compare by value.
+/// A Lexicon string field that keeps its wire value and parses on demand.
+///
+/// Decodes and encodes as a plain `String`, so a value this library would
+/// reject still round-trips byte-for-byte and a record signed elsewhere keeps
+/// its signature valid. See <doc:LexiconStringFormats>.
+///
+/// Equality and hashing use ``rawValue`` (the wire string), not the parsed
+/// value; compare ``typed`` to compare by value.
 public struct FormatString<T: LexiconStringFormat>: RawRepresentable, Codable, Hashable, Sendable {
+  /// The wire string, exactly as it was decoded.
   public let rawValue: String
 
   public init(rawValue: String) {
     self.rawValue = rawValue
   }
 
-  // Stores the canonical `typed.rawValue`, which may differ from a decoded wire string.
+  /// Stores the canonical `typed.rawValue`, which may differ from a decoded wire string.
   public init(_ typed: T) {
     rawValue = typed.rawValue
   }
 
+  /// The value parsed strictly, or `nil` when ``rawValue`` does not satisfy the
+  /// format.
   public var typed: T? { try? T(string: rawValue) }
 
+  /// The value parsed with the format's relaxed rules, or `nil` when it does
+  /// not parse at all.
+  ///
+  /// Identical to ``typed`` for formats that define no relaxed reading.
   public var typedLenient: T? { try? T(string: rawValue, strict: false) }
 
   public init(from decoder: any Decoder) throws {

--- a/Sources/SwiftAtproto/StringFormats/Handle.swift
+++ b/Sources/SwiftAtproto/StringFormats/Handle.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-// Type for the lexicon `handle` string format: a DNS-like atproto handle per the AT Protocol
-// Handle spec (https://atproto.com/specs/handle).
-//
-// Wire-shape validation only: each label is 1–63 byte ASCII alnum / hyphen with no edge hyphen,
-// the trailing TLD starts with a letter, the whole string is dot-separated with at least two
-// labels, and total length is <= 253 byte. Punycode (`xn--…`) labels pass the same byte test —
-// IDN canonicalization is intentionally not performed.
+/// Type for the lexicon `handle` string format: a DNS-like atproto handle per the AT Protocol
+/// Handle spec (https://atproto.com/specs/handle).
+///
+/// Wire-shape validation only: each label is 1–63 byte ASCII alnum / hyphen with no edge hyphen,
+/// the trailing TLD starts with a letter, the whole string is dot-separated with at least two
+/// labels, and total length is <= 253 byte. Punycode (`xn--…`) labels pass the same byte test —
+/// IDN canonicalization is intentionally not performed.
 public struct Handle: LexiconStringFormat {
-  // The original wire string, kept verbatim.
+  /// The original wire string, kept verbatim.
   public let rawValue: String
 
   public init(string: String) throws {
@@ -20,9 +20,9 @@ public struct Handle: LexiconStringFormat {
 }
 
 extension Handle {
-  // Sentinel returned by handle-verification paths (e.g. `DIDDocument.Verified`) when the handle
-  // cannot be confirmed against the DID. Well-formed per `isValid`, so it never fails to
-  // construct at runtime.
+  /// Sentinel returned by handle-verification paths (e.g. `DIDDocument.Verified`) when the handle
+  /// cannot be confirmed against the DID. Well-formed per `isValid`, so it never fails to
+  /// construct at runtime.
   public static let invalid: Handle = try! Handle(string: "handle.invalid")
 }
 

--- a/Sources/SwiftAtproto/StringFormats/Language.swift
+++ b/Sources/SwiftAtproto/StringFormats/Language.swift
@@ -1,26 +1,26 @@
 import Foundation
 
-// Type for the lexicon `language` string format: a range-based BCP-47 (RFC 5646) parser whose
-// `rawValue` keeps the wire string verbatim and acts as the single source of truth — parsed
-// `Components` are never re-serialized back to an identifier.
-//
-// Scope: the canonical BCP-47 langtag grammar plus the RFC 5646 §2.2.8 grandfathered/irregular
-// whitelist, in strict mode. The parser only validates grammar — it does not consult any subtag
-// registry. Lenient mode is still syntax-only BCP-47 parsing: it does not accept `_` separators
-// or perform canonicalization, but it skips RFC 5646 §4.1 duplicate-subtag value checks.
+/// Type for the lexicon `language` string format: a range-based BCP-47 (RFC 5646) parser whose
+/// `rawValue` keeps the wire string verbatim and acts as the single source of truth — parsed
+/// `Components` are never re-serialized back to an identifier.
+///
+/// Scope: the canonical BCP-47 langtag grammar plus the RFC 5646 §2.2.8 grandfathered/irregular
+/// whitelist, in strict mode. The parser only validates grammar — it does not consult any subtag
+/// registry. Lenient mode is still syntax-only BCP-47 parsing: it does not accept `_` separators
+/// or perform canonicalization, but it skips RFC 5646 §4.1 duplicate-subtag value checks.
 public struct Language: LexiconStringFormat {
-  // The original wire string, kept verbatim (no normalization).
+  /// The original wire string, kept verbatim (no normalization).
   public let rawValue: String
-  // The BCP-47 parsed components (or grandfathered match).
+  /// The BCP-47 parsed components (or grandfathered match).
   public let components: Components
 
   public init(string: String) throws {
     try self.init(string: string, strict: true)
   }
 
-  // When `strict == false`, skips RFC 5646 §4.1 duplicate variant / extension-singleton
-  // rejection; grammar, length cap, and ASCII charset gates still apply. Lenient instances
-  // may therefore hold duplicate subtags — an invariant strict-parsed values never violate.
+  /// When `strict == false`, skips RFC 5646 §4.1 duplicate variant / extension-singleton
+  /// rejection; grammar, length cap, and ASCII charset gates still apply. Lenient instances
+  /// may therefore hold duplicate subtags — an invariant strict-parsed values never violate.
   public init(string: String, strict: Bool) throws {
     guard let components = Language.parse(string, strict: strict) else {
       throw LexiconStringFormatError.invalid(format: "language", value: string)
@@ -31,7 +31,7 @@ public struct Language: LexiconStringFormat {
 }
 
 extension Language {
-  // BCP-47 primary language subtag: 2-3 ALPHA, or 4 ALPHA (reserved), or 5-8 ALPHA (registered).
+  /// BCP-47 primary language subtag: 2-3 ALPHA, or 4 ALPHA (reserved), or 5-8 ALPHA (registered).
   public struct LanguageCode: Hashable, Sendable, Codable, RawRepresentable {
     public let rawValue: String
     public init(rawValue: String) { self.rawValue = rawValue }
@@ -39,7 +39,7 @@ extension Language {
     public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
   }
 
-  // BCP-47 script subtag: 4 ALPHA, e.g. `Latn`, `Hant`.
+  /// BCP-47 script subtag: 4 ALPHA, e.g. `Latn`, `Hant`.
   public struct Script: Hashable, Sendable, Codable, RawRepresentable {
     public let rawValue: String
     public init(rawValue: String) { self.rawValue = rawValue }
@@ -47,7 +47,7 @@ extension Language {
     public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
   }
 
-  // BCP-47 region subtag: 2 ALPHA (e.g. `US`) or 3 DIGIT (e.g. `419`).
+  /// BCP-47 region subtag: 2 ALPHA (e.g. `US`) or 3 DIGIT (e.g. `419`).
   public struct Region: Hashable, Sendable, Codable, RawRepresentable {
     public let rawValue: String
     public init(rawValue: String) { self.rawValue = rawValue }
@@ -55,7 +55,7 @@ extension Language {
     public func encode(to encoder: any Encoder) throws { try rawValue.encode(to: encoder) }
   }
 
-  // BCP-47 variant subtag: 5-8 alphanum, or DIGIT + 3 alphanum (e.g. `1901`, `rozaj`).
+  /// BCP-47 variant subtag: 5-8 alphanum, or DIGIT + 3 alphanum (e.g. `1901`, `rozaj`).
   public struct Variant: Hashable, Sendable, Codable, RawRepresentable {
     public let rawValue: String
     public init(rawValue: String) { self.rawValue = rawValue }
@@ -65,43 +65,43 @@ extension Language {
 }
 
 extension Language {
-  // The parsed BCP-47 components: languageCode / script / region, plus the langtag fields the
-  // lexicon needs to model verbatim (variants, extensions, privateUse) and the §2.2.8
-  // grandfathered match.
-  //
-  // `Components` is created by the `Language.init(string:)` parser; callers do not construct it
-  // directly. Sub-tag fields preserve the wire case verbatim (no normalization).
+  /// The parsed BCP-47 components: languageCode / script / region, plus the langtag fields the
+  /// lexicon needs to model verbatim (variants, extensions, privateUse) and the §2.2.8
+  /// grandfathered match.
+  ///
+  /// `Components` is created by the `Language.init(string:)` parser; callers do not construct it
+  /// directly. Sub-tag fields preserve the wire case verbatim (no normalization).
   public struct Components: Hashable, Sendable {
-    // The primary language subtag. nil when the wire string is a grandfathered/irregular tag
-    // or a private-use-only tag (`x-…`).
+    /// The primary language subtag. nil when the wire string is a grandfathered/irregular tag
+    /// or a private-use-only tag (`x-…`).
     public let languageCode: LanguageCode?
-    // BCP-47 §2.2.2 extended language subtags. Up to 3 `3ALPHA` subtags, only present when
-    // the primary language is 2-3 ALPHA. Empty for tags without extlang. RFC 5646 discourages
-    // the extlang form (`zh-cmn`) in favor of the primary subtag directly (`cmn`); the parser
-    // accepts both forms verbatim and leaves canonicalization to the consumer.
-    // The 3-ALPHA constraint is enforced by the parser (`isExtendedLanguageSubtag`), not by
-    // the element type, which reuses `LanguageCode` (2-8 ALPHA) for shape parity.
+    /// BCP-47 §2.2.2 extended language subtags. Up to 3 `3ALPHA` subtags, only present when
+    /// the primary language is 2-3 ALPHA. Empty for tags without extlang. RFC 5646 discourages
+    /// the extlang form (`zh-cmn`) in favor of the primary subtag directly (`cmn`); the parser
+    /// accepts both forms verbatim and leaves canonicalization to the consumer.
+    /// The 3-ALPHA constraint is enforced by the parser (`isExtendedLanguageSubtag`), not by
+    /// the element type, which reuses `LanguageCode` (2-8 ALPHA) for shape parity.
     public let extendedLanguageSubtags: [LanguageCode]
     public let script: Script?
     public let region: Region?
     public let variants: [Variant]
     public let extensions: [Extension]
     public let privateUse: [String]
-    // Per RFC 5646 §2.2.8, grandfathered tags are atomic: only inputs that match a registered
-    // tag exactly (case-insensitive) populate this field. Adding any suffix (e.g.,
-    // `zh-min-nan-x-foo`) demotes the tag to a normal langtag parse where this is nil.
+    /// Per RFC 5646 §2.2.8, grandfathered tags are atomic: only inputs that match a registered
+    /// tag exactly (case-insensitive) populate this field. Adding any suffix (e.g.,
+    /// `zh-min-nan-x-foo`) demotes the tag to a normal langtag parse where this is nil.
     public let grandfathered: Grandfathered?
   }
 
-  // A BCP-47 extension: a singleton (ALPHA / DIGIT except `x`) followed by 1+ subtags of
-  // length 2-8 alphanumeric, e.g. `u-co-phonebk`. Subtags preserve the wire case verbatim.
+  /// A BCP-47 extension: a singleton (ALPHA / DIGIT except `x`) followed by 1+ subtags of
+  /// length 2-8 alphanumeric, e.g. `u-co-phonebk`. Subtags preserve the wire case verbatim.
   public struct Extension: Hashable, Sendable {
     public let singleton: Character
     public let subtags: [String]
   }
 
-  // RFC 5646 §2.2.8 grandfathered/irregular language tags. The parser matches these
-  // case-insensitively but the canonical wire form (as listed below) is the `rawValue`.
+  /// RFC 5646 §2.2.8 grandfathered/irregular language tags. The parser matches these
+  /// case-insensitively but the canonical wire form (as listed below) is the `rawValue`.
   public enum Grandfathered: String, Hashable, Sendable, Codable, CaseIterable {
     // Irregular
     case enGBOed = "en-GB-oed"

--- a/Sources/SwiftAtproto/StringFormats/LexiconStringFormat.swift
+++ b/Sources/SwiftAtproto/StringFormats/LexiconStringFormat.swift
@@ -1,19 +1,34 @@
 import Foundation
 
+/// A Lexicon `string` format such as `did`, `handle`, `at-uri`, or `datetime`.
+///
+/// Conforming types validate the wire shape of a string and expose it as
+/// ``rawValue``. Generated models do not store them directly; they store
+/// ``FormatString``, which keeps the wire string and parses on demand. See
+/// <doc:LexiconStringFormats>.
 public protocol LexiconStringFormat: Hashable, Sendable {
+  /// The canonical wire string for this value.
   var rawValue: String { get }
+  /// Parses `string` strictly, throwing ``LexiconStringFormatError`` when it
+  /// does not satisfy the format.
   init(string: String) throws
+  /// Parses `string`, optionally with the format's relaxed rules.
+  ///
+  /// Formats with no relaxed reading ignore `strict` and always parse strictly.
   init(string: String, strict: Bool) throws
 }
 
 extension LexiconStringFormat {
-  // Formats without a lenient override (most identifier formats) fall through to strict.
+  /// Formats without a lenient override (most identifier formats) fall through to strict.
   public init(string: String, strict: Bool) throws {
     try self.init(string: string)
   }
 }
 
+/// A failure to parse a Lexicon string format.
 public enum LexiconStringFormatError: Error, Equatable {
+  /// The value does not satisfy the named format's grammar.
   case invalid(format: String, value: String)
+  /// The value is longer than the named format's byte limit.
   case tooLong(format: String, limit: Int)
 }

--- a/Sources/SwiftAtproto/StringFormats/NSID.swift
+++ b/Sources/SwiftAtproto/StringFormats/NSID.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-// Type for the lexicon `nsid` string format: AT Protocol Namespaced Identifier per the AT Protocol
-// NSID spec (https://atproto.com/specs/nsid).
-//
-// Wire-shape validation only: a reverse-DNS authority followed by a name segment, with at least
-// three dot-separated segments. Each segment is 1–63 byte ASCII alnum / hyphen with no edge
-// hyphen; the first segment cannot start with a digit; the name (last segment) is alnum-only and
-// cannot start with a digit. Total length <= 317 byte.
+/// Type for the lexicon `nsid` string format: AT Protocol Namespaced Identifier per the AT Protocol
+/// NSID spec (https://atproto.com/specs/nsid).
+///
+/// Wire-shape validation only: a reverse-DNS authority followed by a name segment, with at least
+/// three dot-separated segments. Each segment is 1–63 byte ASCII alnum / hyphen with no edge
+/// hyphen; the first segment cannot start with a digit; the name (last segment) is alnum-only and
+/// cannot start with a digit. Total length <= 317 byte.
 public struct NSID: LexiconStringFormat {
-  // The original wire string, kept verbatim.
+  /// The original wire string, kept verbatim.
   public let rawValue: String
 
   public init(string: String) throws {
@@ -18,14 +18,14 @@ public struct NSID: LexiconStringFormat {
     rawValue = string
   }
 
-  // The reverse-DNS authority portion: all segments except the last one, re-ordered into a
-  // forward domain. For `com.example.foo` this is `"example.com"`; for `org.4chan.lex.getThing`
-  // it is `"lex.4chan.org"`.
+  /// The reverse-DNS authority portion: all segments except the last one, re-ordered into a
+  /// forward domain. For `com.example.foo` this is `"example.com"`; for `org.4chan.lex.getThing`
+  /// it is `"lex.4chan.org"`.
   public var authority: String {
     rawValue.split(separator: ".").dropLast().reversed().joined(separator: ".")
   }
 
-  // The name segment (last dot-separated component). For `com.example.foo` this is `"foo"`.
+  /// The name segment (last dot-separated component). For `com.example.foo` this is `"foo"`.
   public var name: String {
     String(rawValue.split(separator: ".").last ?? "")
   }

--- a/Sources/SwiftAtproto/StringFormats/RecordKey.swift
+++ b/Sources/SwiftAtproto/StringFormats/RecordKey.swift
@@ -1,14 +1,14 @@
 import Foundation
 
-// Type for the lexicon `record-key` string format: the opaque trailing segment of an AT URI per
-// the AT Protocol Record Key spec (https://atproto.com/specs/record-key).
-//
-// Strict mode (the default `init(string:)`): 1–512 byte ASCII alnum / `_~.:-`, excluding the
-// special forbidden values `"."` and `".."`. A lenient mode is also available via
-// `init(string:strict: false)`; see that initializer for the relaxed grammar and the resulting
-// type-invariant trade-off.
+/// Type for the lexicon `record-key` string format: the opaque trailing segment of an AT URI per
+/// the AT Protocol Record Key spec (https://atproto.com/specs/record-key).
+///
+/// Strict mode (the default `init(string:)`): 1–512 byte ASCII alnum / `_~.:-`, excluding the
+/// special forbidden values `"."` and `".."`. A lenient mode is also available via
+/// `init(string:strict: false)`; see that initializer for the relaxed grammar and the resulting
+/// type-invariant trade-off.
 public struct RecordKey: LexiconStringFormat {
-  // The original wire string, kept verbatim.
+  /// The original wire string, kept verbatim.
   public let rawValue: String
 
   public init(string: String) throws {
@@ -18,11 +18,11 @@ public struct RecordKey: LexiconStringFormat {
     rawValue = string
   }
 
-  // Opt-in lenient parsing. Accepts wire strings that violate the strict record-key spec
-  // (`.` / `..` / over 512 byte / chars outside `[a-zA-Z0-9_~.:-]`) as long as the value is
-  // non-empty and contains no `/`, `?`, or `#`. Caller takes responsibility: a lenient instance
-  // can hold values the strict spec rejects, so type invariants weaken when this overload is
-  // used explicitly.
+  /// Opt-in lenient parsing. Accepts wire strings that violate the strict record-key spec
+  /// (`.` / `..` / over 512 byte / chars outside `[a-zA-Z0-9_~.:-]`) as long as the value is
+  /// non-empty and contains no `/`, `?`, or `#`. Caller takes responsibility: a lenient instance
+  /// can hold values the strict spec rejects, so type invariants weaken when this overload is
+  /// used explicitly.
   public init(string: String, strict: Bool) throws {
     let valid = strict ? RecordKey.isValid(string) : RecordKey.isValidLenient(string)
     guard valid else {

--- a/Sources/SwiftAtproto/StringFormats/TID.swift
+++ b/Sources/SwiftAtproto/StringFormats/TID.swift
@@ -1,15 +1,15 @@
 import Foundation
 
-// Type for the lexicon `tid` string format: AT Protocol Timestamp Identifier per the AT Protocol
-// TID spec (https://atproto.com/specs/tid).
-//
-// Wire-shape validation only: a 13-character base32-sortable token. The first character is from
-// `[234567abcdefghij]` (the high bit of the encoded timestamp is always zero in the foreseeable
-// future, restricting the leading character to the lower 16 of the 32-char alphabet). The
-// remaining 12 characters are from the full base32-sortable alphabet
-// `[234567abcdefghijklmnopqrstuvwxyz]`.
+/// Type for the lexicon `tid` string format: AT Protocol Timestamp Identifier per the AT Protocol
+/// TID spec (https://atproto.com/specs/tid).
+///
+/// Wire-shape validation only: a 13-character base32-sortable token. The first character is from
+/// `[234567abcdefghij]` (the high bit of the encoded timestamp is always zero in the foreseeable
+/// future, restricting the leading character to the lower 16 of the 32-char alphabet). The
+/// remaining 12 characters are from the full base32-sortable alphabet
+/// `[234567abcdefghijklmnopqrstuvwxyz]`.
 public struct TID: LexiconStringFormat {
-  // The original wire string, kept verbatim.
+  /// The original wire string, kept verbatim.
   public let rawValue: String
 
   public init(string: String) throws {
@@ -30,28 +30,28 @@ extension TID {
     return true
   }
 
-  // Microsecond timestamp since the UNIX epoch. The top 53 bits of the 64-bit encoded value
-  // per the TID spec. Returns 0 if `rawValue` cannot be decoded (unreachable for instances
-  // produced by `init(string:)`, since the parser guarantees a valid base32-sortable form).
+  /// Microsecond timestamp since the UNIX epoch. The top 53 bits of the 64-bit encoded value
+  /// per the TID spec. Returns 0 if `rawValue` cannot be decoded (unreachable for instances
+  /// produced by `init(string:)`, since the parser guarantees a valid base32-sortable form).
   public var timestamp: UInt64 {
     (decodeBase32Sortable(rawValue) ?? 0) >> 10
   }
 
-  // 10-bit clock identifier (0...1023) per the TID spec. Returns 0 on a decode failure
-  // (unreachable in practice — see `timestamp`).
+  /// 10-bit clock identifier (0...1023) per the TID spec. Returns 0 on a decode failure
+  /// (unreachable in practice — see `timestamp`).
   public var clockId: UInt16 {
     UInt16((decodeBase32Sortable(rawValue) ?? 0) & 0x3FF)
   }
 
-  // Generate a new TID with a monotonic guarantee. Same-millisecond calls receive an
-  // incrementing per-millisecond counter so consecutive TIDs never collide; clock skew
-  // (system clock going backward) is absorbed by taking `max(now, lastTimestamp)`. If `prev`
-  // is supplied and the freshly generated TID is not newer, the timestamp is bumped to
-  // `prev.timestamp + 1` for additional safety across generator instances.
-  //
-  // Wire-shape correctness is guaranteed by construction: the encoded base32-sortable form is
-  // always 13 characters from the allowed alphabet, so the validator inside `init(string:)`
-  // never throws here.
+  /// Generate a new TID with a monotonic guarantee. Same-millisecond calls receive an
+  /// incrementing per-millisecond counter so consecutive TIDs never collide; clock skew
+  /// (system clock going backward) is absorbed by taking `max(now, lastTimestamp)`. If `prev`
+  /// is supplied and the freshly generated TID is not newer, the timestamp is bumped to
+  /// `prev.timestamp + 1` for additional safety across generator instances.
+  ///
+  /// Wire-shape correctness is guaranteed by construction: the encoded base32-sortable form is
+  /// always 13 characters from the allowed alphabet, so the validator inside `init(string:)`
+  /// never throws here.
   public static func next(prev: TID? = nil) -> TID {
     let nowMs = UInt64(Date().timeIntervalSince1970 * 1_000)
     let micros = tidClockState.advanceTimestamp(nowMs: nowMs)

--- a/Sources/SwiftAtproto/StringFormats/URI.swift
+++ b/Sources/SwiftAtproto/StringFormats/URI.swift
@@ -1,31 +1,31 @@
 import Foundation
 
-// Type for the lexicon `uri` string format: a lenient parser that keeps the wire string
-// verbatim and exposes best-effort typed accessors for known schemes (`url: URL?` and
-// `atUri: ATURI?`).
-//
-// Scope: atproto lexicon `uri` is "flexible to any URI schema" per RFC 3986
-// (https://atproto.com/specs/lexicon). This parser only enforces the wire-level shape:
-//   - RFC 3986 §3.1 scheme grammar (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )) followed by ":"
-//   - optional "//"
-//   - non-empty body whose first byte is neither "/" nor ASCII whitespace, and whose remaining
-//     bytes contain no ASCII whitespace / control characters
-//   - total length <= 8 KiB (per spec)
-// Non-ASCII bytes in the body are accepted verbatim (per the spec's "any scheme" stance);
-// canonicalization is left to the consumer.
-//
-// `URL` is intentionally NOT used as the conformance: `URL(string:)` silently re-encodes
-// wire characters (spaces → `%20`, IDN → punycode, etc.), and even
-// `URL(string:encodingInvalidCharacters: false)` is too strict for our lenient wire
-// admission (rejects inputs the lexicon `uri` format may carry, e.g. raw non-ASCII bytes)
-// while still rejecting `at://did:plc:…` (the DID authority's embedded colon collides with
-// port grammar). `URL` is offered as a best-effort derived accessor instead, exposing the
-// `encodingInvalidCharacters:` toggle so callers choose between best-effort (silent
-// re-encoding) and strict wire-faithful (nil for inputs needing encoding).
+/// Type for the lexicon `uri` string format: a lenient parser that keeps the wire string
+/// verbatim and exposes best-effort typed accessors for known schemes (`url: URL?` and
+/// `atUri: ATURI?`).
+///
+/// Scope: atproto lexicon `uri` is "flexible to any URI schema" per RFC 3986
+/// (https://atproto.com/specs/lexicon). This parser only enforces the wire-level shape:
+///   - RFC 3986 §3.1 scheme grammar (ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )) followed by ":"
+///   - optional "//"
+///   - non-empty body whose first byte is neither "/" nor ASCII whitespace, and whose remaining
+///     bytes contain no ASCII whitespace / control characters
+///   - total length <= 8 KiB (per spec)
+/// Non-ASCII bytes in the body are accepted verbatim (per the spec's "any scheme" stance);
+/// canonicalization is left to the consumer.
+///
+/// `URL` is intentionally NOT used as the conformance: `URL(string:)` silently re-encodes
+/// wire characters (spaces → `%20`, IDN → punycode, etc.), and even
+/// `URL(string:encodingInvalidCharacters: false)` is too strict for our lenient wire
+/// admission (rejects inputs the lexicon `uri` format may carry, e.g. raw non-ASCII bytes)
+/// while still rejecting `at://did:plc:…` (the DID authority's embedded colon collides with
+/// port grammar). `URL` is offered as a best-effort derived accessor instead, exposing the
+/// `encodingInvalidCharacters:` toggle so callers choose between best-effort (silent
+/// re-encoding) and strict wire-faithful (nil for inputs needing encoding).
 public struct URI: LexiconStringFormat {
-  // The original wire string, kept verbatim (no normalization).
+  /// The original wire string, kept verbatim (no normalization).
   public let rawValue: String
-  // The URI scheme (before the colon), preserved verbatim (no lowercase canonicalization).
+  /// The URI scheme (before the colon), preserved verbatim (no lowercase canonicalization).
   public let scheme: String
   public let kind: Kind
 
@@ -44,25 +44,25 @@ public struct URI: LexiconStringFormat {
     kind = URI.classify(string)
   }
 
-  // Best-effort `URL` projection. The `encodingInvalidCharacters` parameter is forwarded to
-  // `URL(string:encodingInvalidCharacters:)`:
-  //   - `true` (default, matching Foundation's historical `URL(string:)` behavior): silently
-  //     re-encodes wire characters that need encoding (spaces → `%20`, IDN → punycode, etc.)
-  //     and converts the result to a usable URL when possible. `absoluteString` may diverge
-  //     from `rawValue`.
-  //   - `false`: returns nil for wire forms that would require any re-encoding. When
-  //     non-nil, the URL's `absoluteString` matches `rawValue` byte-for-byte (wire-faithful).
-  //
-  // Returns nil in either mode for inputs `URL` cannot parse — notably any URI whose
-  // authority contains a colon followed by non-numeric bytes (port grammar violation, e.g.
-  // `at://did:plc:abc` or `at://example.com:notaport/path`). Non-nil does NOT imply the URL
-  // is semantically loadable (e.g. `https:///x` parses but has no host).
+  /// Best-effort `URL` projection. The `encodingInvalidCharacters` parameter is forwarded to
+  /// `URL(string:encodingInvalidCharacters:)`:
+  ///   - `true` (default, matching Foundation's historical `URL(string:)` behavior): silently
+  ///     re-encodes wire characters that need encoding (spaces → `%20`, IDN → punycode, etc.)
+  ///     and converts the result to a usable URL when possible. `absoluteString` may diverge
+  ///     from `rawValue`.
+  ///   - `false`: returns nil for wire forms that would require any re-encoding. When
+  ///     non-nil, the URL's `absoluteString` matches `rawValue` byte-for-byte (wire-faithful).
+  ///
+  /// Returns nil in either mode for inputs `URL` cannot parse — notably any URI whose
+  /// authority contains a colon followed by non-numeric bytes (port grammar violation, e.g.
+  /// `at://did:plc:abc` or `at://example.com:notaport/path`). Non-nil does NOT imply the URL
+  /// is semantically loadable (e.g. `https:///x` parses but has no host).
   public func url(encodingInvalidCharacters: Bool = true) -> URL? {
     URL(string: rawValue, encodingInvalidCharacters: encodingInvalidCharacters)
   }
 
-  // Best-effort AT-URI projection. Non-nil only when the wire string is a valid restricted-form
-  // AT URI (scheme=at, authority=DID/handle, …).
+  /// Best-effort AT-URI projection. Non-nil only when the wire string is a valid restricted-form
+  /// AT URI (scheme=at, authority=DID/handle, …).
   public var atUri: ATURI? { try? ATURI(string: rawValue) }
 }
 

--- a/Sources/SwiftAtproto/SwiftAtproto.swift
+++ b/Sources/SwiftAtproto/SwiftAtproto.swift
@@ -5,11 +5,21 @@ import Multicodec
 import Multihash
 import SwiftCbor
 
+/// The response body of a method that returns no data.
+///
+/// Decoding is short-circuited for this type, so a method declaring it never
+/// parses the response payload.
 public struct EmptyResponse: Codable, Sendable, Hashable {
   public init() {}
 }
 
+/// A record type generated from a Lexicon record schema.
+///
+/// The generated conformance encodes ``nsId`` as the record's `$type`, which is
+/// what lets ``UnknownATPValueProtocol`` dispatch a decoded value back to its
+/// concrete type.
 public protocol ATProtoRecord: Codable, Sendable, Hashable {
+  /// The NSID of the Lexicon this record was generated from.
   static var nsId: String { get }
 }
 
@@ -17,41 +27,79 @@ enum TypeCodingKeys: String, CodingKey {
   case type = "$type"
 }
 
+/// A single XRPC method, generated from a Lexicon query or procedure.
+///
+/// Conforming types are generated; you call them through
+/// `_XRPCCallable.call(_:input:)` rather than constructing requests directly.
+/// See <doc:MakingXRPCCalls>.
 public protocol XRPCRequest: Sendable {
+  /// The type the response payload decodes into.
   associatedtype ResponseBody: Codable & Sendable & Hashable
+  /// The error type the method's Lexicon declares.
   associatedtype Error: XRPCError
 
+  /// The NSID of the method, used as the `/xrpc/` path component.
   static var id: String { get }
 }
 
 extension XRPCRequest {
+  /// The Lexicon method identifier checked against a session's `rpc` scope.
+  ///
+  /// Defaults to ``id``. See <doc:OAuthScopes>.
   public static func requiredRpcLxm() -> String { id }
 }
 
+/// An XRPC method whose input travels in the query string, sent as `GET`.
 public protocol XRPCQuery: XRPCRequest {
+  /// The generated wrapper around this method's parameters.
   associatedtype Input: XRPCQueryInput
 }
 
+/// The input of an ``XRPCQuery``, wrapping its parameters.
 public protocol XRPCQueryInput: Sendable & Hashable {
+  /// The parameter type that renders itself as query items.
   associatedtype Query: XRPCInputQuery
 
+  /// The parameters to send.
   var query: Query { get }
 }
 
+/// A parameter set that can be rendered as URL query items.
 public protocol XRPCInputQuery: Sendable, Hashable {
+  /// The parameters to encode, or `nil` when the method takes none.
+  ///
+  /// `nil` values inside the returned ``Parameters`` are omitted rather than
+  /// sent empty.
   var asParameters: Parameters? { get }
 }
 
+/// An XRPC method whose input travels in the request body, sent as `POST`.
+///
+/// The body is the JSON encoding of ``RequestBody``, except when the input is
+/// raw `Data` or an ``XRPCBlobUpload``, which are sent unchanged.
 public protocol XRPCProcedure: XRPCRequest {
+  /// The type encoded into the request body.
   associatedtype RequestBody: Codable & Sendable & Hashable
+  /// The `Content-Type` to send, unless an ``XRPCBlobUpload`` overrides it.
   static var contentType: String { get }
 }
 
+/// The generated enum that decodes a Lexicon `unknown` field.
+///
+/// Code generation emits one conforming type per module, mapping every `$type`
+/// it knows to the matching ``ATProtoRecord``. A `$type` that is not in
+/// ``allTypes`` decodes into ``UnknownRecord`` so the value still re-encodes
+/// unchanged. See <doc:DecodingLexiconRecords>.
 public protocol UnknownATPValueProtocol: Codable, Sendable, Hashable {
+  /// Wraps a decoded record.
   static func record(_: any ATProtoRecord) -> Self
+  /// Wraps a value that carried no `$type`.
   static func any(_: any Codable & Sendable & Hashable) -> Self
+  /// The `$type` of the wrapped value, or `nil` when it carried none.
   var type: String? { get }
+  /// The wrapped value.
   var val: any Codable & Hashable & Sendable { get }
+  /// Every record type this module can dispatch to, keyed by `$type`.
   static var allTypes: [String: any ATProtoRecord.Type] { get }
 }
 
@@ -125,7 +173,9 @@ extension String {
   }
 }
 
+/// A Lexicon `cid-link`: a content identifier pointing at another block.
 public struct LexLink: Sendable, Hashable, Codable, CborCodable, CustomStringConvertible {
+  /// The content identifier this link resolves to.
   public var cid: CID
 
   public init(_ cid: CID) {
@@ -288,10 +338,16 @@ public struct LexLink: Sendable, Hashable, Codable, CborCodable, CustomStringCon
   }
 }
 
+/// A Lexicon `blob`: a reference to binary data, not the bytes themselves.
+///
+/// Uploading the bytes is a separate procedure call; see ``XRPCBlobUpload``.
 public struct LexBlob: Codable, Sendable, Hashable {
   public let type = "blob"
+  /// The content identifier of the uploaded data.
   public let ref: LexLink
+  /// The MIME type the blob was uploaded with.
   public let mimeType: String
+  /// The size of the blob in bytes.
   public let size: UInt
 
   public init(original: Self, mimeType: String) {
@@ -328,6 +384,10 @@ public struct LexBlob: Codable, Sendable, Hashable {
   }
 }
 
+/// One query parameter value.
+///
+/// A `nil` payload means the parameter is omitted rather than sent empty; an
+/// ``array(_:)`` is expanded into one query item per element.
 public enum ParamElement {
   case string(String?)
   case bool(Bool?)
@@ -335,7 +395,9 @@ public enum ParamElement {
   case array([any CustomStringConvertible]?)
 }
 
+/// The query parameters of an ``XRPCQuery``, keyed by parameter name.
 public final class Parameters: ExpressibleByDictionaryLiteral {
+  /// The parameters to encode.
   public let dictionary: [String: ParamElement]
   public init(dictionary: [String: ParamElement]) {
     self.dictionary = dictionary

--- a/Sources/SwiftAtproto/XRPCBlobUpload.swift
+++ b/Sources/SwiftAtproto/XRPCBlobUpload.swift
@@ -1,7 +1,15 @@
 import Foundation
 
+/// Binary data to upload as a blob.
+///
+/// Passing this as a procedure input sends the bytes unchanged and uses
+/// ``mimeType`` as the `Content-Type`, bypassing JSON encoding. When the client
+/// has an OAuth session, the MIME type is checked against its granted `blob`
+/// scope before the request is sent.
 public struct XRPCBlobUpload: Codable, Sendable, Hashable {
+  /// The bytes to upload.
   public let data: Data
+  /// The MIME type of ``data``, sent as the `Content-Type` header.
   public let mimeType: String
 
   public init(data: Data, mimeType: String) {

--- a/Sources/SwiftAtproto/XRPCRequestComponents.swift
+++ b/Sources/SwiftAtproto/XRPCRequestComponents.swift
@@ -1,12 +1,22 @@
 import Foundation
 import HTTPTypes
 
+/// A prepared XRPC request in transport-neutral form.
+///
+/// A client turns this into whatever its HTTP stack expects; see
+/// <doc:MakingXRPCCalls>.
 public struct XRPCRequestComponents: Sendable {
+  /// The NSID of the method being called.
   public var nsId: String
+  /// The path to append to the service endpoint: `/xrpc/<nsid>`.
   public var relativePath: String { "/xrpc/\(nsId)" }
+  /// The encoded query parameters, empty for a procedure.
   public var queryItems: [URLQueryItem]
+  /// The headers to send, including `Content-Type` and any proxy header.
   public var headers: HTTPFields
+  /// `GET` for a query, `POST` for a procedure.
   public var method: HTTPRequest.Method
+  /// The encoded request body, or `nil` for a query.
   public var body: Data?
 
   public init(

--- a/Sources/SwiftAtproto/XRPCSubscription.swift
+++ b/Sources/SwiftAtproto/XRPCSubscription.swift
@@ -2,6 +2,10 @@ import Foundation
 import HTTPTypes
 import SwiftCbor
 
+/// A Lexicon `subscription` method, generated from its schema.
+///
+/// Consume one through ``XRPCSubscriptionCallable/subscribe(_:input:)``; see
+/// <doc:Subscriptions>.
 public protocol XRPCSubscription: Sendable {
   associatedtype Input: XRPCQueryInput
   associatedtype Message: Decodable & Sendable
@@ -16,9 +20,13 @@ extension XRPCSubscription {
   public static func requiredRpcLxm() -> String { id }
 }
 
+/// A prepared subscription request, before it is turned into a WebSocket URL.
 public struct XRPCSubscriptionRequestComponents: Sendable {
+  /// The NSID of the subscription method.
   public var nsId: String
+  /// The encoded subscription parameters.
   public var queryItems: [URLQueryItem]
+  /// The headers to send, including any proxy header.
   public var headers: HTTPFields
 
   public init(nsId: String, queryItems: [URLQueryItem], headers: HTTPFields = .init()) {
@@ -28,8 +36,11 @@ public struct XRPCSubscriptionRequestComponents: Sendable {
   }
 }
 
+/// The WebSocket handshake a transport is asked to perform.
 public struct XRPCWebSocketRequest: Sendable {
+  /// The `wss://` (or `ws://`) URL to connect to.
   public var url: URL
+  /// The headers to send with the handshake, including `Authorization`.
   public var headers: HTTPFields
 
   public init(url: URL, headers: HTTPFields = .init()) {
@@ -38,12 +49,18 @@ public struct XRPCWebSocketRequest: Sendable {
   }
 }
 
+/// A frame received from a WebSocket transport.
+///
+/// AT Protocol event streams are binary; a `text` frame is a protocol
+/// violation and ends the stream.
 public enum XRPCWebSocketMessage: Sendable {
   case binary(Data)
   case text(String)
 }
 
+/// An open WebSocket connection supplied by a transport.
 public struct XRPCWebSocketConnection: Sendable {
+  /// The frames arriving on this connection.
   public let messages: AsyncThrowingStream<XRPCWebSocketMessage, any Error>
   private let closeOperation: @Sendable () async -> Void
 
@@ -55,17 +72,28 @@ public struct XRPCWebSocketConnection: Sendable {
     closeOperation = close
   }
 
+  /// Closes the connection and ends ``messages``.
   public func close() async {
     await closeOperation()
   }
 }
 
+/// The WebSocket stack a client uses for subscriptions.
+///
+/// This module opens no sockets of its own. Back this with
+/// `URLSessionWebSocketTask` on Apple platforms and a NIO-based client on
+/// Linux. See <doc:Subscriptions>.
 public protocol XRPCSubscriptionTransport: Sendable {
   func connect(_ request: XRPCWebSocketRequest) async throws -> XRPCWebSocketConnection
 }
 
+/// The bounds applied to a subscription stream.
 public struct XRPCSubscriptionConfiguration: Sendable {
+  /// The largest frame accepted before
+  /// ``XRPCSubscriptionStreamError/frameTooLarge(limit:)`` is thrown.
+  /// Defaults to 2 MiB.
   public var maximumFrameBytes: Int
+  /// How many messages are buffered for a slow consumer. Defaults to 16.
   public var bufferCapacity: Int
 
   public init(maximumFrameBytes: Int = 2 * 1_024 * 1_024, bufferCapacity: Int = 16) {
@@ -76,6 +104,7 @@ public struct XRPCSubscriptionConfiguration: Sendable {
   }
 }
 
+/// A protocol-level failure that terminates a subscription stream.
 public enum XRPCSubscriptionStreamError: Error, Sendable, Equatable {
   case textFrame
   case frameTooLarge(limit: Int)
@@ -85,7 +114,13 @@ public enum XRPCSubscriptionStreamError: Error, Sendable, Equatable {
   case bufferOverflow(limit: Int)
 }
 
+/// A client that can consume Lexicon subscriptions.
+///
+/// ``ATPClientProtocol`` already implements
+/// ``prepareSubscriptionRequest(_:)``, so a conforming client usually only
+/// supplies ``subscriptionTransport``. See <doc:Subscriptions>.
 public protocol XRPCSubscriptionCallable: _XRPCCallable {
+  /// The WebSocket stack used to open connections.
   var subscriptionTransport: any XRPCSubscriptionTransport { get }
   var subscriptionConfiguration: XRPCSubscriptionConfiguration { get }
   func prepareSubscriptionRequest(
@@ -96,6 +131,10 @@ public protocol XRPCSubscriptionCallable: _XRPCCallable {
 extension XRPCSubscriptionCallable {
   public var subscriptionConfiguration: XRPCSubscriptionConfiguration { .init() }
 
+  /// Opens a subscription and yields its decoded messages.
+  ///
+  /// Cancelling the consuming task closes the connection. When the client has
+  /// an OAuth session, the granted `rpc` scope is checked before connecting.
   public func subscribe<X: XRPCSubscription>(
     _ subscription: X.Type,
     input: X.Input.Query

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -5,11 +5,30 @@ extension HTTPField.Name {
   static var atprotoProxy: Self { .init("atproto-proxy")! }
 }
 
+/// The minimum a client has to provide in order to make XRPC calls.
+///
+/// Implement `response(_:)`; the protocol extension implements both `call`
+/// overloads on top of it, which is what makes every generated method callable.
+/// See <doc:MakingXRPCCalls>.
+///
+/// This protocol is infrastructure shared with generated code. Conform to
+/// ``ATPClientProtocol`` instead of using it directly.
 public protocol _XRPCCallable: Sendable {
+  /// The OAuth session whose granted scopes gate outgoing calls, or `nil` to
+  /// skip scope enforcement entirely. Defaults to `nil`.
   var oauthSession: (any OAuthSession)? { get }
+  /// The service to proxy this method to via the `atproto-proxy` header, or
+  /// `nil` to send it to the client's own endpoint.
   func getProxy(nsid: String) -> String?
+  /// Sends a prepared request and returns the raw response payload.
+  ///
+  /// This is the only transport-specific requirement. Throw
+  /// ``UnExpectedError`` for a failure the method's Lexicon does not describe;
+  /// it is converted into the method's own error type.
   func response(_ requestComponents: XRPCRequestComponents) async throws -> Data
+  /// Calls a query, encoding `input` as query items.
   func call<X: XRPCQuery>(_ request: X.Type, input: X.Input.Query) async throws -> X.ResponseBody
+  /// Calls a procedure, encoding `input` into the request body.
   func call<X: XRPCProcedure>(_ request: X.Type, input: X.RequestBody?) async throws -> X.ResponseBody
 }
 
@@ -133,6 +152,8 @@ extension _XRPCCallable {
     )
   }
 
+  /// Renders parameters as percent-encoded query items, dropping `nil` values
+  /// and expanding arrays into repeated items.
   public static func makeParameters(params: Parameters) -> [URLQueryItem] {
     var items = [URLQueryItem]()
     for (key, value) in params {

--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -1,18 +1,37 @@
 import Foundation
 
+/// A client that talks to one AT Protocol service.
+///
+/// Refines the callable infrastructure with the endpoint and session hooks a
+/// transport needs. Implementing `response(_:)` is still the only
+/// transport-specific work; see <doc:MakingXRPCCalls>.
 public protocol ATPClientProtocol: _XRPCCallable {
+  /// The service base URL that `/xrpc/<nsid>` is appended to.
   var serviceEndpoint: URL { get }
+  /// The decoder used for response payloads.
   var decoder: JSONDecoder { get }
 
+  /// Whether this error means the access token needs refreshing, so the call
+  /// can be retried after ``refreshSession()``.
   func tokenIsExpired(error: some XRPCError) -> Bool
+  /// The `Authorization` header value to send for this method, or `nil` for an
+  /// unauthenticated call.
   func getAuthorization(endpoint: String) -> String?
 
+  /// Refreshes the session, returning whether it succeeded.
   func refreshSession() async -> Bool
 }
 
+/// A client backed by mutable session credentials.
+///
+/// This protocol is infrastructure shared with generated code and with the
+/// deprecated `@XRPCClient` macro. Prefer the `XRPCClientProtocol` emitted by
+/// code generation, which also carries the XRPC method requirements.
 public protocol _XRPCClientProtocol: ATPClientProtocol {
+  /// The credentials this client sends.
   var auth: any XRPCAuth { get set }
 
+  /// Discards the current session.
   func signout()
 }
 
@@ -44,9 +63,17 @@ extension ATPClientProtocol where Self: XRPCSubscriptionCallable {
   }
 }
 
+/// An error payload declared by a Lexicon method.
+///
+/// One conforming type is generated per method. A failure the Lexicon does not
+/// describe arrives as ``UnExpectedError`` and is converted through
+/// ``init(error:)``.
 public protocol XRPCError: Error, LocalizedError, Decodable, Sendable {
+  /// The machine-readable error name returned by the service.
   var error: String? { get }
+  /// The human-readable message returned by the service.
   var message: String? { get }
+  /// Wraps a failure that the method's Lexicon does not describe.
   init(error: UnExpectedError)
 }
 
@@ -56,6 +83,8 @@ extension XRPCError {
   }
 }
 
+/// A failure that no Lexicon error case describes, such as a transport error
+/// or an unrecognized status.
 public final class UnExpectedError: XRPCError {
   public let error: String?
   public let message: String?
@@ -70,6 +99,10 @@ public final class UnExpectedError: XRPCError {
   }
 }
 
+/// A record whose `$type` this module was not generated against.
+///
+/// The unrecognized fields are kept in `_unknownValues` so the record
+/// re-encodes exactly as it arrived. See <doc:DecodingLexiconRecords>.
 public struct UnknownRecord: Identifiable, ATProtoRecord {
   public static let nsId = "unknown"
   public let type: String

--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -173,11 +173,70 @@ else
   mkdir -p "${archives_directory}"
 fi
 
+# A target's directory and its module name do not follow from its name: the
+# `swift-atproto` executable lives in `CommandLineTool` and compiles as the
+# module `swift_atproto`. Both come from the package manifest.
+package_description="$(swift package describe --package-path "${repository_root}")"
+
+# Prints "<module name>\t<path relative to the package root>" for one target.
+target_metadata() {
+  local target="$1"
+  printf '%s\n' "${package_description}" | awk -v target="${target}" '
+    /^[[:space:]]*Name:[[:space:]]/ {
+      name = $0
+      sub(/^[[:space:]]*Name:[[:space:]]*/, "", name)
+      module = ""
+      path = ""
+      next
+    }
+    /^[[:space:]]*C99name:[[:space:]]/ {
+      module = $0
+      sub(/^[[:space:]]*C99name:[[:space:]]*/, "", module)
+      next
+    }
+    /^[[:space:]]*Path:[[:space:]]/ {
+      path = $0
+      sub(/^[[:space:]]*Path:[[:space:]]*/, "", path)
+      next
+    }
+    name == target && module != "" && path != "" {
+      print module "\t" path
+      found = 1
+      exit
+    }
+    END {
+      if (!found && name == target && module != "" && path != "") {
+        print module "\t" path
+      }
+    }
+  '
+}
+
+module_name_for() {
+  local metadata
+  metadata="$(target_metadata "$1")"
+  printf '%s\n' "${metadata%%$'\t'*}"
+}
+
+catalog_path_for() {
+  local metadata
+  metadata="$(target_metadata "$1")"
+  local path="${metadata#*$'\t'}"
+  [[ -n "${path}" && "${path}" != "${metadata}" ]] || return 1
+  printf '%s/%s/Documentation.docc\n' "${repository_root}" "${path}"
+}
+
 # Emits the symbol graphs for one target and copies just that module's graphs
 # into a directory of its own. A single build directory also collects the
 # graphs of every dependency, which DocC would otherwise document as well.
 symbol_graph_directory_for() {
   local target="$1"
+  local module
+  module="$(module_name_for "${target}")"
+  if [[ -z "${module}" ]]; then
+    printf 'error: %s is not a target of this package\n' "${target}" >&2
+    return 1
+  fi
   local build_directory="${temporary_directory}/symbol-graph-build/${target}"
   local module_directory="${temporary_directory}/symbol-graphs/${target}"
   mkdir -p "${build_directory}" "${module_directory}"
@@ -190,14 +249,14 @@ symbol_graph_directory_for() {
     -Xswiftc -emit-symbol-graph-dir -Xswiftc "${build_directory}" \
     >&2
 
-  if [[ ! -f "${build_directory}/${target}.symbols.json" ]]; then
+  if [[ ! -f "${build_directory}/${module}.symbols.json" ]]; then
     printf 'error: no symbol graph was emitted for %s\n' "${target}" >&2
     return 1
   fi
 
   local graph_path
-  for graph_path in "${build_directory}/${target}.symbols.json" \
-    "${build_directory}/${target}@"*.symbols.json; do
+  for graph_path in "${build_directory}/${module}.symbols.json" \
+    "${build_directory}/${module}@"*.symbols.json; do
     [[ -f "${graph_path}" ]] || continue
     cp "${graph_path}" "${module_directory}/"
   done
@@ -224,7 +283,7 @@ if [[ -n "${preview_target}" ]]; then
   done < <(docc_options_for "${preview_target}" "${symbol_graph_directory}")
 
   exec "${docc_command[@]}" preview \
-    "${repository_root}/Sources/${preview_target}/Documentation.docc" \
+    "$(catalog_path_for "${preview_target}")" \
     --port "${preview_port}" \
     --output-path "${archives_directory}/${preview_target}.doccarchive" \
     "${options[@]}"
@@ -232,7 +291,11 @@ fi
 
 failed_targets=()
 for target in "${targets[@]}"; do
-  catalog_path="${repository_root}/Sources/${target}/Documentation.docc"
+  if ! catalog_path="$(catalog_path_for "${target}")"; then
+    printf 'error: %s is not a target of this package\n' "${target}" >&2
+    failed_targets+=("${target}")
+    continue
+  fi
   if [[ ! -d "${catalog_path}" ]]; then
     printf 'error: documentation catalog is missing: %s\n' "${catalog_path}" >&2
     failed_targets+=("${target}")

--- a/scripts/build-documentation.sh
+++ b/scripts/build-documentation.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+#
+# Build this package's DocC documentation locally.
+#
+# The Swift Package Index builds and hosts the published documentation from
+# `.spi.yml`. This script reads the same manifest so that a local build covers
+# exactly the targets the index publishes, using the same documentation
+# parameters. It never writes into the repository; documentation output is not
+# committed.
+
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/build-documentation.sh [--strict] [--output <dir>]
+       scripts/build-documentation.sh --preview <target> [--port <port>]
+
+  (no arguments)     Build every target listed in .spi.yml and report failures.
+  --strict           Treat DocC warnings as errors.
+  --output <dir>     Keep the generated archives in <dir> instead of a
+                     temporary directory that is removed on exit.
+  --preview <target> Serve one target's documentation for local browsing.
+  --port <port>      Port for --preview (default: 8080).
+USAGE
+}
+
+repository_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly repository_root
+readonly manifest_path="${repository_root}/.spi.yml"
+
+# The Swift Package Index serves documentation from
+# `swiftpackageindex.com/<owner>/<repository>/<reference>/documentation/<target>`,
+# and passes that prefix to DocC as the hosting base path. Mirroring it locally
+# keeps generated links in the same shape as the published ones.
+hosting_base_path="${DOCC_HOSTING_BASE_PATH:-nnabeyang/swift-atproto/main}"
+bundle_identifier_prefix="com.nnabeyang.swift-atproto"
+
+strict=false
+output_path=""
+preview_target=""
+preview_port=8080
+
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    --strict)
+      strict=true
+      shift
+      ;;
+    --output)
+      [[ "$#" -ge 2 ]] || { usage; exit 64; }
+      output_path="$2"
+      shift 2
+      ;;
+    --preview)
+      [[ "$#" -ge 2 ]] || { usage; exit 64; }
+      preview_target="$2"
+      shift 2
+      ;;
+    --port)
+      [[ "$#" -ge 2 ]] || { usage; exit 64; }
+      preview_port="$2"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'error: unrecognized argument: %s\n' "$1" >&2
+      usage
+      exit 64
+      ;;
+  esac
+done
+
+if [[ -n "${preview_target}" && -n "${output_path}" ]]; then
+  printf 'error: --preview and --output are mutually exclusive\n' >&2
+  exit 64
+fi
+
+if [[ ! -f "${manifest_path}" ]]; then
+  printf 'error: Swift Package Index manifest is missing: %s\n' "${manifest_path}" >&2
+  exit 1
+fi
+
+# Reads a YAML sequence from .spi.yml, accepting both the block form
+# (`key:` followed by `- item` lines) and the inline form (`key: [a, b]`). The
+# key itself may be the first key of a list item, so a leading `- ` is allowed.
+read_manifest_sequence() {
+  local key="$1"
+  awk -v key="${key}" '
+    function emit(value) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", value)
+      gsub(/^["\x27]|["\x27]$/, "", value)
+      if (value != "") print value
+    }
+    {
+      line = $0
+      sub(/[[:space:]]*#.*$/, "", line)
+    }
+    line ~ ("^[[:space:]]*(-[[:space:]]+)?" key ":[[:space:]]*\\[") {
+      inline = line
+      sub(/^[^[]*\[/, "", inline)
+      sub(/\].*$/, "", inline)
+      count = split(inline, items, ",")
+      for (index_ = 1; index_ <= count; index_++) emit(items[index_])
+      next
+    }
+    line ~ ("^[[:space:]]*(-[[:space:]]+)?" key ":[[:space:]]*$") {
+      collecting = 1
+      next
+    }
+    collecting && line ~ /^[[:space:]]*-[[:space:]]*/ {
+      item = line
+      sub(/^[[:space:]]*-[[:space:]]*/, "", item)
+      emit(item)
+      next
+    }
+    collecting && line ~ /^[[:space:]]*[^[:space:]]/ {
+      collecting = 0
+    }
+  ' "${manifest_path}"
+}
+
+targets=()
+while IFS= read -r target; do
+  targets+=("${target}")
+done < <(read_manifest_sequence documentation_targets)
+
+if [[ "${#targets[@]}" == 0 ]]; then
+  printf 'error: no documentation_targets found in %s\n' "${manifest_path}" >&2
+  exit 1
+fi
+
+# `custom_documentation_parameters` is passed through to DocC by the index, so
+# a local build has to pass it too.
+custom_parameters=()
+while IFS= read -r parameter; do
+  custom_parameters+=("${parameter}")
+done < <(read_manifest_sequence custom_documentation_parameters)
+
+if [[ -n "${preview_target}" ]]; then
+  found=false
+  for target in "${targets[@]}"; do
+    [[ "${target}" == "${preview_target}" ]] && found=true
+  done
+  if [[ "${found}" == false ]]; then
+    printf 'error: %s is not listed in documentation_targets: %s\n' \
+      "${preview_target}" "${targets[*]}" >&2
+    exit 64
+  fi
+  targets=("${preview_target}")
+fi
+
+if command -v docc >/dev/null 2>&1; then
+  docc_command=(docc)
+elif command -v xcrun >/dev/null 2>&1; then
+  docc_command=(xcrun docc)
+else
+  printf 'error: neither docc nor xcrun is available\n' >&2
+  exit 1
+fi
+
+temporary_directory="$(mktemp -d "${TMPDIR:-/tmp}/swift-atproto-documentation.XXXXXX")"
+readonly temporary_directory
+trap 'rm -rf -- "${temporary_directory}"' EXIT
+
+if [[ -n "${output_path}" ]]; then
+  mkdir -p "${output_path}"
+  archives_directory="$(cd -- "${output_path}" && pwd)"
+else
+  archives_directory="${temporary_directory}/archives"
+  mkdir -p "${archives_directory}"
+fi
+
+# Emits the symbol graphs for one target and copies just that module's graphs
+# into a directory of its own. A single build directory also collects the
+# graphs of every dependency, which DocC would otherwise document as well.
+symbol_graph_directory_for() {
+  local target="$1"
+  local build_directory="${temporary_directory}/symbol-graph-build/${target}"
+  local module_directory="${temporary_directory}/symbol-graphs/${target}"
+  mkdir -p "${build_directory}" "${module_directory}"
+
+  # Each target is built separately: passing several `--target` options to one
+  # `swift build` invocation does not emit a symbol graph for every target.
+  swift build --package-path "${repository_root}" \
+    --target "${target}" \
+    -Xswiftc -emit-symbol-graph \
+    -Xswiftc -emit-symbol-graph-dir -Xswiftc "${build_directory}" \
+    >&2
+
+  if [[ ! -f "${build_directory}/${target}.symbols.json" ]]; then
+    printf 'error: no symbol graph was emitted for %s\n' "${target}" >&2
+    return 1
+  fi
+
+  local graph_path
+  for graph_path in "${build_directory}/${target}.symbols.json" \
+    "${build_directory}/${target}@"*.symbols.json; do
+    [[ -f "${graph_path}" ]] || continue
+    cp "${graph_path}" "${module_directory}/"
+  done
+
+  printf '%s\n' "${module_directory}"
+}
+
+docc_options_for() {
+  local target="$1"
+  printf '%s\n' \
+    --additional-symbol-graph-dir "$2" \
+    --fallback-display-name "${target}" \
+    --fallback-bundle-identifier "${bundle_identifier_prefix}.${target}"
+  if [[ "${#custom_parameters[@]}" -gt 0 ]]; then
+    printf '%s\n' "${custom_parameters[@]}"
+  fi
+}
+
+if [[ -n "${preview_target}" ]]; then
+  symbol_graph_directory="$(symbol_graph_directory_for "${preview_target}")"
+  options=()
+  while IFS= read -r option; do
+    options+=("${option}")
+  done < <(docc_options_for "${preview_target}" "${symbol_graph_directory}")
+
+  exec "${docc_command[@]}" preview \
+    "${repository_root}/Sources/${preview_target}/Documentation.docc" \
+    --port "${preview_port}" \
+    --output-path "${archives_directory}/${preview_target}.doccarchive" \
+    "${options[@]}"
+fi
+
+failed_targets=()
+for target in "${targets[@]}"; do
+  catalog_path="${repository_root}/Sources/${target}/Documentation.docc"
+  if [[ ! -d "${catalog_path}" ]]; then
+    printf 'error: documentation catalog is missing: %s\n' "${catalog_path}" >&2
+    failed_targets+=("${target}")
+    continue
+  fi
+
+  printf '==> Building documentation for %s\n' "${target}" >&2
+
+  if ! symbol_graph_directory="$(symbol_graph_directory_for "${target}")"; then
+    failed_targets+=("${target}")
+    continue
+  fi
+
+  options=()
+  while IFS= read -r option; do
+    options+=("${option}")
+  done < <(docc_options_for "${target}" "${symbol_graph_directory}")
+  if [[ "${strict}" == true ]]; then
+    options+=(--warnings-as-errors)
+  fi
+
+  if "${docc_command[@]}" convert "${catalog_path}" \
+    --output-path "${archives_directory}/${target}.doccarchive" \
+    --transform-for-static-hosting \
+    --hosting-base-path "${hosting_base_path}" \
+    "${options[@]}"; then
+    :
+  else
+    failed_targets+=("${target}")
+  fi
+done
+
+if [[ "${#failed_targets[@]}" -gt 0 ]]; then
+  printf 'error: documentation build failed for: %s\n' "${failed_targets[*]}" >&2
+  exit 1
+fi
+
+printf 'Built documentation for: %s\n' "${targets[*]}" >&2
+if [[ -n "${output_path}" ]]; then
+  printf 'Archives are in %s.\n' "${archives_directory}" >&2
+fi


### PR DESCRIPTION
This PR adds a documentation system to the package. Each target gets a `Documentation.docc` catalog next to its sources, the main API surface gets doc comments, and `.spi.yml` configures the Swift Package Index to build and host the result.
