### PR TITLE
feat: generate space type declarations

### DIFF
--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -86,6 +86,11 @@ let posts = try await client.call(
 - ``RepoWriteOperationDescribing``
 - ``RepoWriteRequirement``
 
+### Space type declarations
+
+- ``LexSpace``
+- ``LexRecordKeyType``
+
 ### Event streams
 
 - <doc:Subscriptions>

--- a/Sources/SwiftAtproto/LexSpace.swift
+++ b/Sources/SwiftAtproto/LexSpace.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// The key type a Lexicon declaration recommends for the keys under it: `any`,
+/// `nsid`, `tid`, or a `literal:` value.
+///
+/// Space type declarations carry one as ``LexSpace/key``. Record declarations
+/// use the same vocabulary, so this type is not specific to spaces.
+///
+/// Unknown values round-trip through ``rawValue`` rather than failing to
+/// decode, so a declaration written against a newer Lexicon still reads.
+public struct LexRecordKeyType: RawRepresentable, Codable, Hashable, Sendable {
+  public let rawValue: String
+
+  public init(rawValue: String) {
+    self.rawValue = rawValue
+  }
+
+  public init(from decoder: Decoder) throws {
+    self.rawValue = try decoder.singleValueContainer().decode(String.self)
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(rawValue)
+  }
+
+  /// Any key syntactically valid as a record key.
+  public static let any = Self(rawValue: "any")
+  /// An NSID.
+  public static let nsid = Self(rawValue: "nsid")
+  /// A TID.
+  public static let tid = Self(rawValue: "tid")
+
+  /// A key fixed to one literal value, encoded as `literal:<value>`.
+  ///
+  /// The value is not validated here; read it back with ``literalValue``.
+  public static func literal(_ value: String) -> Self {
+    Self(rawValue: "\(literalPrefix)\(value)")
+  }
+
+  /// The value behind a `literal:` key type, or `nil` for every other key type.
+  ///
+  /// An empty value (a bare `"literal:"`) reads back as `nil`, matching the
+  /// AT Protocol requirement that a literal key name a non-empty value.
+  public var literalValue: String? {
+    guard rawValue.hasPrefix(Self.literalPrefix) else { return nil }
+    let value = rawValue.dropFirst(Self.literalPrefix.count)
+    return value.isEmpty ? nil : String(value)
+  }
+
+  private static let literalPrefix = "literal:"
+}
+
+/// A space type declaration, generated from a Lexicon `space` definition.
+///
+/// A space type NSID resolves to one of these. ``name`` is what an OAuth
+/// consent screen shows when an application asks for access to spaces of this
+/// type, and ``collections`` is the record collections a client should expect
+/// to find inside such a space.
+public protocol LexSpace {
+  /// The NSID of the declaring Lexicon.
+  static var id: String { get }
+  /// The key type recommended for space keys of this type.
+  static var key: LexRecordKeyType { get }
+  /// A human-readable name for the space type, shown to users on consent
+  /// screens. 1–64 characters.
+  static var name: String { get }
+  /// Localized ``name`` values by language code, or `nil` when the declaration
+  /// gives none.
+  static var nameLang: [String: String]? { get }
+  /// The collections clients should expect in a space of this type.
+  ///
+  /// Advisory only: any collection may be written to any space, and the
+  /// protocol does not constrain writes to this list. Empty when the
+  /// declaration lists none.
+  static var collections: [FormatString<NSID>] { get }
+  /// A description of the space type for developers, or `nil` when the
+  /// declaration gives none. Not shown to users.
+  static var description: String? { get }
+}

--- a/Sources/SwiftAtprotoLex/Definitions/SpaceTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/SpaceTypeDefinition.swift
@@ -1,0 +1,190 @@
+import SwiftSyntax
+
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
+struct SpaceTypeDefinition: Codable {
+  let type: FieldType
+  let key: String
+  let name: String
+  let nameLang: [String: String]?
+  let collections: [String]
+  let description: String?
+
+  private enum CodingKeys: String, CodingKey {
+    case type
+    case key
+    case name
+    case nameLang = "name:lang"
+    case collections
+    case description
+  }
+}
+
+extension SpaceTypeDefinition: SwiftCodeGeneratable {
+  func generateDeclaration(
+    leadingTrivia: Trivia? = nil, ts _: TypeSchema, name declName: String, type typeName: String,
+    defMap _: ExtDefMap, generate _: GenerateOption
+  ) -> any DeclSyntaxProtocol {
+    EnumDeclSyntax(
+      leadingTrivia: leadingTrivia,
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      name: .lexIdentifier(declName),
+      inheritanceClause: InheritanceClauseSyntax {
+        InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("LexSpace")))
+      }
+    ) {
+      staticLetDecl(leadingTrivia: .newline, ident: "id", value: StringLiteralExprSyntax(content: typeName))
+      Self.typedStaticLet(
+        ident: "key",
+        type: Lex.typeSyntax("LexRecordKeyType"),
+        value: Self.keyExpr(key)
+      )
+      Self.typedStaticLet(
+        ident: "name",
+        type: Lex.typeSyntax("Swift.String"),
+        value: ExprSyntax(StringLiteralExprSyntax(content: name))
+      )
+      Self.typedStaticLet(
+        ident: "nameLang",
+        type: TypeSyntax(
+          OptionalTypeSyntax(
+            wrappedType: DictionaryTypeSyntax(
+              key: Lex.typeSyntax("Swift.String"),
+              value: Lex.typeSyntax("Swift.String")
+            )
+          )
+        ),
+        value: Self.nameLangExpr(nameLang)
+      )
+      Self.typedStaticLet(
+        ident: "collections",
+        type: Lex.typeSyntax("[FormatString<NSID>]"),
+        value: Self.collectionsExpr(collections)
+      )
+      Self.typedStaticLet(
+        ident: "description",
+        type: TypeSyntax(OptionalTypeSyntax(wrappedType: Lex.typeSyntax("Swift.String"))),
+        value: Self.optionalStringExpr(description)
+      )
+    }
+  }
+
+  private static func typedStaticLet(ident: String, type: TypeSyntax, value: some ExprSyntaxProtocol) -> VariableDeclSyntax {
+    VariableDeclSyntax(
+      leadingTrivia: .newline,
+      modifiers: [
+        DeclModifierSyntax(name: .keyword(.public)),
+        DeclModifierSyntax(name: .keyword(.static)),
+      ],
+      bindingSpecifier: .keyword(.let)
+    ) {
+      PatternBindingSyntax(
+        pattern: IdentifierPatternSyntax(identifier: .identifier(ident)),
+        typeAnnotation: TypeAnnotationSyntax(type: type),
+        initializer: InitializerClauseSyntax(value: value)
+      )
+    }
+  }
+
+  // The record key vocabulary is open: `literal:<value>` carries a payload and
+  // newer Lexicons may add types, so anything outside the three known values
+  // goes through the raw-value initializer instead of being dropped.
+  private static func keyExpr(_ key: String) -> ExprSyntax {
+    switch key {
+    case "any", "nsid", "tid":
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier(key)))
+    default:
+      ExprSyntax(
+        FunctionCallExprSyntax(
+          calledExpression: DeclReferenceExprSyntax(baseName: .identifier("LexRecordKeyType")),
+          leftParen: .leftParenToken(),
+          arguments: LabeledExprListSyntax([
+            LabeledExprSyntax(
+              label: .identifier("rawValue"),
+              colon: .colonToken(),
+              expression: StringLiteralExprSyntax(content: key)
+            )
+          ]),
+          rightParen: .rightParenToken()
+        )
+      )
+    }
+  }
+
+  private static func nameLangExpr(_ nameLang: [String: String]?) -> ExprSyntax {
+    guard let nameLang, !nameLang.isEmpty else {
+      return ExprSyntax(NilLiteralExprSyntax())
+    }
+    // Sort by language code so the generated source does not depend on the
+    // dictionary's iteration order.
+    let sorted = nameLang.sorted { $0.key < $1.key }
+    return ExprSyntax(
+      DictionaryExprSyntax(
+        leftSquare: .leftSquareToken(),
+        content: .elements(
+          DictionaryElementListSyntax {
+            for (i, element) in sorted.enumerated() {
+              DictionaryElementSyntax(
+                leadingTrivia: .newline,
+                key: StringLiteralExprSyntax(content: element.key),
+                value: StringLiteralExprSyntax(content: element.value),
+                trailingComma: i < sorted.count - 1 ? .commaToken() : nil
+              )
+            }
+          }),
+        rightSquare: .rightSquareToken(leadingTrivia: .newline)
+      )
+    )
+  }
+
+  private static func collectionsExpr(_ collections: [String]) -> ExprSyntax {
+    guard !collections.isEmpty else {
+      return ExprSyntax(ArrayExprSyntax(elements: ArrayElementListSyntax([])))
+    }
+    return ExprSyntax(
+      ArrayExprSyntax(
+        leftSquare: .leftSquareToken(),
+        elements: ArrayElementListSyntax {
+          for (i, collection) in collections.enumerated() {
+            ArrayElementSyntax(
+              leadingTrivia: .newline,
+              expression: formatStringInit(collection),
+              trailingComma: i < collections.count - 1 ? .commaToken() : nil
+            )
+          }
+        },
+        rightSquare: .rightSquareToken(leadingTrivia: .newline)
+      )
+    )
+  }
+
+  // `FormatString` keeps the wire string verbatim, so a collection that is not
+  // a well-formed NSID still round-trips and simply reads back as `nil` from
+  // `typed`.
+  private static func formatStringInit(_ collection: String) -> ExprSyntax {
+    ExprSyntax(
+      FunctionCallExprSyntax(
+        calledExpression: DeclReferenceExprSyntax(baseName: .identifier("FormatString<NSID>")),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([
+          LabeledExprSyntax(
+            label: .identifier("rawValue"),
+            colon: .colonToken(),
+            expression: StringLiteralExprSyntax(content: collection)
+          )
+        ]),
+        rightParen: .rightParenToken()
+      )
+    )
+  }
+
+  private static func optionalStringExpr(_ value: String?) -> ExprSyntax {
+    if let value {
+      ExprSyntax(StringLiteralExprSyntax(content: value))
+    } else {
+      ExprSyntax(NilLiteralExprSyntax())
+    }
+  }
+}

