### PR TITLE
feat: resolve space authority entries in DID documents

### DIFF
--- a/Sources/SwiftAtproto/DIDDocument+Space.swift
+++ b/Sources/SwiftAtproto/DIDDocument+Space.swift
@@ -1,0 +1,167 @@
+import Foundation
+
+// Space authority resolution for the permissioned data protocol. The `SpaceAuthorities` article
+// describes the model these entries make up.
+//
+// The file is split in two. The first section looks entries up as written and fails when what it
+// was asked for is absent. The second section holds the fallbacks that apply when an entry is not
+// published at all.
+
+// MARK: - Entry lookup
+
+extension DIDDocument {
+  /// Whether `id` names the entry that `fragment` refers to.
+  ///
+  /// A DID document may write an entry id either relative (`#atproto_space`) or absolute
+  /// (`did:plc:xxx#atproto_space`); both name the same entry.
+  private func matchesID(_ id: String, fragment: String) -> Bool {
+    id == "#\(fragment)" || id == "\(did.rawValue)#\(fragment)"
+  }
+
+  /// The verification method published under `fragment`, or `nil` when the document has none.
+  ///
+  /// Returns the entry rather than a parsed key, because `SwiftAtproto` does not depend on
+  /// `ATProtoCrypto`. Callers that need a key pass `publicKeyMultibase` to
+  /// `ATProtoCrypto.PublicKey.publicKeyFromMultibaseString(string:)`.
+  public func verificationMaterial(fragment: String) -> DocVerificationMethod? {
+    (verificationMethod ?? []).first { matchesID($0.id, fragment: fragment) }
+  }
+
+  /// The service entry published under `fragment`, or `nil` when the document has none. The
+  /// endpoint is returned as written; ``spaceHostUrl`` and ``endpoint(for:)`` validate it.
+  ///
+  /// Matching is by id only: a `type` is required for `#atproto_pds` (see ``pdsUrl``) but no type
+  /// string is defined for the space host or for a syncer's own service entry.
+  public func serviceEntry(fragment: String) -> DocService? {
+    (service ?? []).first { matchesID($0.id, fragment: fragment) }
+  }
+
+  /// How this authority is addressed when acting as the space host, and therefore the `aud` of a
+  /// delegation token or client attestation sent to it.
+  ///
+  /// This is the audience, not necessarily where the request is sent — an authority that publishes
+  /// no `#atproto_space_host` entry is still addressed this way while being reached at its PDS.
+  public var spaceHostAudience: String {
+    "\(did.rawValue)#atproto_space_host"
+  }
+
+  /// Resolves the key a space token names in its `kid`.
+  ///
+  /// Only `atproto`
+  /// and `atproto_space` are accepted, with or without a leading `#`. Unlike the fallback property of
+  /// the same name, this does not fall back — the token said which key signed it, so a missing entry is an error.
+  public func spaceSigningKey(keyId: String) throws -> DocVerificationMethod {
+    let fragment = keyId.hasPrefix("#") ? String(keyId.dropFirst()) : keyId
+    guard fragment == "atproto" || fragment == "atproto_space" else {
+      throw VerifyError.unsupportedSpaceKeyId(keyId)
+    }
+    guard let material = verificationMaterial(fragment: fragment) else {
+      throw VerifyError.missingSpaceSigningKey
+    }
+    return material
+  }
+
+  /// The endpoint to deliver to for `identifier`. `self` must be the document for
+  /// `identifier.did`; this performs no DID resolution of its own.
+  ///
+  /// A bare DID names an account and an account is served by its PDS, so it resolves through
+  /// ``pdsUrl``; a fragment-bearing identifier resolves to that service entry.
+  public func endpoint(for identifier: ServiceIdentifier) throws -> URL {
+    guard identifier.did.rawValue == did.rawValue else {
+      throw VerifyError.invalidServiceIdentifier
+    }
+    guard let fragment = identifier.fragment else {
+      return try pdsUrl
+    }
+    guard let svc = serviceEntry(fragment: fragment) else {
+      throw VerifyError.missingServiceEndpoint
+    }
+    guard let url = Self.parseEndpoint(svc.serviceEndpoint) else {
+      throw VerifyError.invalidServiceEndpoint
+    }
+    return url
+  }
+}
+
+// MARK: - Fallbacks
+
+extension DIDDocument {
+  /// The space host endpoint. Falls back to ``pdsUrl`` when no `#atproto_space_host` entry is
+  /// published, per the proposal.
+  ///
+  /// A published-but-malformed endpoint throws instead of falling back: the fallback is for an
+  /// authority that declares no dedicated host, and quietly routing past a misconfigured one would
+  /// send space-host traffic to the PDS.
+  public var spaceHostUrl: URL {
+    get throws {
+      guard let svc = serviceEntry(fragment: "atproto_space_host") else {
+        return try pdsUrl
+      }
+      guard let url = Self.parseEndpoint(svc.serviceEndpoint) else {
+        throw VerifyError.invalidServiceEndpoint
+      }
+      return url
+    }
+  }
+
+  /// The key this authority signs its space credentials with: the dedicated `#atproto_space` entry
+  /// when published, otherwise the account's `#atproto` signing key. To verify a credential that
+  /// already names its key, use ``spaceSigningKey(keyId:)`` instead of this.
+  public var spaceSigningKey: DocVerificationMethod {
+    get throws {
+      if let dedicated = verificationMaterial(fragment: "atproto_space") {
+        return dedicated
+      }
+      guard let account = verificationMaterial(fragment: "atproto") else {
+        throw VerifyError.missingSpaceSigningKey
+      }
+      return account
+    }
+  }
+}
+
+// MARK: - Service identifier
+
+/// A DID with an optional service fragment, naming the entry in that DID's document to deliver to —
+/// e.g. `did:web:syncer.example.com#atproto_space_syncer`. `com.atproto.space.registerNotify` takes
+/// one of these rather than a bare URL, because `notifyWrite` is delivered with service auth
+/// addressed to the identifier itself.
+///
+/// Parsing rejects malformed input rather than normalizing it, matching the other identifier types
+/// in this module: an empty fragment (`did:plc:xxx#`) and a second `#` are both rejected.
+public struct ServiceIdentifier: Sendable, Hashable, CustomStringConvertible {
+  public let did: DID
+  /// Without the leading `#`. Nil when the identifier names a bare DID.
+  public let fragment: String?
+
+  /// - Throws: ``LexiconStringFormatError`` when the DID itself is malformed, and
+  ///   ``DIDDocument/VerifyError/invalidServiceIdentifier`` when the fragment structure is.
+  public init(string: String) throws {
+    let parts = string.split(separator: "#", omittingEmptySubsequences: false)
+    switch parts.count {
+    case 1:
+      did = try DID(string: String(parts[0]))
+      fragment = nil
+    case 2:
+      guard !parts[1].isEmpty else {
+        throw DIDDocument.VerifyError.invalidServiceIdentifier
+      }
+      did = try DID(string: String(parts[0]))
+      fragment = String(parts[1])
+    default:
+      throw DIDDocument.VerifyError.invalidServiceIdentifier
+    }
+  }
+
+  public init(did: DID, fragment: String? = nil) {
+    self.did = did
+    self.fragment = fragment
+  }
+
+  public var rawValue: String {
+    guard let fragment else { return did.rawValue }
+    return "\(did.rawValue)#\(fragment)"
+  }
+
+  public var description: String { rawValue }
+}

