### PR TITLE
Upgrade swift-secp256k1 past the P256K rename

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c88911f4d330bbe35eabe8b8b77cb1ceb990021af0aa1423348b6555220afab6",
+  "originHash" : "90808b5ae57f3266cc96552b7c9fd873ae4d3bd01f52ba73823fc2fa473929bc",
   "pins" : [
     {
       "identity" : "cryptoswift",
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/21-DOT-DEV/swift-secp256k1",
       "state" : {
-        "revision" : "e2f4de7caec61e971081d44e73ea6ef20359743b",
-        "version" : "0.19.0"
+        "revision" : "e70a10e036a55fffea31568f0af92d69b6d449cd",
+        "version" : "0.23.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,7 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"604.0.0"),
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.3.1")),
     .package(url: "https://github.com/apple/swift-crypto", .upToNextMajor(from: "4.0.0")),
-    .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", "0.18.0"..<"0.20.0"),
+    .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", "0.23.0"..<"0.24.0"),
     .package(url: "https://github.com/apple/swift-http-types.git", from: "1.0.0"),
   ],
   targets: [
@@ -58,7 +58,8 @@ let package = Package(
       name: "ATProtoCrypto",
       dependencies: [
         .product(name: "Crypto", package: "swift-crypto"),
-        .product(name: "secp256k1", package: "swift-secp256k1"),
+        .product(name: "P256K", package: "swift-secp256k1"),
+        .product(name: "libsecp256k1", package: "swift-secp256k1"),
         .product(name: "Multibase", package: "swift-multibase"),
       ]
     ),

--- a/Sources/ATProtoCrypto/Key.swift
+++ b/Sources/ATProtoCrypto/Key.swift
@@ -1,6 +1,7 @@
 import Crypto
 import Multibase
-import secp256k1
+import P256K
+import libsecp256k1
 
 #if !canImport(Darwin)
   import FoundationEssentials
@@ -36,7 +37,7 @@ public struct PrivateKey {
     case .p256:
       raw = .p256(P256.Signing.PrivateKey())
     case .secp256k1:
-      raw = try .secp256k1(secp256k1.Signing.PrivateKey())
+      raw = try .secp256k1(P256K.Signing.PrivateKey())
     }
   }
 
@@ -51,7 +52,7 @@ public struct PrivateKey {
     case .p256:
       raw = try .p256(P256.Signing.PrivateKey(rawRepresentation: rawValue))
     case .secp256k1:
-      raw = try .secp256k1(secp256k1.Signing.PrivateKey(dataRepresentation: rawValue))
+      raw = try .secp256k1(P256K.Signing.PrivateKey(dataRepresentation: rawValue))
     }
   }
 
@@ -91,14 +92,14 @@ public struct PrivateKey {
     case .p256(let raw):
       try raw.signature(for: data).rawRepresentation
     case .secp256k1(let raw):
-      try raw.signature(for: data).compactRepresentation
+      raw.signature(for: data).compactRepresentation
     }
   }
 
   public enum Raw {
     case ed25519(Curve25519.Signing.PrivateKey)
     case p256(P256.Signing.PrivateKey)
-    case secp256k1(secp256k1.Signing.PrivateKey)
+    case secp256k1(P256K.Signing.PrivateKey)
   }
 }
 
@@ -237,8 +238,8 @@ public struct PublicKey {
       let raw = try P256.Signing.PublicKey(rawRepresentation: raw)
       return PublicKey(type: keyType, raw: .p256(raw))
     case .secp256k1:
-      let format: secp256k1.Format = raw.count == secp256k1.Format.compressed.length ? .compressed : .uncompressed
-      let pubKey = try secp256k1.Signing.PublicKey(dataRepresentation: raw, format: format)
+      let format: P256K.Format = raw.count == P256K.Format.compressed.length ? .compressed : .uncompressed
+      let pubKey = try P256K.Signing.PublicKey(dataRepresentation: raw, format: format)
       return try PublicKey(type: keyType, raw: .secp256k1(pubKey.compressed))
     }
   }