--- a/Sources/SwiftAtprotoLex/FieldTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/FieldTypeDefinition.swift
@@ -22,6 +22,7 @@ enum FieldTypeDefinition: Encodable, DecodableWithConfiguration, Sendable {
   case subscription(SubscriptionDefinition)
   case record(RecordDefinition)
   case permissionSet(PermissionSetTypeDefinition)
+  case space(SpaceTypeDefinition)
   private enum CodingKeys: String, CodingKey {
     case type
   }
@@ -83,6 +84,8 @@ enum FieldTypeDefinition: Encodable, DecodableWithConfiguration, Sendable {
       self = try .record(RecordDefinition(from: decoder, configuration: configuration))
     case .permissionSet:
       self = try .permissionSet(PermissionSetTypeDefinition(from: decoder))
+    case .space:
+      self = try .space(SpaceTypeDefinition(from: decoder))
     }
   }
 
@@ -125,6 +128,8 @@ enum FieldTypeDefinition: Encodable, DecodableWithConfiguration, Sendable {
     case .record(let def):
       try def.encode(to: encoder)
     case .permissionSet(let def):
+      try def.encode(to: encoder)
+    case .space(let def):
       try def.encode(to: encoder)
     }
   }
@@ -194,6 +199,7 @@ extension FieldTypeDefinition: CustomStringConvertible {
     case .subscription: "subscription"
     case .record: "record"
     case .permissionSet: "permissionSet"
+    case .space: "space"
     }
   }
 }

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -130,6 +130,8 @@ final class Schema: Encodable, Decodable, Sendable {
         out[name] = ts
       case .permissionSet:
         out[name] = ts
+      case .space:
+        out[name] = ts
       default:
         break
       }
