### PR TITLE
feat: parse space record URIs in ATURI

### DIFF
--- a/Sources/SwiftAtproto/Documentation.docc/Articles/LexiconStringFormats.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/LexiconStringFormats.md
@@ -46,15 +46,21 @@ createdAt.typedLenient      // Date?, accepts the relaxed spelling
 
 ``LexiconStringFormat`` has two initializers. `init(string:)` is always strict.
 `init(string:strict:)` defaults to calling the strict one, so identifier formats
-that have no relaxed reading — ``DID``, ``Handle``, ``NSID``, ``TID``,
-``RecordKey`` — behave identically either way.
+that have no relaxed reading — ``DID``, ``Handle``, ``NSID``, ``TID`` — behave
+identically either way.
 
-`Date` is the format where the distinction matters. The AT Protocol datetime
+`Date` is the format where the distinction is widest. The AT Protocol datetime
 grammar is narrower than ISO 8601: strict parsing requires the full form the
 spec mandates, while lenient parsing accepts the older spellings that existing
 records contain. Because decoding a response uses
 ``LexiconDecodingMode/permissive``, a value that only parses leniently still
 arrives intact and is yours to interpret.
+
+``RecordKey`` relaxes too, dropping its length and character limits and keeping
+only what AT URI path syntax requires. ``SpaceRef`` carries that relaxation into
+its space key and ``ATURI`` into both key segments, the latter additionally
+accepting a trailing slash, a query string, and a malformed percent-escape in a
+fragment.
 
 ## Validation is about shape
 

--- a/Sources/SwiftAtproto/StringFormats/ATURI.swift
+++ b/Sources/SwiftAtproto/StringFormats/ATURI.swift
@@ -3,7 +3,7 @@ import Foundation
 /// A dedicated AT URI type for the lexicon `at-uri` string format. There is no natural Foundation type
 /// (`URL` rejects the `at://` scheme and normalizes), so this is a self-contained, range-based parser.
 ///
-/// Scope: this implements ONLY the *restricted* (Lexicon) AT URI syntax in strict mode, per the
+/// Scope: this implements the *restricted* (Lexicon) AT URI syntax in strict mode, per the
 /// AT Protocol AT URI spec (https://atproto.com/specs/at-uri-scheme):
 ///
 ///   AT-URI     = "at://" AUTHORITY [ "/" COLLECTION [ "/" RKEY ] ] [ "#" FRAGMENT ]
@@ -11,25 +11,53 @@ import Foundation
 ///   COLLECTION = NSID
 ///   RKEY       = RECORD-KEY
 ///