@@ -252,7 +253,7 @@ public struct PublicKey {
     case .ed25519(let raw):
       return raw.isValidSignature(signature, for: message)
     case .secp256k1(let raw):
-      guard let signature = try? secp256k1.Signing.ECDSASignature(compactRepresentation: signature).normalize else { return false }
+      guard let signature = try? P256K.Signing.ECDSASignature(compactRepresentation: signature).normalize else { return false }
       let hash = SHA256.hash(data: message)
       return raw.isValidSignature(signature, for: hash)
     case .p256(let raw):
@@ -269,18 +270,18 @@ public struct PublicKey {
   public enum Raw {
     case ed25519(Curve25519.Signing.PublicKey)
     case p256(P256.Signing.PublicKey)
-    case secp256k1(secp256k1.Signing.PublicKey)
+    case secp256k1(P256K.Signing.PublicKey)
   }
 }
 
-extension secp256k1.Signing.PublicKey {
+extension P256K.Signing.PublicKey {
   var compressed: Self {
     get throws {
       guard format != .compressed else {
         return self
       }
-      let format = secp256k1.Format.compressed
-      let context = secp256k1.Context.rawRepresentation
+      let format = P256K.Format.compressed
+      let context = P256K.Context.rawRepresentation
       var pubKeyLen = format.length
       var combinedKey = secp256k1_pubkey()
       var combinedBytes = [UInt8](repeating: 0, count: pubKeyLen)
@@ -309,10 +310,10 @@ extension secp256k1.Signing.PublicKey {
   }
 }
 
-extension secp256k1.Signing.ECDSASignature {
-  fileprivate var normalize: secp256k1.Signing.ECDSASignature {
+extension P256K.Signing.ECDSASignature {
+  fileprivate var normalize: P256K.Signing.ECDSASignature {
     get throws {
-      let context = secp256k1.Context.rawRepresentation
+      let context = P256K.Context.rawRepresentation
       var signature = secp256k1_ecdsa_signature()
       var resultSignature = secp256k1_ecdsa_signature()
 
@@ -328,7 +329,13 @@ extension secp256k1.Signing.ECDSASignature {
         return self
       }
 
-      return try secp256k1.Signing.ECDSASignature(dataRepresentation: resultSignature.dataValue)
+      // `resultSignature` carries no public accessor for its bytes; serialize
+      // it through the C API instead of reaching into vendor internals.
+      var compact = [UInt8](repeating: 0, count: 64)
+      guard secp256k1_ecdsa_signature_serialize_compact(context, &compact, &resultSignature) != 0 else {
+        throw secp256k1Error.underlyingCryptoError
+      }
+      return try P256K.Signing.ECDSASignature(compactRepresentation: compact)
     }
   }
 }


### PR DESCRIPTION
## Summary
- Bump the `swift-secp256k1` dependency range from `0.18.0..<0.20.0` to `0.23.0..<0.24.0` and split the `ATProtoCrypto` product dependency into `P256K` and `libsecp256k1`, matching the package's post-rename layout.
- Migrate `Sources/ATProtoCrypto/Key.swift` from the old `secp256k1` API to `P256K`.
- Set the lower bound to `0.23.0` to keep the package buildable on Xcode 27.0 beta 5 — 0.22.0 fails to compile there (`Ambiguous use of 'words'` in the vendored `UInt256.swift`).
- Since every version in the new range has already dropped `throws` from `PrivateKey.signature(for:)`, drop the now-dead `try` in `Key.swift`.

## Test plan
- [x] macOS + iPhone Simulator build/test with the declared range (resolves to 0.23.2) — no warnings, all tests pass
- [x] Same, pinned to the range's lower bound (0.23.0) — no warnings, all tests pass
- [x] Confirmed 0.22.0 fails to build under Xcode 27.0 beta 5 (`Ambiguous use of 'words'`), motivating the raised lower bound