### PR TITLE
feat: add space-ref string format

### DIFF
--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -63,6 +63,7 @@ let posts = try await client.call(
 - ``ATURI``
 - ``TID``
 - ``RecordKey``
+- ``SpaceRef``
 - ``URI``
 - ``Language``
 - ``AtprotoDatetimeFormatStyle``

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -157,7 +157,4 @@ extension ATURI {
 
 private let slash = UInt8(ascii: "/")
 
-private let uriAllowedPunct = Set(#"._~:@!$&'()*+,;=%/\[]#?-"#.utf8)
 private let pointerPunct = Set("._~:@!$&')(*+,;=%[]/-".utf8)
-
-private func isAllowedURIByte(_ b: UInt8) -> Bool { isAlphanumeric(b) || uriAllowedPunct.contains(b) }

--- a/Sources/SwiftAtproto/StringFormats/SpaceRef.swift
+++ b/Sources/SwiftAtproto/StringFormats/SpaceRef.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+/// Type for the lexicon `space-ref` string format: a reference to a permissioned data space, as
+/// distinct from a record within one.
+///
+///     at://{spaceDid}/space/{spaceType}/{skey}
+///
+/// Wire-shape validation only: exactly four slash-separated segments after `at://`, with the
+/// second one being the literal `space` marker. Each remaining segment is handed to the validator
+/// of its own identifier type — the authority must be a ``DID`` (a handle is not accepted here),
+/// the space type must be an ``NSID``, and the space key carries the same syntax requirements as a
+/// ``RecordKey``.
+///
+/// A query string or fragment is rejected, because a space ref names a space and nothing within
+/// it. Both fall out of the segment validators, which admit neither `?` nor `#`.
+///
+/// This parser is self-contained rather than layered on ``ATURI``: the lexicon `at-uri` grammar
+/// admits at most two path segments below the authority, so it cannot carry a space ref. The
+/// six-segment record URI form and its conversion to this type are a separate addition.
+public struct SpaceRef: LexiconStringFormat {
+  /// The original wire string, kept verbatim (no normalization).
+  public let rawValue: String
+  /// The authority that owns the space. Always a DID.
+  public let spaceDid: DID
+  /// The NSID naming the space type.
+  public let spaceType: NSID
+  /// The space key: the trailing segment identifying this space within its type.
+  public let skey: RecordKey
+
+  public init(string: String) throws {
+    try self.init(string: string, strict: true)
+  }
+
+  /// When `strict == false`, only ``skey`` relaxes, to the same structural admission
+  /// ``RecordKey`` uses in its own lenient mode. The authority and the space type are validated
+  /// either way, matching where the space URI grammar places each check.
+  public init(string: String, strict: Bool) throws {
+    guard let parts = SpaceRef.parse(string, strict: strict) else {
+      throw LexiconStringFormatError.invalid(format: "space-ref", value: string)
+    }
+    rawValue = string
+    // `SpaceRef.parse` has already run each component through its identifier-type validator, so
+    // the typed inits below cannot throw in practice — the force-tries document that invariant.
+    spaceDid = try! DID(string: String(parts.spaceDid))
+    spaceType = try! NSID(string: String(parts.spaceType))
+    skey = try! RecordKey(string: String(parts.skey), strict: strict)
+  }
+}
+
+extension SpaceRef {
+  /// Composes a strict space ref from its parts.
+  ///
+  /// This initializer can throw because ``RecordKey`` also supports explicitly lenient values,
+  /// which do not necessarily satisfy the strict space-ref wire format.
+  public init(spaceDid: DID, spaceType: NSID, skey: RecordKey) throws {
+    try self.init(
+      string: "at://\(spaceDid.rawValue)/\(SpaceRef.marker)/\(spaceType.rawValue)/\(skey.rawValue)"
+    )
+  }
+}
+
+extension SpaceRef: CustomStringConvertible {
+  public var description: String { rawValue }
+}
+
+extension SpaceRef {
+  /// The fixed second path segment that distinguishes a space ref from a public AT URI. It
+  /// contains no dot, while a collection NSID always contains at least two, so the two forms can
+  /// never be confused.
+  static let marker = "space"
+
+  private struct Parts {
+    var spaceDid: Substring
+    var spaceType: Substring
+    var skey: Substring
+  }
+
+  private static func parse(_ input: String, strict: Bool) -> Parts? {
+    // The component validators cap their own lengths, but a lenient `skey` is uncapped, so bound
+    // the whole string the way `ATURI` does.
+    guard input.utf8.count <= 8192 else { return nil }
+    for byte in input.utf8 where !isAllowedURIByte(byte) { return nil }
+    guard input.hasPrefix("at://") else { return nil }
+
+    // Empty subsequences are kept so that an empty segment, a doubled slash, or a trailing slash
+    // changes the count or fails a component validator instead of being silently dropped.
+    let segments = input.dropFirst(5).split(separator: "/", omittingEmptySubsequences: false)
+    guard segments.count == 4, segments[1] == marker else { return nil }
+
+    let spaceDid = segments[0]
+    let spaceType = segments[2]
+    let skey = segments[3]
+    guard DID.isValid(spaceDid), NSID.isValid(spaceType) else { return nil }
+    guard strict ? RecordKey.isValid(skey) : RecordKey.isValidLenient(skey) else { return nil }
+    return Parts(spaceDid: spaceDid, spaceType: spaceType, skey: skey)
+  }
+}

--- a/Sources/SwiftAtproto/StringFormats/_ASCII.swift
+++ b/Sources/SwiftAtproto/StringFormats/_ASCII.swift
@@ -7,3 +7,9 @@ func isLowerAlpha(_ b: UInt8) -> Bool { (UInt8(ascii: "a")...UInt8(ascii: "z")).
 func isUpperAlpha(_ b: UInt8) -> Bool { (UInt8(ascii: "A")...UInt8(ascii: "Z")).contains(b) }
 func isAlpha(_ b: UInt8) -> Bool { isLowerAlpha(b) || isUpperAlpha(b) }
 func isAlphanumeric(_ b: UInt8) -> Bool { isAlpha(b) || isDigit(b) }
+
+private let uriAllowedPunct = Set(#"._~:@!$&'()*+,;=%/\[]#?-"#.utf8)
+
+func isAllowedURIByte(_ b: UInt8) -> Bool {
+  isAlphanumeric(b) || uriAllowedPunct.contains(b)
+}

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -607,6 +607,7 @@ struct StringFormat: Codable, RawRepresentable {
   static let language: Self = .init("language")
   static let tid: Self = .init("tid")
   static let recordKey: Self = .init("record-key")
+  static let spaceRef: Self = .init("space-ref")
 
   var swiftFormatTypeName: String? {
     switch rawValue {
@@ -621,6 +622,7 @@ struct StringFormat: Codable, RawRepresentable {
     case "tid": "TID"
     case "record-key": "RecordKey"
     case "at-identifier": "AtIdentifier"
+    case "space-ref": "SpaceRef"
     default: nil
     }
   }

--- a/Tests/SwiftAtprotoLexTests/SpaceRefGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/SpaceRefGenerationTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("space-ref generation")
+struct SpaceRefGenerationTests {
+  @Test("space-ref fields generate as FormatString<SpaceRef>")
+  func spaceRefFieldsGenerateAsFormatString() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-space-ref-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let input = root.appending(path: "input", directoryHint: .isDirectory)
+    let output = root.appending(path: "output", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    // Shaped after `com.atproto.simplespace.getSpace`, which takes the space ref as a query
+    // parameter and returns it in the response body.
+    let fixture = """
+      {
+        "lexicon": 1,
+        "id": "com.example.getSpace",
+        "defs": {
+          "main": {
+            "type": "query",
+            "parameters": {
+              "type": "params",
+              "required": ["space"],
+              "properties": {
+                "space": {"type": "string", "format": "space-ref"}
+              }
+            },
+            "output": {
+              "encoding": "application/json",
+              "schema": {
+                "type": "object",
+                "required": ["space"],
+                "properties": {
+                  "space": {"type": "string", "format": "space-ref"},
+                  "unknownFormat": {"type": "string", "format": "not-a-real-format"}
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    try fixture.write(to: input.appending(path: "getSpace.json"), atomically: true, encoding: .utf8)
+
+    try await SwiftAtprotoLex.main(
+      outdir: output,
+      path: input.path,
+      generate: [.client, .server],
+      pluginSource: .command
+    )
+
+    let clientSource = try String(contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+    let serverSource = try String(contentsOf: output.appending(path: "XRPCAPIProtocol.swift"), encoding: .utf8)
+
+    #expect(!Parser.parse(source: clientSource).hasError)
+    #expect(!Parser.parse(source: serverSource).hasError)
+    #expect(clientSource.contains("FormatString<SpaceRef>"))
+    #expect(serverSource.contains("FormatString<SpaceRef>"))
+    // An unrecognized format still falls back to a plain string.
+    #expect(clientSource.contains("Swift.String"))
+    #expect(!clientSource.contains("FormatString<not-a-real-format>"))
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringSpaceRefTests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringSpaceRefTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct FormatStringSpaceRefTests {
+  static let wire = "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/space/com.example.forum/self"
+
+  @Test func decodePreservesWireStringAndTypedYieldsSpaceRef() throws {
+    let data = Data("\"\(Self.wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<SpaceRef>.self, from: data)
+    #expect(value.rawValue == Self.wire)
+    #expect(value.typed?.rawValue == Self.wire)
+    #expect(value.typed?.skey.rawValue == "self")
+  }
+
+  @Test func invalidSpaceRefDecodesLenientlyWithNilTyped() throws {
+    let wire = "at://alice.example.com/space/com.example.forum/self"  // handle authority
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<SpaceRef>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+    #expect(value.typedLenient == nil)
+  }
+
+  @Test func overlongSpaceKeyIsTypedOnlyLeniently() throws {
+    let wire =
+      "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/space/com.example.forum/"
+      + String(repeating: "a", count: 513)
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<SpaceRef>.self, from: data)
+    #expect(value.rawValue == wire)
+    #expect(value.typed == nil)
+    #expect(value.typedLenient?.rawValue == wire)
+  }
+
+  @Test func encodeEmitsWireString() throws {
+    let value = FormatString<SpaceRef>(rawValue: Self.wire)
+    let encoder = JSONEncoder()
+    // The wire string contains "/", which JSONEncoder escapes to "\/" by default.
+    encoder.outputFormatting = [.withoutEscapingSlashes]
+    let data = try encoder.encode(value)
+    #expect(String(decoding: data, as: UTF8.self) == "\"\(Self.wire)\"")
+  }
+}

--- a/Tests/SwiftAtprotoTests/SpaceRefInteropTests.swift
+++ b/Tests/SwiftAtprotoTests/SpaceRefInteropTests.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Wire-shape vectors for the lexicon `space-ref` string format.
+struct SpaceRefInteropTests {
+  static let did = "did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+  static let maxSkey = String(repeating: "a", count: 512)
+
+  static let validSpaceRefs: [String] = [
+    // Common forms.
+    "at://\(did)/space/com.example.forum/self",
+    "at://\(did)/space/com.example.forum/3jzfcijpj2z2a",
+    // Allowed record-key punctuation in the space key.
+    "at://\(did)/space/com.example.forum/abc-def",
+    "at://\(did)/space/com.example.forum/abc_def",
+    "at://\(did)/space/com.example.forum/abc.def",
+    "at://\(did)/space/com.example.forum/abc:def",
+    "at://\(did)/space/com.example.forum/abc~def",
+    // Other DID methods.
+    "at://did:web:example.com/space/com.example.forum/self",
+    // Deeper NSID authority.
+    "at://\(did)/space/com.example.sub.forum/self",
+    // Space key at the 512-byte limit.
+    "at://\(did)/space/com.example.forum/\(maxSkey)",
+  ]
+
+  static let invalidSpaceRefs: [String] = [
+    // Missing or wrong scheme.
+    "\(did)/space/com.example.forum/self",
+    "https://\(did)/space/com.example.forum/self",
+    // Missing `space` marker.
+    "at://\(did)/com.example.forum/self",
+    // Marker in the wrong position.
+    "at://\(did)/com.example.forum/space/self",
+    // Wrong marker.
+    "at://\(did)/spaces/com.example.forum/self",
+    // Too few segments.
+    "at://\(did)/space/com.example.forum",
+    "at://\(did)/space",
+    "at://\(did)",
+    // Too many segments: this is a record URI, not a space ref.
+    "at://\(did)/space/com.example.forum/self/\(did)/com.example.post/3jzfcijpj2z2a",
+    // Trailing slash.
+    "at://\(did)/space/com.example.forum/self/",
+    // Empty segments.
+    "at:///space/com.example.forum/self",
+    "at://\(did)/space//self",
+    "at://\(did)/space/com.example.forum/",
+    // Authority must be a DID, not a handle.
+    "at://alice.example.com/space/com.example.forum/self",
+    // Malformed DID.
+    "at://did:plc:/space/com.example.forum/self",
+    "at://did/space/com.example.forum/self",
+    // Space type must be an NSID.
+    "at://\(did)/space/forum/self",
+    "at://\(did)/space/com.example/self",
+    "at://\(did)/space/com.example.4forum/self",
+    // Space key must be a record key.
+    "at://\(did)/space/com.example.forum/.",
+    "at://\(did)/space/com.example.forum/..",
+    "at://\(did)/space/com.example.forum/\(maxSkey)a",
+    "at://\(did)/space/com.example.forum/has space",
+    // Query and fragment are not part of a space ref.
+    "at://\(did)/space/com.example.forum/self?foo=bar",
+    "at://\(did)/space/com.example.forum/self#/name",
+  ]
+
+  @Test func acceptsValidSpaceRefs() throws {
+    for wire in Self.validSpaceRefs {
+      let ref = try SpaceRef(string: wire)
+      #expect(ref.rawValue == wire)
+    }
+  }
+
+  @Test func rejectsInvalidSpaceRefs() {
+    for wire in Self.invalidSpaceRefs {
+      #expect(throws: LexiconStringFormatError.self) {
+        try SpaceRef(string: wire)
+      }
+    }
+  }
+
+  @Test func exposesParsedComponents() throws {
+    let ref = try SpaceRef(string: "at://\(Self.did)/space/com.example.forum/self")
+    #expect(ref.spaceDid.rawValue == Self.did)
+    #expect(ref.spaceType.rawValue == "com.example.forum")
+    #expect(ref.skey.rawValue == "self")
+  }
+
+  @Test func lenientModeRelaxesOnlyTheSpaceKey() throws {
+    let overlong = "at://\(Self.did)/space/com.example.forum/\(Self.maxSkey)a"
+    #expect(throws: LexiconStringFormatError.self) { try SpaceRef(string: overlong) }
+    let lenient = try SpaceRef(string: overlong, strict: false)
+    #expect(lenient.rawValue == overlong)
+
+    // The authority and the space type are validated in both modes.
+    let handleAuthority = "at://alice.example.com/space/com.example.forum/self"
+    #expect(throws: LexiconStringFormatError.self) {
+      try SpaceRef(string: handleAuthority, strict: false)
+    }
+    let badType = "at://\(Self.did)/space/forum/self"
+    #expect(throws: LexiconStringFormatError.self) {
+      try SpaceRef(string: badType, strict: false)
+    }
+
+    // Lenient record-key handling does not relax the AT URI character set.
+    for invalidKey in ["has space", "日本語", "double\"quote"] {
+      let wire = "at://\(Self.did)/space/com.example.forum/\(invalidKey)"
+      #expect(throws: LexiconStringFormatError.self) {
+        try SpaceRef(string: wire, strict: false)
+      }
+    }
+  }
+
+  @Test func composesFromComponents() throws {
+    let ref = try SpaceRef(
+      spaceDid: try DID(string: Self.did),
+      spaceType: try NSID(string: "com.example.forum"),
+      skey: try RecordKey(string: "self")
+    )
+    #expect(ref.rawValue == "at://\(Self.did)/space/com.example.forum/self")
+    #expect(ref.description == ref.rawValue)
+    // The composed string round-trips through the parser.
+    #expect(try SpaceRef(string: ref.rawValue).rawValue == ref.rawValue)
+  }
+
+  @Test func composingRejectsALenientRecordKey() throws {
+    let lenientKey = try RecordKey(string: "\(Self.maxSkey)a", strict: false)
+    #expect(throws: LexiconStringFormatError.self) {
+      try SpaceRef(
+        spaceDid: try DID(string: Self.did),
+        spaceType: try NSID(string: "com.example.forum"),
+        skey: lenientKey
+      )
+    }
+  }
+}


### PR DESCRIPTION
This PR adds `SpaceRef` for the `space-ref` string format and maps it in the code generator, so a space reference generates as `FormatString<SpaceRef>` instead of degrading to a plain string.