-/// This is the form used by lexicon `at-uri` fields and covers essentially all real AT URIs. The
-/// general AT URI syntax (multi-segment paths, query strings) is intentionally NOT supported. A parse
-/// mode for the lenient variant (relaxed record key, trailing slash, query) may be added to this same
-/// type later (`init(string:strict:)` / `typedLenient`); a fully permissive/general parser would be a
-/// separate addition if a concrete need arises.
+/// plus the permissioned-data form, which carries a fixed `space` marker below the authority:
+///
+///   SPACE-URI  = "at://" DID "/space/" SPACE-TYPE "/" SKEY [ "/" DID "/" COLLECTION "/" RKEY ]
+///                [ "#" FRAGMENT ]
+///   SPACE-TYPE = NSID
+///   SKEY       = RECORD-KEY
+///
+/// The record triple is all-or-nothing: a space URI either names a space or a record within one.
+/// ``isSpace`` discriminates the two forms, and ``collection`` / ``rkey`` / ``authorDid`` name the
+/// record either way, so a caller reading a record out of an `at-uri` field does not need to know
+/// which form it holds.
+///
+/// The general AT URI syntax (arbitrary multi-segment paths, query strings) is still NOT supported.
+/// A parse mode for the lenient variant (relaxed record key, trailing slash, query) is available
+/// through `init(string:strict:)` / `typedLenient`; a fully permissive parser would be a separate
+/// addition if a concrete need arises.
 ///
 /// DID / Handle / NSID / RecordKey / AtIdentifier component validators live in their dedicated
 /// identifier-type files. Only the JSON Pointer fragment validator remains here.
 public struct ATURI: LexiconStringFormat {
   /// The original wire string, kept verbatim (no normalization).
   public let rawValue: String
-  /// Required authority: a DID or a handle, dispatched via `AtIdentifier`.
+  /// Required authority: a DID or a handle, dispatched via `AtIdentifier`. Always a DID on a
+  /// space URI.
   public let authority: AtIdentifier
-  /// Optional collection NSID.
+  /// Optional collection NSID. On a space URI this is the record's collection, not the `space`
+  /// marker, and it is nil when the URI names the space itself.
   public let collection: NSID?
-  /// Optional record key (trailing path segment).
+  /// Optional record key (trailing path segment). Nil when the URI names no record.
   public let rkey: RecordKey?
   /// Optional JSON Pointer fragment (without the leading "#").
   public let fragment: String?
+  /// Whether this URI addresses permissioned space data.
+  public let isSpace: Bool
+  /// The authority that owns the space. Nil on a public URI.
+  public let spaceDid: DID?
+  /// The NSID naming the space type. Nil on a public URI.
+  public let spaceType: NSID?
+  /// The space key identifying this space within its type. Nil on a public URI.
+  public let skey: RecordKey?
+  /// The account whose record this is: the fifth segment on a space URI, or the authority on a
+  /// public URI when that authority is a DID. Nil when the URI names no record, and nil on a
+  /// public URI whose authority is a handle.
+  public let authorDid: DID?
+  /// The space this URI belongs to, whether it names the space itself or a record within it.
+  /// Nil on a public URI.
+  public let spaceRef: SpaceRef?
 
   public init(string: String) throws {
     try self.init(string: string, strict: true)
@@ -41,12 +69,51 @@ public struct ATURI: LexiconStringFormat {
     }
     rawValue = string
     // `ATURI.parse` runs each component through its identifier-type validator
-    // (`AtIdentifier.isValid` / `NSID.isValid` / `RecordKey.isValid`) before returning, so the
-    // typed inits below cannot throw in practice — the force-tries document that invariant.
+    // (`AtIdentifier.isValid` / `DID.isValid` / `NSID.isValid` / `RecordKey.isValid`) before
+    // returning, so the typed inits below cannot throw in practice — the force-tries document
+    // that invariant.
     authority = try! AtIdentifier(string: String(parts.authority))
     collection = parts.collection.map { try! NSID(string: String($0)) }
     rkey = parts.rkey.map { try! RecordKey(string: String($0), strict: strict) }
     fragment = parts.fragment.map(String.init)
+    isSpace = parts.isSpace
+    spaceDid = parts.isSpace ? try! DID(string: String(parts.authority)) : nil
+    spaceType = parts.spaceType.map { try! NSID(string: String($0)) }
+    skey = parts.skey.map { try! RecordKey(string: String($0), strict: strict) }
+    if let author = parts.author {
+      authorDid = try! DID(string: String(author))
+    } else if !parts.isSpace, case .did(let did) = authority {
+      authorDid = did
+    } else {
+      authorDid = nil
+    }
+    // Composed from the already-validated segments rather than re-parsing `rawValue`, which may
+    // carry a record tail, a fragment, or (leniently) a query. `strict` is passed through so a
+    // leniently read space key does not become a strict `SpaceRef`.
+    if parts.isSpace, let spaceType = parts.spaceType, let skey = parts.skey {
+      spaceRef = try! SpaceRef(
+        string: "at://\(parts.authority)/\(SpaceRef.marker)/\(spaceType)/\(skey)", strict: strict)
+    } else {
+      spaceRef = nil
+    }
+  }
+}
+
+extension ATURI {
+  /// Composes a strict AT URI naming a space.
+  ///
+  /// This initializer can throw for the same reason ``SpaceRef/init(spaceDid:spaceType:skey:)``
+  /// does: a ``RecordKey`` obtained leniently does not necessarily satisfy the strict wire format.
+  public init(spaceRef: SpaceRef) throws {
+    try self.init(string: spaceRef.rawValue)
+  }
+
+  /// Composes a strict AT URI naming a record within a space.
+  public init(spaceRef: SpaceRef, authorDid: DID, collection: NSID, rkey: RecordKey) throws {
+    try self.init(
+      string:
+        "\(spaceRef.rawValue)/\(authorDid.rawValue)/\(collection.rawValue)/\(rkey.rawValue)"
+    )
   }
 }
 