--- a/Sources/SwiftAtproto/DIDDocument+Verified.swift
+++ b/Sources/SwiftAtproto/DIDDocument+Verified.swift
@@ -2,14 +2,33 @@ import Foundation
 
 extension DIDDocument {
   public enum VerifyError: Swift.Error, Sendable {
+    /// The document publishes no `#atproto_pds` entry and no entry typed
+    /// `AtprotoPersonalDataServer`.
     case missingPDSService
+    /// The PDS entry's endpoint is not an absolute `http`/`https` URL with a host.
     case invalidPDSEndpoint
+    /// The document's own `id` is not a parseable DID, or is not the DID the
+    /// caller expected.
     case invalidDID
+    /// The advertised handle is not the one the caller expected.
     case handleMismatch
+    /// The document publishes neither an `#atproto_space` nor an `#atproto`
+    /// verification method, so no key signs its space credentials.
+    case missingSpaceSigningKey
+    /// A space token named a key other than `#atproto` or `#atproto_space`.
+    case unsupportedSpaceKeyId(String)
+    /// The document publishes no service entry for the requested fragment.
+    case missingServiceEndpoint
+    /// A service entry's endpoint is not an absolute `http`/`https` URL with a
+    /// host.
+    case invalidServiceEndpoint
+    /// The service identifier is malformed, or names a DID other than the one
+    /// this document describes.
+    case invalidServiceIdentifier
   }
 
-  // Preferred selector matches the AT Protocol spec (`#atproto_pds`); the type-based fallback
-  // preserves interoperability with older DID documents that predate the fragment convention.
+  /// Preferred selector matches the AT Protocol spec (`#atproto_pds`); the type-based fallback
+  /// preserves interoperability with older DID documents that predate the fragment convention.
   public var pdsUrl: URL {
     get throws {
       let atprotoPDSID = "\(did.rawValue)#atproto_pds"
@@ -20,19 +39,30 @@ extension DIDDocument {
         }
         ?? (service ?? []).first { $0.type == "AtprotoPersonalDataServer" }
       guard let svc else { throw VerifyError.missingPDSService }
-      guard let url = URL(string: svc.serviceEndpoint),
-        let scheme = url.scheme?.lowercased(),
-        scheme == "http" || scheme == "https",
-        url.host != nil
-      else {
+      guard let url = Self.parseEndpoint(svc.serviceEndpoint) else {
         throw VerifyError.invalidPDSEndpoint
       }
       return url
     }
   }
 
-  // First `at://<handle>` entry in `alsoKnownAs` with no collection/rkey. Nil when no bare handle
-  // is advertised; callers still need to cross-check it via a resolver before trusting it.
+  /// Parses `string` as a service endpoint: an absolute `http`/`https` URL with a host.
+  ///
+  /// Shared by ``pdsUrl`` and the space authority resolvers. Returns `nil` rather than throwing so
+  /// each caller can attribute the failure to its own entry.
+  static func parseEndpoint(_ string: String) -> URL? {
+    guard let url = URL(string: string),
+      let scheme = url.scheme?.lowercased(),
+      scheme == "http" || scheme == "https",
+      url.host != nil
+    else {
+      return nil
+    }
+    return url
+  }
+
+  /// First `at://<handle>` entry in `alsoKnownAs` with no collection/rkey. Nil when no bare handle
+  /// is advertised; callers still need to cross-check it via a resolver before trusting it.
   public var unverifiedHandle: Handle? {
     for aka in alsoKnownAs ?? [] {
       guard let uri = try? ATURI(string: aka),
@@ -47,7 +77,7 @@ extension DIDDocument {
   public struct Verified: Sendable, Hashable {
     public let document: DIDDocument
     public let did: DID
-    // `Handle.invalid` when handle verification failed or no handle was advertised.
+    /// `Handle.invalid` when handle verification failed or no handle was advertised.
     public let verifiedHandle: Handle
 
     public init(document: DIDDocument, did: DID, verifiedHandle: Handle) {
@@ -57,16 +87,16 @@ extension DIDDocument {
     }
   }
 
-  // Synchronous check for callers that already have both sides of the pair.
+  /// Synchronous check for callers that already have both sides of the pair.
   public func verified(expecting handle: Handle, did: DID) throws -> Verified {
     guard let parsed = self.did.typed, parsed == did else { throw VerifyError.invalidDID }
     guard unverifiedHandle == handle else { throw VerifyError.handleMismatch }
     return Verified(document: self, did: did, verifiedHandle: handle)
   }
 
-  // Bidirectional check: parse our advertised DID, look up the advertised handle in the resolver,
-  // and require the round-trip to close. On mismatch we return `Handle.invalid` rather than
-  // throwing so callers can distinguish "no handle advertised" from "document malformed".
+  /// Bidirectional check: parse our advertised DID, look up the advertised handle in the resolver,
+  /// and require the round-trip to close. On mismatch we return `Handle.invalid` rather than
+  /// throwing so callers can distinguish "no handle advertised" from "document malformed".
   public func verified(resolver: any DIDHandleResolver) async throws -> Verified {
     guard let did = self.did.typed else { throw VerifyError.invalidDID }
     guard let handle = unverifiedHandle else {

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/SpaceAuthorities.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/SpaceAuthorities.md
@@ -1,0 +1,70 @@
+# Resolving space authorities
+
+Find where a space authority answers and which key signs what it issues.
+
+## Overview
+
+> Important: Space authorities come from the permissioned data proposal, not from
+> the ratified AT Protocol. The fallback rules below are the part most likely to
+> change.
+
+A space authority is reached through two optional entries in its DID document:
+
+- an `#atproto_space_host` service entry — where the space host answers
+- an `#atproto_space` verification method — the key its space credentials are
+  signed with
+
+Neither is required. When an entry is absent the authority is reached through the
+account's own `#atproto_pds` service entry and `#atproto` verification method
+instead, so an authority that runs no dedicated infrastructure still resolves.
+
+## Looking entries up
+
+``DIDDocument/serviceEntry(fragment:)`` and
+``DIDDocument/verificationMaterial(fragment:)`` return an entry exactly as the
+document publishes it, or `nil` when it is not there. Both accept a relative id
+(`#atproto_space`) or an absolute one (`did:plc:xxx#atproto_space`), because a
+document may write either.
+
+Matching is by id alone. A `type` is required for `#atproto_pds` (see
+``DIDDocument/pdsUrl``), but the proposal defines no type string for a space host
+or for a syncer's own service entry.
+
+``DIDDocument/verificationMaterial(fragment:)`` returns the entry rather than a
+parsed key, because this module does not depend on `ATProtoCrypto`. Pass the
+entry's `publicKeyMultibase` to
+`ATProtoCrypto.PublicKey.publicKeyFromMultibaseString(string:)` when you need the
+key itself.
+
+## Falling back
+
+``DIDDocument/spaceHostUrl`` and ``DIDDocument/spaceSigningKey`` apply the
+proposal's fallbacks:
+
+| | Published | Absent |
+|---|---|---|
+| ``DIDDocument/spaceHostUrl`` | the `#atproto_space_host` endpoint | ``DIDDocument/pdsUrl`` |
+| ``DIDDocument/spaceSigningKey`` | the `#atproto_space` key | the `#atproto` key |
+
+A published-but-malformed endpoint throws rather than falling back. The fallback
+is for an authority that declares no dedicated host; quietly routing past a
+misconfigured one would send space-host traffic to the PDS.
+
+Verification is the other direction and does not fall back. A space token names
+the key that signed it in its `kid`, so
+``DIDDocument/spaceSigningKey(keyId:)`` resolves that key and treats a missing
+entry as an error. Only `atproto` and `atproto_space` are accepted.
+
+## Addressing
+
+``DIDDocument/spaceHostAudience`` is how an authority is addressed when acting as
+the space host — the `aud` of a delegation token or client attestation sent to
+it. It is the audience, not the destination: an authority that publishes no
+`#atproto_space_host` entry is still addressed this way while being reached at
+its PDS.
+
+For delivery to a specific service, ``ServiceIdentifier`` carries a DID with an
+optional fragment naming the entry to deliver to, and
+``DIDDocument/endpoint(for:)`` resolves it against the document for that DID. A
+bare DID names an account, and an account is served by its PDS, so it resolves
+through ``DIDDocument/pdsUrl``.

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -109,10 +109,12 @@ let posts = try await client.call(
 
 ### Identity documents
 
+- <doc:SpaceAuthorities>
 - ``DIDDocument``
 - ``DocService``
 - ``DocVerificationMethod``
 - ``DIDHandleResolver``
+- ``ServiceIdentifier``
 
 ### Errors
 

--- a/Tests/SwiftAtprotoTests/DIDDocumentSpaceTests.swift
+++ b/Tests/SwiftAtprotoTests/DIDDocumentSpaceTests.swift
@@ -1,0 +1,303 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct DIDDocumentSpaceTests {
+  private static let subject = "did:plc:example"
+
+  private func makeDoc(
+    services: [DocService] = [],
+    verificationMethods: [DocVerificationMethod] = []
+  ) -> DIDDocument {
+    let encoder = JSONEncoder()
+    let json = """
+      {
+        "@context": ["https://www.w3.org/ns/did/v1"],
+        "id": "\(Self.subject)",
+        "service": \(try! String(data: encoder.encode(services), encoding: .utf8)!),
+        "verificationMethod": \(try! String(data: encoder.encode(verificationMethods), encoding: .utf8)!)
+      }
+      """
+    return try! JSONDecoder().decode(DIDDocument.self, from: Data(json.utf8))
+  }
+
+  private func pds(_ endpoint: String = "https://pds.example") -> DocService {
+    DocService(id: "#atproto_pds", type: "AtprotoPersonalDataServer", serviceEndpoint: endpoint)
+  }
+
+  private func key(id: String, multibase: String) -> DocVerificationMethod {
+    DocVerificationMethod(
+      id: id,
+      type: "Multikey",
+      controller: Self.subject,
+      publicKeyMultibase: multibase)
+  }
+
+  // MARK: - spaceHostUrl
+
+  @Test
+  func spaceHostUsesDedicatedEntry() throws {
+    let doc = makeDoc(services: [
+      pds(),
+      DocService(
+        id: "#atproto_space_host", type: "AtprotoSpaceHost",
+        serviceEndpoint: "https://space.example"),
+    ])
+    #expect(try doc.spaceHostUrl == URL(string: "https://space.example"))
+  }
+
+  @Test
+  func spaceHostAcceptsAbsoluteEntryID() throws {
+    let doc = makeDoc(services: [
+      pds(),
+      DocService(
+        id: "did:plc:example#atproto_space_host", type: "AtprotoSpaceHost",
+        serviceEndpoint: "https://space.example"),
+    ])
+    #expect(try doc.spaceHostUrl == URL(string: "https://space.example"))
+  }
+
+  // No service `type` is defined for the space host, so the entry is matched on id alone.
+  @Test
+  func spaceHostIgnoresServiceType() throws {
+    let doc = makeDoc(services: [
+      DocService(
+        id: "#atproto_space_host", type: "SomethingElse",
+        serviceEndpoint: "https://space.example")
+    ])
+    #expect(try doc.spaceHostUrl == URL(string: "https://space.example"))
+  }
+
+  @Test
+  func spaceHostFallsBackToPDSWhenAbsent() throws {
+    let doc = makeDoc(services: [pds()])
+    #expect(try doc.spaceHostUrl == URL(string: "https://pds.example"))
+  }
+
+  @Test
+  func spaceHostMayPointAtTheSameEndpointAsPDS() throws {
+    let doc = makeDoc(services: [
+      pds(),
+      DocService(
+        id: "#atproto_space_host", type: "AtprotoSpaceHost",
+        serviceEndpoint: "https://pds.example"),
+    ])
+    #expect(try doc.spaceHostUrl == URL(string: "https://pds.example"))
+  }
+
+  // A published-but-malformed entry is a misconfiguration, not an absent entry: it must not fall
+  // through to the PDS.
+  @Test
+  func spaceHostWithRelativeEndpointThrows() {
+    let doc = makeDoc(services: [
+      pds(),
+      DocService(id: "#atproto_space_host", type: "AtprotoSpaceHost", serviceEndpoint: "/xrpc"),
+    ])
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.spaceHostUrl }
+  }
+
+  @Test
+  func spaceHostWithNonHTTPEndpointThrows() {
+    let doc = makeDoc(services: [
+      pds(),
+      DocService(
+        id: "#atproto_space_host", type: "AtprotoSpaceHost",
+        serviceEndpoint: "ftp://space.example"),
+    ])
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.spaceHostUrl }
+  }
+
+  @Test
+  func spaceHostThrowsWhenNeitherEntryExists() {
+    let doc = makeDoc()
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.spaceHostUrl }
+  }
+
+  // MARK: - spaceSigningKey
+
+  @Test
+  func spaceSigningKeyPrefersDedicatedEntry() throws {
+    let doc = makeDoc(verificationMethods: [
+      key(id: "#atproto", multibase: "zAccount"),
+      key(id: "#atproto_space", multibase: "zSpace"),
+    ])
+    #expect(try doc.spaceSigningKey.publicKeyMultibase == "zSpace")
+  }
+
+  @Test
+  func spaceSigningKeyFallsBackToAccountKey() throws {
+    let doc = makeDoc(verificationMethods: [key(id: "#atproto", multibase: "zAccount")])
+    #expect(try doc.spaceSigningKey.publicKeyMultibase == "zAccount")
+  }
+
+  @Test
+  func spaceSigningKeyAcceptsAbsoluteEntryID() throws {
+    let doc = makeDoc(verificationMethods: [
+      key(id: "did:plc:example#atproto_space", multibase: "zSpace")
+    ])
+    #expect(try doc.spaceSigningKey.publicKeyMultibase == "zSpace")
+  }
+
+  @Test
+  func spaceSigningKeyThrowsWhenNeitherEntryExists() {
+    let doc = makeDoc(verificationMethods: [key(id: "#other", multibase: "zOther")])
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.spaceSigningKey }
+  }
+
+  // MARK: - spaceSigningKey(keyId:)
+
+  @Test(arguments: ["atproto", "#atproto"])
+  func spaceSigningKeyByIDResolvesAccountKey(keyId: String) throws {
+    let doc = makeDoc(verificationMethods: [
+      key(id: "#atproto", multibase: "zAccount"),
+      key(id: "#atproto_space", multibase: "zSpace"),
+    ])
+    #expect(try doc.spaceSigningKey(keyId: keyId).publicKeyMultibase == "zAccount")
+  }
+
+  @Test(arguments: ["atproto_space", "#atproto_space"])
+  func spaceSigningKeyByIDResolvesSpaceKey(keyId: String) throws {
+    let doc = makeDoc(verificationMethods: [
+      key(id: "#atproto", multibase: "zAccount"),
+      key(id: "#atproto_space", multibase: "zSpace"),
+    ])
+    #expect(try doc.spaceSigningKey(keyId: keyId).publicKeyMultibase == "zSpace")
+  }
+
+  // Unlike the fallback property, a named key that is absent is an error rather than a fallback.
+  @Test
+  func spaceSigningKeyByIDDoesNotFallBack() {
+    let doc = makeDoc(verificationMethods: [key(id: "#atproto", multibase: "zAccount")])
+    #expect(throws: DIDDocument.VerifyError.self) {
+      try doc.spaceSigningKey(keyId: "atproto_space")
+    }
+  }
+
+  @Test(arguments: ["atproto_pds", "verificationKey", "", "#"])
+  func spaceSigningKeyByIDRejectsUnsupportedKeyID(keyId: String) {
+    let doc = makeDoc(verificationMethods: [key(id: "#atproto", multibase: "zAccount")])
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.spaceSigningKey(keyId: keyId) }
+  }
+
+  // MARK: - spaceHostAudience
+
+  @Test
+  func spaceHostAudienceIsIndependentOfPublishedEntries() {
+    #expect(makeDoc().spaceHostAudience == "did:plc:example#atproto_space_host")
+    let withEntry = makeDoc(services: [
+      DocService(
+        id: "#atproto_space_host", type: "AtprotoSpaceHost",
+        serviceEndpoint: "https://space.example")
+    ])
+    #expect(withEntry.spaceHostAudience == "did:plc:example#atproto_space_host")
+  }
+
+  // MARK: - ServiceIdentifier
+
+  @Test
+  func serviceIdentifierParsesFragment() throws {
+    let id = try ServiceIdentifier(string: "did:web:syncer.example.com#atproto_space_syncer")
+    #expect(id.did.rawValue == "did:web:syncer.example.com")
+    #expect(id.fragment == "atproto_space_syncer")
+    #expect(id.rawValue == "did:web:syncer.example.com#atproto_space_syncer")
+  }
+
+  @Test
+  func serviceIdentifierParsesBareDID() throws {
+    let id = try ServiceIdentifier(string: "did:plc:example")
+    #expect(id.did.rawValue == "did:plc:example")
+    #expect(id.fragment == nil)
+    #expect(id.rawValue == "did:plc:example")
+  }
+
+  @Test(arguments: ["did:plc:example#", "did:plc:example#a#b"])
+  func serviceIdentifierRejectsMalformedFragment(string: String) {
+    #expect(throws: DIDDocument.VerifyError.self) { try ServiceIdentifier(string: string) }
+  }
+
+  // An empty DID part is a malformed DID rather than a malformed fragment, so it surfaces as a
+  // `LexiconStringFormatError` from the DID parser.
+  @Test(arguments: ["not-a-did#frag", "did:PLC:example", "", "#atproto_space_syncer"])
+  func serviceIdentifierRejectsMalformedDID(string: String) {
+    #expect(throws: LexiconStringFormatError.self) { try ServiceIdentifier(string: string) }
+  }
+
+  // MARK: - endpoint(for:)
+
+  @Test
+  func endpointResolvesFragmentEntryWithoutTypeConstraint() throws {
+    let doc = makeDoc(services: [
+      pds(),
+      DocService(
+        id: "#atproto_space_syncer", type: "Whatever", serviceEndpoint: "https://syncer.example"),
+    ])
+    let id = try ServiceIdentifier(string: "did:plc:example#atproto_space_syncer")
+    #expect(try doc.endpoint(for: id) == URL(string: "https://syncer.example"))
+  }
+
+  @Test
+  func endpointForBareDIDResolvesThroughPDS() throws {
+    let doc = makeDoc(services: [pds()])
+    let id = try ServiceIdentifier(string: "did:plc:example")
+    #expect(try doc.endpoint(for: id) == URL(string: "https://pds.example"))
+  }
+
+  @Test
+  func endpointThrowsWhenFragmentEntryMissing() throws {
+    let doc = makeDoc(services: [pds()])
+    let id = try ServiceIdentifier(string: "did:plc:example#atproto_space_syncer")
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.endpoint(for: id) }
+  }
+
+  @Test
+  func endpointThrowsOnMalformedFragmentEndpoint() throws {
+    let doc = makeDoc(services: [
+      DocService(id: "#atproto_space_syncer", type: "Whatever", serviceEndpoint: "/notify")
+    ])
+    let id = try ServiceIdentifier(string: "did:plc:example#atproto_space_syncer")
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.endpoint(for: id) }
+  }
+
+  // The document must be the one for the identifier's DID; resolving against another account's
+  // document would silently address the wrong service.
+  @Test
+  func endpointThrowsWhenIdentifierNamesAnotherDID() throws {
+    let doc = makeDoc(services: [pds()])
+    let id = try ServiceIdentifier(string: "did:plc:other#atproto_space_syncer")
+    #expect(throws: DIDDocument.VerifyError.self) { try doc.endpoint(for: id) }
+  }
+
+  // MARK: - Entry lookup
+
+  @Test
+  func lookupsReturnNilWhenArraysAreAbsent() throws {
+    let json = """
+      {"@context": ["c"], "id": "did:plc:example"}
+      """
+    let doc = try JSONDecoder().decode(DIDDocument.self, from: Data(json.utf8))
+    #expect(doc.serviceEntry(fragment: "atproto_space_host") == nil)
+    #expect(doc.verificationMaterial(fragment: "atproto_space") == nil)
+  }
+}
+
+extension DocService {
+  fileprivate init(id: String, type: String, serviceEndpoint: String) {
+    let json = """
+      {"id": "\(id)", "type": "\(type)", "serviceEndpoint": "\(serviceEndpoint)"}
+      """
+    self = try! JSONDecoder().decode(DocService.self, from: Data(json.utf8))
+  }
+}
+
+extension DocVerificationMethod {
+  fileprivate init(id: String, type: String, controller: String, publicKeyMultibase: String) {
+    let json = """
+      {
+        "id": "\(id)", "type": "\(type)",
+        "controller": "\(controller)", "publicKeyMultibase": "\(publicKeyMultibase)"
+      }
+      """
+    self = try! JSONDecoder().decode(DocVerificationMethod.self, from: Data(json.utf8))
+  }
+}


### PR DESCRIPTION
This PR adds `#atproto_space_host` and `#atproto_space` resolution to `DIDDocument`, along with `ServiceIdentifier` for the DID-plus-fragment form.