@@ -521,6 +523,8 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
       def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     case .permissionSet(let def):
       def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
+    case .space(let def):
+      def.generateDeclaration(leadingTrivia: leadingTrivia, ts: self, name: name, type: typeName, defMap: defMap, generate: generate)
     default:
       fatalError()
     }
@@ -564,6 +568,7 @@ enum FieldType: String, Codable {
   case subscription
   case record
   case permissionSet = "permission-set"
+  case space
 }
 
 enum AtpType {

--- a/Tests/SwiftAtprotoLexTests/SpaceGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/SpaceGenerationTests.swift
@@ -1,0 +1,237 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Space type declaration generation")
+struct SpaceGenerationTests {
+  @Test("space declarations generate LexSpace conformances")
+  func spaceDeclarationsGenerateLexSpaceConformances() async throws {
+    let source = try await generateClient(fixtures: [
+      "forum.json": Self.basicSpace,
+      "empty.json": Self.spaceWithEmptyCollections,
+    ])
+    #expect(!Parser.parse(source: source).hasError)
+
+    #expect(source.contains("public enum Forum: LexSpace"))
+    #expect(source.contains(#"public static let id = "com.atmoboards.forum""#))
+    #expect(source.contains("public static let key: LexRecordKeyType = .any"))
+    #expect(source.contains(#"public static let name: Swift.String = "AtmoBoards Forum""#))
+    #expect(source.contains(#"public static let description: Swift.String? = "A discussion forum""#))
+    #expect(source.contains(#""es": "Foro AtmoBoards""#))
+    #expect(source.contains(#""ja": "AtmoBoards 掲示板""#))
+    #expect(source.contains(#"FormatString<NSID>(rawValue: "com.atmoboards.thread")"#))
+    #expect(source.contains(#"FormatString<NSID>(rawValue: "com.atmoboards.reply")"#))
+
+    #expect(source.contains("public enum Empty: LexSpace"))
+    #expect(source.contains("public static let key: LexRecordKeyType = .tid"))
+    #expect(source.contains("public static let nameLang: [Swift.String: Swift.String]? = nil"))
+    #expect(source.contains("public static let collections: [FormatString<NSID>] = []"))
+    #expect(source.contains("public static let description: Swift.String? = nil"))
+  }
+
+  // The reference implementation rejects six space fixtures. swift-atproto
+  // rejects the three that omit a required field, which is the same strictness
+  // the other primary definitions already apply.
+  @Test(arguments: [Self.spaceMissingName, Self.spaceMissingKey, Self.spaceMissingCollections])
+  func spaceMissingARequiredFieldFailsToDecode(_ fixture: String) {
+    #expect(throws: (any Error).self) {
+      try JSONDecoder().decode(Schema.self, from: Data(fixture.utf8))
+    }
+  }
+
+  // The remaining three are accepted here on purpose, and this test pins that
+  // down so a change in behaviour is deliberate rather than incidental.
+  //
+  // - The key vocabulary is open, so an unrecognized key type is carried as a
+  //   raw value the way an unknown permission resource already is.
+  // - A collection is generated as `FormatString<NSID>`, which keeps the wire
+  //   string verbatim and reports the malformed value through `typed`.
+  // - Rejecting a primary definition placed outside `main` would be a
+  //   schema-wide rule; `record`, `query`, and the rest do not enforce it
+  //   either.
+  @Test(arguments: [Self.spaceWithInvalidKeyType, Self.spaceWithNonNSIDCollection, Self.spaceAsNonMainDefinition])
+  func spaceFixturesOutsideRequiredFieldCheckingDecode(_ fixture: String) throws {
+    let schema = try JSONDecoder().decode(Schema.self, from: Data(fixture.utf8))
+    let definition = try #require(schema.defs.first?.value)
+    #expect(definition.type.description == "space")
+  }
+
+  @Test("an unrecognized key type is generated as a raw value")
+  func unrecognizedKeyTypeIsGeneratedAsARawValue() async throws {
+    let source = try await generateClient(fixtures: ["space.json": Self.spaceWithInvalidKeyType])
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains(#"public static let key: LexRecordKeyType = LexRecordKeyType(rawValue: "bogus")"#))
+  }
+
+  @Test("a literal key type keeps its payload")
+  func literalKeyTypeKeepsItsPayload() async throws {
+    let source = try await generateClient(fixtures: ["space.json": Self.spaceWithLiteralKey])
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains(#"public static let key: LexRecordKeyType = LexRecordKeyType(rawValue: "literal:self")"#))
+  }
+
+  private func generateClient(fixtures: [String: String]) async throws -> String {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-space-generation-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let input = root.appending(path: "input", directoryHint: .isDirectory)
+    let output = root.appending(path: "output", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    for (name, contents) in fixtures {
+      try contents.write(to: input.appending(path: name), atomically: true, encoding: .utf8)
+    }
+    try await SwiftAtprotoLex.main(outdir: output, path: input.path, generate: .client, pluginSource: .command)
+    return try String(contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+  }
+
+  // Fixtures come verbatim from the reference implementation's lexicon tests at
+  // the pinned alpha commit (packages/lex/lex-document/tests/lexicon-valid.json).
+  static let basicSpace = """
+    {
+      "lexicon": 1,
+      "id": "com.atmoboards.forum",
+      "defs": {
+        "main": {
+          "type": "space",
+          "key": "any",
+          "name": "AtmoBoards Forum",
+          "description": "A discussion forum",
+          "name:lang": {
+            "es": "Foro AtmoBoards",
+            "ja": "AtmoBoards 掲示板"
+          },
+          "collections": [
+            "com.atmoboards.thread",
+            "com.atmoboards.reply"
+          ]
+        }
+      }
+    }
+    """
+
+  static let spaceWithEmptyCollections = """
+    {
+      "lexicon": 1,
+      "id": "com.example.empty",
+      "defs": {
+        "main": {
+          "type": "space",
+          "key": "tid",
+          "name": "Empty Space",
+          "collections": []
+        }
+      }
+    }
+    """
+
+  // Fixtures the reference implementation lists as invalid
+  // (packages/lex/lex-document/tests/lexicon-invalid.json).
+  static let spaceMissingName = """
+    {
+      "lexicon": 1,
+      "id": "com.example.space",
+      "defs": {
+        "main": {
+          "type": "space",
+          "collections": []
+        }
+      }
+    }
+    """
+
+  static let spaceMissingKey = """
+    {
+      "lexicon": 1,
+      "id": "com.example.space",
+      "defs": {
+        "main": {
+          "type": "space",
+          "name": "Example Space",
+          "collections": []
+        }
+      }
+    }
+    """
+
+  static let spaceMissingCollections = """
+    {
+      "lexicon": 1,
+      "id": "com.example.space",
+      "defs": {
+        "main": {
+          "type": "space",
+          "name": "Example Space"
+        }
+      }
+    }
+    """
+
+  static let spaceWithInvalidKeyType = """
+    {
+      "lexicon": 1,
+      "id": "com.example.space",
+      "defs": {
+        "main": {
+          "type": "space",
+          "key": "bogus",
+          "name": "Example Space",
+          "collections": []
+        }
+      }
+    }
+    """
+
+  static let spaceWithNonNSIDCollection = """
+    {
+      "lexicon": 1,
+      "id": "com.example.space",
+      "defs": {
+        "main": {
+          "type": "space",
+          "key": "any",
+          "name": "Example Space",
+          "collections": [
+            "not-a-valid-nsid"
+          ]
+        }
+      }
+    }
+    """
+
+  static let spaceAsNonMainDefinition = """
+    {
+      "lexicon": 1,
+      "id": "com.example.space",
+      "defs": {
+        "demo": {
+          "type": "space",
+          "key": "any",
+          "name": "Example Space",
+          "collections": []
+        }
+      }
+    }
+    """
+
+  // Not a reference fixture: `literal:` is the one key type that carries a
+  // payload, and no valid-side fixture exercises it.
+  static let spaceWithLiteralKey = """
+    {
+      "lexicon": 1,
+      "id": "com.example.space",
+      "defs": {
+        "main": {
+          "type": "space",
+          "key": "literal:self",
+          "name": "Example Space",
+          "collections": []
+        }
+      }
+    }
+    """
+}

--- a/Tests/SwiftAtprotoTests/LexSpaceTests.swift
+++ b/Tests/SwiftAtprotoTests/LexSpaceTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+struct LexSpaceTests {
+  @Test func recordKeyTypeKnownConstantsRoundTrip() throws {
+    let encoder = JSONEncoder()
+    let decoder = JSONDecoder()
+    for value in [LexRecordKeyType.any, .nsid, .tid] {
+      let data = try encoder.encode(value)
+      #expect(String(data: data, encoding: .utf8) == "\"\(value.rawValue)\"")
+      let decoded = try decoder.decode(LexRecordKeyType.self, from: data)
+      #expect(decoded == value)
+    }
+  }
+
+  @Test func recordKeyTypePreservesUnknownRawValue() throws {
+    let data = Data("\"bogus\"".utf8)
+    let decoded = try JSONDecoder().decode(LexRecordKeyType.self, from: data)
+    #expect(decoded.rawValue == "bogus")
+    #expect(decoded != .any)
+    #expect(decoded.literalValue == nil)
+
+    let reEncoded = try JSONEncoder().encode(decoded)
+    #expect(String(data: reEncoded, encoding: .utf8) == "\"bogus\"")
+  }
+
+  @Test func literalKeyTypeRoundTripsThroughItsPayload() {
+    let key = LexRecordKeyType.literal("self")
+    #expect(key.rawValue == "literal:self")
+    #expect(key.literalValue == "self")
+  }
+
+  @Test func knownKeyTypesHaveNoLiteralPayload() {
+    #expect(LexRecordKeyType.any.literalValue == nil)
+    #expect(LexRecordKeyType.nsid.literalValue == nil)
+    #expect(LexRecordKeyType.tid.literalValue == nil)
+  }
+
+  // A bare `literal:` names no value, so it reads back as no payload rather
+  // than as an empty one.
+  @Test func emptyLiteralPayloadReadsAsNil() {
+    #expect(LexRecordKeyType(rawValue: "literal:").literalValue == nil)
+  }
+
+  @Test func conformingTypeSatisfiesProtocol() {
+    #expect(SampleForumSpace.id == "com.example.forum")
+    #expect(SampleForumSpace.key == .any)
+    #expect(SampleForumSpace.name == "Example Forum")
+    #expect(SampleForumSpace.nameLang?["ja"] == "サンプル掲示板")
+    #expect(SampleForumSpace.collections.count == 1)
+    #expect(SampleForumSpace.collections[0].typed?.rawValue == "com.example.thread")
+    #expect(SampleForumSpace.description == nil)
+  }
+
+  // A collection that is not a well-formed NSID still round-trips as a wire
+  // string; only `typed` reports the problem.
+  @Test func malformedCollectionKeepsItsWireString() {
+    let collection = FormatString<NSID>(rawValue: "not-a-valid-nsid")
+    #expect(collection.rawValue == "not-a-valid-nsid")
+    #expect(collection.typed == nil)
+  }
+}
+
+private enum SampleForumSpace: LexSpace {
+  static let id = "com.example.forum"
+  static let key: LexRecordKeyType = .any
+  static let name: String = "Example Forum"
+  static let nameLang: [String: String]? = ["ja": "サンプル掲示板"]
+  static let collections: [FormatString<NSID>] = [
+    FormatString<NSID>(rawValue: "com.example.thread")
+  ]
+  static let description: String? = nil
+}


### PR DESCRIPTION
This PR adds the `space` primary definition, so a space type declaration generates a `LexSpace` conformance instead of failing to decode.

`key` is required, matching the proposal and the reference implementation's lex-document schema. The key type generates as `LexRecordKeyType` and each collection as `FormatString<NSID>`, both of which keep an unrecognized value's wire string rather than dropping it.