@@ -56,12 +123,16 @@ extension ATURI {
     var collection: Substring?
     var rkey: Substring?
     var fragment: Substring?
+    var isSpace = false
+    var spaceType: Substring?
+    var skey: Substring?
+    var author: Substring?
   }
 
   // Restricted-syntax validation per the AT URI spec. When `strict` is false the lenient variant
   // is applied: trailing slash, query, and percent-encoding errors in the fragment are accepted,
-  // and `rkey` is admitted through `RecordKey.isValidLenient` (non-empty + no path delimiters)
-  // instead of the strict record-key grammar.
+  // and `rkey` / `skey` are admitted through `RecordKey.isValidLenient` (non-empty + no path
+  // delimiters) instead of the strict record-key grammar.
   private static func parse(_ input: String, strict: Bool = true) -> Parts? {
     guard input.utf8.count <= 8192 else { return nil }
     for byte in input.utf8 where !isAllowedURIByte(byte) { return nil }
@@ -77,12 +148,17 @@ extension ATURI {
       return input[start..<i]
     }
     func atSegmentBoundary() -> Bool { i >= end || input[i] == "?" || input[i] == "#" }
+    // Consumes a "/" and reports whether a further segment follows it.
+    func consumeSlash() -> Bool {
+      guard i < end, input[i] == "/" else { return false }
+      i = input.index(after: i)
+      return !atSegmentBoundary()
+    }
 
     let authority = scanSegment()
     if authority.isEmpty { return nil }
 
-    var collection: Substring?
-    var rkey: Substring?
+    var parts = Parts(authority: authority)
     var trailingSlash = false
 
     if i < end, input[i] == "/" {
@@ -90,19 +166,51 @@ extension ATURI {
       if atSegmentBoundary() {
         trailingSlash = true
       } else {
-        collection = scanSegment()
-        if i < end, input[i] == "/" {
-          i = input.index(after: i)
-          if atSegmentBoundary() {
-            trailingSlash = true
-          } else {
-            rkey = scanSegment()
-            if i < end, input[i] == "/" {
-              i = input.index(after: i)
-              if atSegmentBoundary() {
-                trailingSlash = true
-              } else {
-                return nil  // more than two path segments
+        let first = scanSegment()
+        if first == SpaceRef.marker {
+          parts.isSpace = true
+          // The space type and the space key are both mandatory, so a URI that stops at the
+          // marker is rejected in either mode rather than read as a trailing slash.
+          guard consumeSlash() else { return nil }
+          parts.spaceType = scanSegment()
+          guard consumeSlash() else { return nil }
+          parts.skey = scanSegment()
+          if i < end, input[i] == "/" {
+            i = input.index(after: i)
+            if atSegmentBoundary() {
+              trailingSlash = true
+            } else {
+              // The record triple is all-or-nothing: a partial tail is not a shorter URI.
+              parts.author = scanSegment()
+              guard consumeSlash() else { return nil }
+              parts.collection = scanSegment()
+              guard consumeSlash() else { return nil }
+              parts.rkey = scanSegment()
+              if i < end, input[i] == "/" {
+                i = input.index(after: i)
+                if atSegmentBoundary() {
+                  trailingSlash = true
+                } else {
+                  return nil  // more than six path segments
+                }
+              }
+            }
+          }
+        } else {
+          parts.collection = first
+          if i < end, input[i] == "/" {
+            i = input.index(after: i)
+            if atSegmentBoundary() {
+              trailingSlash = true
+            } else {
+              parts.rkey = scanSegment()
+              if i < end, input[i] == "/" {
+                i = input.index(after: i)
+                if atSegmentBoundary() {
+                  trailingSlash = true
+                } else {
+                  return nil  // more than two path segments
+                }
               }
             }
           }
@@ -123,20 +231,38 @@ extension ATURI {
       fragment = input[i..<end]
       i = end
     }
+    parts.fragment = fragment
 
     guard i == end else { return nil }
 
     // Component validation (applies in both strict and lenient).
-    guard AtIdentifier.isValid(authority) else { return nil }
-    if let collection, !NSID.isValid(collection) { return nil }
+    if parts.isSpace {
+      // A space's identity and membership are keyed on DIDs, so neither the authority nor the
+      // author may be a handle.
+      guard DID.isValid(authority) else { return nil }
+      guard let spaceType = parts.spaceType, NSID.isValid(spaceType) else { return nil }
+      if let author = parts.author {
+        guard DID.isValid(author) else { return nil }
+      }
+    } else {
+      guard AtIdentifier.isValid(authority) else { return nil }
+    }
+    if let collection = parts.collection, !NSID.isValid(collection) { return nil }
     if let fragment, !isValidJSONPointer(fragment, strict: strict) { return nil }
-    if let rkey, !(strict ? RecordKey.isValid(rkey) : RecordKey.isValidLenient(rkey)) { return nil }
+    if let skey = parts.skey,
+      !(strict ? RecordKey.isValid(skey) : RecordKey.isValidLenient(skey))
+    {
+      return nil
+    }
+    if let rkey = parts.rkey, !(strict ? RecordKey.isValid(rkey) : RecordKey.isValidLenient(rkey)) {
+      return nil
+    }
 
     // Strict-only constraints.
     if strict, trailingSlash { return nil }
     if strict, hasQuery { return nil }
 
-    return Parts(authority: authority, collection: collection, rkey: rkey, fragment: fragment)
+    return parts
   }
 
   // MARK: - JSON Pointer fragment

--- a/Sources/SwiftAtproto/StringFormats/SpaceRef.swift
+++ b/Sources/SwiftAtproto/StringFormats/SpaceRef.swift
@@ -14,9 +14,10 @@ import Foundation
 /// A query string or fragment is rejected, because a space ref names a space and nothing within
 /// it. Both fall out of the segment validators, which admit neither `?` nor `#`.
 ///
-/// This parser is self-contained rather than layered on ``ATURI``: the lexicon `at-uri` grammar
-/// admits at most two path segments below the authority, so it cannot carry a space ref. The
-/// six-segment record URI form and its conversion to this type are a separate addition.
+/// This parser is self-contained rather than layered on ``ATURI``, which accepts the record URI
+/// form as well and therefore has to keep a query, a fragment, and an optional record tail in
+/// view. Going the other way is supported: ``ATURI/spaceRef`` yields the space a URI belongs to,
+/// whether it names the space itself or a record within it.
 public struct SpaceRef: LexiconStringFormat {
   /// The original wire string, kept verbatim (no normalization).
   public let rawValue: String

--- a/Tests/SwiftAtprotoTests/ATURISpaceTests.swift
+++ b/Tests/SwiftAtprotoTests/ATURISpaceTests.swift
@@ -1,0 +1,230 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Vectors for the permissioned-data form of an AT URI, taken from the reference implementation's
+// unit tests (packages/syntax/tests/aturi-string.test.ts at the pinned alpha commit). The upstream
+// interop fixture files carry no space entries, so `ATURIInteropTests` stays as it is and these
+// live on their own.
+struct ATURISpaceTests {
+  static let spaceRefURI = "at://did:plc:asdf123/space/com.example.group/default"
+  static let recordURI =
+    "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1/com.atproto.feed.post/abc123"
+  static let publicURI = "at://did:plc:asdf123/com.atproto.feed.post/abc123"
+
+  static let validSpaceURIs = [
+    // a space reference: authority / marker / type / skey
+    spaceRefURI,
+    // a record within a space
+    recordURI,
+    // skey carries the same syntax as a record key
+    "at://did:plc:asdf123/space/com.example.group/self",
+    "at://did:plc:asdf123/space/com.example.group/3jui7kd54zh2y",
+    "at://did:plc:asdf123/space/com.example.group/a.b-c_d~e:f",
+    // fragments attach to either form
+    "at://did:plc:asdf123/space/com.example.group/default#/frag",
+    "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1/com.atproto.feed.post/abc#/frag",
+  ]
+
+  static let invalidSpaceURIs = [
+    // the space type must be an NSID
+    "at://did:plc:asdf123/space/short/default",
+    // a space is keyed on DIDs, so a handle is not allowed in either DID position
+    "at://user.bsky.social/space/com.example.group/default",
+    "at://did:plc:asdf123/space/com.example.group/default/user.bsky.social/com.atproto.feed.post/abc123",
+    // the record collection must be an NSID
+    "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1/short/abc123",
+    // too few segments: the space type and the space key are both mandatory
+    "at://did:plc:asdf123/space",
+    "at://did:plc:asdf123/space/com.example.group",
+    "at://did:plc:asdf123/space/com.example.group/",
+    // the record triple is all-or-nothing
+    "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1",
+    "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1/com.atproto.feed.post",
+    // too many segments
+    "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1/com.atproto.feed.post/abc/x",
+    // record-key rules apply to the space key
+    "at://did:plc:asdf123/space/com.example.group/.",
+    "at://did:plc:asdf123/space/com.example.group/..",
+    // a space character is rejected before any component validator runs
+    "at://not a did/space/com.example.group/default",
+    // fragments follow the same JSON Pointer rules as on a public URI
+    "at://did:plc:asdf123/space/com.example.group/default#",
+    "at://did:plc:asdf123/space/com.example.group/default#/a#/b",
+  ]
+
+  @Test(arguments: validSpaceURIs)
+  func validParses(_ uri: String) throws {
+    let parsed = try ATURI(string: uri)
+    #expect(parsed.rawValue == uri)
+    #expect(parsed.isSpace)
+  }
+
+  @Test(arguments: invalidSpaceURIs)
+  func invalidThrows(_ uri: String) {
+    #expect(throws: (any Error).self) { try ATURI(string: uri) }
+  }
+
+  @Test func overlongSpaceKeyIsRejected() {
+    let uri = "at://did:plc:asdf123/space/com.example.group/\(String(repeating: "x", count: 513))"
+    #expect(throws: (any Error).self) { try ATURI(string: uri) }
+  }
+
+  // MARK: discriminating space from public
+
+  // The marker has to match exactly. A collection NSID always carries at least two dots, so the
+  // two forms can never be confused — but a near miss is read as a public URI and then fails the
+  // collection validator rather than being treated as a malformed space URI.
+  @Test func markerMatchesExactly() throws {
+    #expect(throws: (any Error).self) { try ATURI(string: "at://did:plc:asdf123/spacey/x/y") }
+    #expect(try !ATURI(string: Self.publicURI).isSpace)
+    #expect(try !ATURI(string: "at://did:plc:asdf123").isSpace)
+  }
+
+  @Test func spaceAccessorsAreNilOnAPublicURI() throws {
+    let uri = try ATURI(string: Self.publicURI)
+    #expect(uri.spaceDid == nil)
+    #expect(uri.spaceType == nil)
+    #expect(uri.skey == nil)
+    #expect(uri.spaceRef == nil)
+  }
+
+  // MARK: reading a record
+
+  // collection / rkey / authorDid name the record, so they read the same way for both forms.
+  @Test func readsARecordFromASpaceURI() throws {
+    let uri = try ATURI(string: Self.recordURI)
+    // the record's collection, not the `space` marker
+    #expect(uri.collection?.rawValue == "com.atproto.feed.post")
+    #expect(uri.rkey?.rawValue == "abc123")
+    // the record's author, not the space's authority
+    #expect(uri.authorDid?.rawValue == "did:plc:user1")
+    #expect(uri.spaceDid?.rawValue == "did:plc:asdf123")
+  }
+
+  @Test func readsARecordFromAPublicURI() throws {
+    let uri = try ATURI(string: Self.publicURI)
+    #expect(uri.collection?.rawValue == "com.atproto.feed.post")
+    #expect(uri.rkey?.rawValue == "abc123")
+    #expect(uri.authorDid?.rawValue == "did:plc:asdf123")
+  }
+
+  @Test func aSpaceURIWithNoRecordPathNamesNoRecord() throws {
+    let uri = try ATURI(string: Self.spaceRefURI)
+    #expect(uri.collection == nil)
+    #expect(uri.rkey == nil)
+    #expect(uri.authorDid == nil)
+  }
+
+  @Test func aPublicURIWithAHandleAuthorityHasNoAuthorDID() throws {
+    let uri = try ATURI(string: "at://user.bsky.social/com.atproto.feed.post/abc")
+    #expect(uri.authorDid == nil)
+    #expect(uri.collection?.rawValue == "com.atproto.feed.post")
+  }
+
+  // MARK: reading a space
+
+  @Test func exposesTheSpaceParts() throws {
+    let uri = try ATURI(string: Self.spaceRefURI)
+    #expect(uri.spaceDid?.rawValue == "did:plc:asdf123")
+    #expect(uri.spaceType?.rawValue == "com.example.group")
+    #expect(uri.skey?.rawValue == "default")
+  }
+
+  // A record URI belongs to a space, so it names one — the record tail is dropped.
+  @Test func aRecordURINamesTheSpaceItBelongsTo() throws {
+    let uri = try ATURI(string: Self.recordURI)
+    #expect(uri.spaceRef?.rawValue == Self.spaceRefURI)
+  }
+
+  @Test func aSpaceRefURIYieldsTheSameRefItSpells() throws {
+    let uri = try ATURI(string: Self.spaceRefURI)
+    let ref = try #require(uri.spaceRef)
+    #expect(ref.rawValue == Self.spaceRefURI)
+    #expect(ref.spaceDid.rawValue == "did:plc:asdf123")
+    #expect(ref.spaceType.rawValue == "com.example.group")
+    #expect(ref.skey.rawValue == "default")
+  }
+
+  // The ref is composed from the parsed segments, so a fragment on the URI does not leak into it.
+  @Test func aFragmentDoesNotLeakIntoTheSpaceRef() throws {
+    let uri = try ATURI(string: "\(Self.spaceRefURI)#/frag")
+    #expect(uri.spaceRef?.rawValue == Self.spaceRefURI)
+    #expect(uri.fragment == "/frag")
+  }
+
+  // MARK: composing
+
+  @Test func composesASpaceURIFromARef() throws {
+    let ref = try SpaceRef(string: Self.spaceRefURI)
+    let uri = try ATURI(spaceRef: ref)
+    #expect(uri.rawValue == Self.spaceRefURI)
+    #expect(uri.isSpace)
+    #expect(uri.collection == nil)
+  }
+
+  @Test func composesARecordURIFromARef() throws {
+    let ref = try SpaceRef(string: Self.spaceRefURI)
+    let uri = try ATURI(
+      spaceRef: ref,
+      authorDid: try DID(string: "did:plc:user1"),
+      collection: try NSID(string: "com.atproto.feed.post"),
+      rkey: try RecordKey(string: "abc123")
+    )
+    #expect(uri.rawValue == Self.recordURI)
+    #expect(uri.spaceRef?.rawValue == Self.spaceRefURI)
+  }
+
+  // Parsing a composed URI yields the ref it was composed from.
+  @Test func composingAndParsingRoundTrip() throws {
+    let ref = try SpaceRef(string: Self.spaceRefURI)
+    let uri = try ATURI(
+      spaceRef: ref,
+      authorDid: try DID(string: "did:plc:user1"),
+      collection: try NSID(string: "com.atproto.feed.post"),
+      rkey: try RecordKey(string: "abc123")
+    )
+    #expect(try ATURI(string: uri.rawValue).spaceRef == ref)
+  }
+
+  // `SpaceRef` also admits explicitly lenient record keys, which do not satisfy the strict wire
+  // format the composing initializer parses through.
+  @Test func composingRejectsALenientSpaceKey() throws {
+    let lenientKey = try RecordKey(string: String(repeating: "x", count: 513), strict: false)
+    let ref = try SpaceRef(
+      string: "at://did:plc:asdf123/space/com.example.group/\(lenientKey.rawValue)", strict: false)
+    #expect(throws: LexiconStringFormatError.self) { try ATURI(spaceRef: ref) }
+  }
+
+  // MARK: lenient parsing
+
+  @Test(arguments: [
+    "at://did:plc:asdf123/space/com.example.group/default/",
+    "at://did:plc:asdf123/space/com.example.group/default?foo=bar",
+    "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1/com.atproto.feed.post/%%%",
+  ])
+  func strictRejectsAndLenientAccepts(_ wire: String) throws {
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: true) }
+    let uri = try ATURI(string: wire, strict: false)
+    #expect(uri.rawValue == wire)
+    #expect(uri.isSpace)
+  }
+
+  @Test func lenientRelaxesTheSpaceKeyTheSameWayItRelaxesARecordKey() throws {
+    let wire = "at://did:plc:asdf123/space/com.example.group/\(String(repeating: "x", count: 513))"
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: true) }
+    let uri = try ATURI(string: wire, strict: false)
+    #expect(uri.skey?.rawValue == String(repeating: "x", count: 513))
+  }
+
+  // The authority and the space type are validated in both modes, matching where the space URI
+  // grammar places each check.
+  @Test(arguments: [
+    "at://user.bsky.social/space/com.example.group/default",
+    "at://did:plc:asdf123/space/short/default",
+  ])
+  func lenientDoesNotRelaxTheAuthorityOrTheSpaceType(_ wire: String) {
+    #expect(throws: (any Error).self) { try ATURI(string: wire, strict: false) }
+  }
+}

--- a/Tests/SwiftAtprotoTests/FormatStringATURITests.swift
+++ b/Tests/SwiftAtprotoTests/FormatStringATURITests.swift
@@ -65,6 +65,22 @@ struct FormatStringATURITests {
     #expect(value.typedLenient?.rkey?.rawValue == "..")
   }
 
+  // A space record URI is what the alpha `com.atproto.space` methods return in their `at-uri`
+  // fields. Before space support it decoded fine but degraded to a nil `typed`, leaving the
+  // caller unable to read the record it names.
+  @Test func spaceRecordURIIsTyped() throws {
+    let wire =
+      "at://did:plc:asdf123/space/com.example.group/default/did:plc:user1/com.atproto.feed.post/abc123"
+    let data = Data("\"\(wire)\"".utf8)
+    let value = try JSONDecoder().decode(FormatString<ATURI>.self, from: data)
+    #expect(value.rawValue == wire)
+    let typed = try #require(value.typed)
+    #expect(typed.isSpace)
+    #expect(typed.collection?.rawValue == "com.atproto.feed.post")
+    #expect(typed.rkey?.rawValue == "abc123")
+    #expect(typed.spaceRef?.rawValue == "at://did:plc:asdf123/space/com.example.group/default")
+  }
+
   @Test func descriptionIsRawValue() {
     let value = FormatString<ATURI>(rawValue: Self.wire)
     #expect(value.description == Self.wire)


### PR DESCRIPTION
This PR teaches `ATURI` the permissioned-data form, so a space URI parses instead of decoding into a `FormatString` whose `typed` degrades silently to nil. The alpha `com.atproto.space` methods return that form from their `at-uri` fields.

`collection`, `rkey`, and `authorDid` name the record for both forms, so a caller does not need to know which one it holds, and `spaceRef` yields the space a URI belongs to whether it names the space itself or a record within it. The record triple is all-or-nothing, matching the reference implementation's grammar.

The second commit corrects the string-format article, which listed `RecordKey` among the formats with no lenient mode.