### PR TITLE
Add RFC 7638 JWK thumbprints for signing keys

### DIFF
--- a/Sources/ATProtoCrypto/Documentation.docc/Articles/SigningAndVerifying.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/Articles/SigningAndVerifying.md
@@ -58,6 +58,16 @@ and "not a signature at all".
 reading the multicodec prefix to decide the curve. `secp256k1` keys are accepted
 in both compressed and uncompressed form and are normalized to compressed.
 
+## Thumbprints
+
+``PublicKey/jwkThumbprint`` is the RFC 7638 JWK thumbprint, base64url-encoded
+without padding. It digests the key material alone — the curve, the key type, and
+the coordinates — so the two `secp256k1` encodings above give the same
+thumbprint, and neither the multibase form nor a `kid` affects it.
+
+A token bound to a key names it this way: comparing a `cnf.jkt` claim against the
+thumbprint of a key you hold tells you whether that token was issued for it.
+
 ## Reading a key out of a DID document
 
 ``Document`` is the parsed DID document. ``Document/getPublicKey(id:)`` finds a

--- a/Sources/ATProtoCrypto/JWK.swift
+++ b/Sources/ATProtoCrypto/JWK.swift
@@ -1,0 +1,86 @@
+import Crypto
+
+#if !canImport(Darwin)
+  import FoundationEssentials
+#else
+  import Foundation
+#endif
+
+extension PublicKey {
+  /// The RFC 7638 JWK thumbprint of this key, base64url-encoded without padding.
+  ///
+  /// This is the value a `cnf.jkt` claim carries: comparing it against the
+  /// thumbprint of a key you hold tells you whether a token was bound to that
+  /// key. It is a digest of the key material alone, so two representations of
+  /// the same key — a compressed and an uncompressed `secp256k1` point, say —
+  /// produce the same thumbprint.
+  ///
+  /// - Throws: `secp256k1Error.underlyingCryptoError` when a `secp256k1` point
+  ///   cannot be re-serialized to read its coordinates.
+  public var jwkThumbprint: String {
+    get throws {
+      switch raw {
+      case .p256:
+        // `rawRepresentation` is the two 32-byte coordinates, `x` then `y`.
+        let bytes = rawBytes
+        return Self.thumbprint(
+          members: [
+            ("crv", "P-256"),
+            ("kty", "EC"),
+            ("x", base64URLEncoded(bytes.prefix(32))),
+            ("y", base64URLEncoded(bytes.suffix(32))),
+          ])
+      case .secp256k1(let key):
+        // Drop the `0x04` prefix of the uncompressed encoding.
+        let bytes = try key.uncompressedBytes.dropFirst()
+        return Self.thumbprint(
+          members: [
+            ("crv", "secp256k1"),
+            ("kty", "EC"),
+            ("x", base64URLEncoded(bytes.prefix(32))),
+            ("y", base64URLEncoded(bytes.suffix(32))),
+          ])
+      case .ed25519:
+        return Self.thumbprint(
+          members: [
+            ("crv", "Ed25519"),
+            ("kty", "OKP"),
+            ("x", base64URLEncoded(rawBytes)),
+          ])
+      }
+    }
+  }
+
+  // RFC 7638 §3: serialize the required members, and only those, as JSON with no
+  // whitespace and the member names in lexicographic order, then take the
+  // base64url-encoded SHA-256 of those octets.
+  //
+  // `members` is taken in order rather than sorted here so that a caller states
+  // the order the RFC prescribes for its key type; the tests pass the RFC's own
+  // worked example through this. Every value the AT Protocol key types produce is
+  // base64url or a curve name, so no value needs JSON string escaping.
+  static func thumbprint(members: [(name: String, value: String)]) -> String {
+    let json = members.map { #""\#($0.name)":"\#($0.value)""# }.joined(separator: ",")
+    let digest = SHA256.hash(data: Data("{\(json)}".utf8))
+    return base64URLEncoded(Data(digest))
+  }
+}
+
+/// Encodes `data` with the URL-safe base64 alphabet and no padding, as every
+/// JOSE field is spelled.
+///
+/// `Multibase` also encodes base64url, but prefixes the result with the
+/// multibase tag, which a JOSE field must not carry.
+func base64URLEncoded(_ data: some DataProtocol) -> String {
+  var encoded = ""
+  encoded.reserveCapacity(((data.count + 2) / 3) * 4)
+  for character in Data(data).base64EncodedString() {
+    switch character {
+    case "+": encoded.append("-")
+    case "/": encoded.append("_")
+    case "=": break
+    default: encoded.append(character)
+    }
+  }
+  return encoded
+}

--- a/Sources/ATProtoCrypto/Key.swift
+++ b/Sources/ATProtoCrypto/Key.swift
@@ -314,6 +314,13 @@ extension P256K.Signing.PublicKey {
   // The uncompressed SEC 1 encoding: a `0x04` prefix followed by the two 32-byte
   // coordinates. `dataRepresentation` is the compressed form, which carries only
   // `x` and a parity bit, so the JWK coordinates cannot be read off it directly.
+  //
+  // This re-parses from `dataRepresentation` rather than serializing
+  // `rawRepresentation` directly, matching how `compressed` above works around
+  // the same issue: `secp256k1_pubkey`'s internal layout is documented as
+  // implementation-defined and not portable across libsecp256k1 versions. The
+  // library's own `uncompressedRepresentation` (added in 0.19.0) still copies
+  // `rawRepresentation` directly, so it isn't used here.
   var uncompressedBytes: Data {
     get throws {
       let format = P256K.Format.uncompressed

--- a/Sources/ATProtoCrypto/Key.swift
+++ b/Sources/ATProtoCrypto/Key.swift
@@ -310,6 +310,35 @@ extension P256K.Signing.PublicKey {
   }
 }
 
+extension P256K.Signing.PublicKey {
+  // The uncompressed SEC 1 encoding: a `0x04` prefix followed by the two 32-byte
+  // coordinates. `dataRepresentation` is the compressed form, which carries only
+  // `x` and a parity bit, so the JWK coordinates cannot be read off it directly.
+  var uncompressedBytes: Data {
+    get throws {
+      let format = P256K.Format.uncompressed
+      let context = P256K.Context.rawRepresentation
+      var pubKeyLen = format.length
+      var bytes = [UInt8](repeating: 0, count: pubKeyLen)
+      var pubkey = secp256k1_pubkey()
+      let parsed = dataRepresentation.withUnsafeBytes { (rawPtr: UnsafeRawBufferPointer) in
+        secp256k1_ec_pubkey_parse(
+          context,
+          &pubkey,
+          rawPtr.baseAddress!.assumingMemoryBound(to: UInt8.self),
+          dataRepresentation.count
+        )
+      }
+      guard parsed == 1,
+        secp256k1_ec_pubkey_serialize(context, &bytes, &pubKeyLen, &pubkey, format.rawValue) > 0
+      else {
+        throw secp256k1Error.underlyingCryptoError
+      }
+      return Data(bytes)
+    }
+  }
+}
+
 extension P256K.Signing.ECDSASignature {
   fileprivate var normalize: P256K.Signing.ECDSASignature {
     get throws {

--- a/Tests/ATProtoCryptoTests/JWKThumbprintTests.swift
+++ b/Tests/ATProtoCryptoTests/JWKThumbprintTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+
+@testable import ATProtoCrypto
+
+struct JWKThumbprintTests {
+  // MARK: - RFC 7638
+
+  // The only worked example in RFC 7638 is the RSA key in §3.1. The AT Protocol
+  // key types are all EC or OKP, so the vector is fed to the shared core to check
+  // the algorithm itself — member order, whitespace-free JSON, SHA-256, base64url.
+  @Test func matchesTheRFC7638WorkedExample() {
+    let modulus =
+      "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc"
+      + "_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQ"
+      + "R0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bF"
+      + "TWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw"
+    let thumbprint = PublicKey.thumbprint(members: [
+      ("e", "AQAB"),
+      ("kty", "RSA"),
+      ("n", modulus),
+    ])
+    #expect(thumbprint == "NzbLsXh8uDCcd-6MNwXF4W_7noWXFZAfHkxZsRGC9Xs")
+  }
+
+  // MARK: - base64url
+
+  @Test func base64URLUsesTheURLSafeAlphabetWithoutPadding() {
+    // 0xFB 0xFF encodes as "+/8=" in the standard alphabet, exercising both
+    // substitutions and the padding strip in one vector.
+    #expect(base64URLEncoded(Data([0xFB, 0xFF])) == "-_8")
+    #expect(base64URLEncoded(Data()) == "")
+    #expect(base64URLEncoded(Data([0x00])) == "AA")
+  }
+
+  // MARK: - Key types
+
+  // `KeyType` is not `Sendable`, so these iterate a local list rather than going
+  // through `@Test(arguments:)`.
+  private var keyTypes: [KeyType] { [.p256, .secp256k1, .ed25519] }
+
+  @Test func thumbprintIsA43CharacterBase64URLDigest() throws {
+    for type in keyTypes {
+      let thumbprint = try PrivateKey(type: type).publicKey.jwkThumbprint
+      // SHA-256 is 32 bytes, which is 43 base64 characters once padding is dropped.
+      #expect(thumbprint.count == 43)
+      #expect(!thumbprint.contains("+"))
+      #expect(!thumbprint.contains("/"))
+      #expect(!thumbprint.contains("="))
+    }
+  }
+
+  @Test func thumbprintIsStableForOneKeyAndDistinctBetweenKeys() throws {
+    for type in keyTypes {
+      let key = try PrivateKey(type: type).publicKey
+      #expect(try key.jwkThumbprint == key.jwkThumbprint)
+      let other = try PrivateKey(type: type).publicKey
+      #expect(try key.jwkThumbprint != other.jwkThumbprint)
+    }
+  }
+
+  // The thumbprint covers the key, not the encoding it arrived in, so a key read
+  // back from its `did:key` form has to agree with the one it came from.
+  @Test func thumbprintSurvivesAMultibaseRoundTrip() throws {
+    for type in keyTypes {
+      let key = try PrivateKey(type: type).publicKey
+      let restored = try PublicKey.publicKeyFromMultibaseString(string: key.multibaseString)
+      #expect(try key.jwkThumbprint == restored.jwkThumbprint)
+    }
+  }
+
+  // MARK: - Coordinates
+
+  @Test func p256CoordinatesAreTheTwoHalvesOfTheRawRepresentation() throws {
+    let key = try PrivateKey(type: .p256).publicKey
+    let bytes = key.rawBytes
+    #expect(bytes.count == 64)
+    let expected = PublicKey.thumbprint(members: [
+      ("crv", "P-256"),
+      ("kty", "EC"),
+      ("x", base64URLEncoded(bytes.prefix(32))),
+      ("y", base64URLEncoded(bytes.suffix(32))),
+    ])
+    #expect(try key.jwkThumbprint == expected)
+  }
+
+  // `rawBytes` is the 33-byte compressed point, which carries `x` and a parity
+  // bit; the coordinates come from re-serializing it uncompressed.
+  @Test func secp256k1CoordinatesComeFromTheUncompressedPoint() throws {
+    let key = try PrivateKey(type: .secp256k1).publicKey
+    #expect(key.rawBytes.count == 33)
+    guard case .secp256k1(let underlying) = key.raw else {
+      Issue.record("expected a secp256k1 key")
+      return
+    }
+    let uncompressed = try underlying.uncompressedBytes
+    #expect(uncompressed.count == 65)
+    #expect(uncompressed.first == 0x04)
+    // The compressed form is the prefix byte plus `x`, so `x` has to agree.
+    #expect(Array(uncompressed.dropFirst().prefix(32)) == Array(key.rawBytes.dropFirst()))
+  }
+
+  @Test func ed25519UsesTheOKPMemberSet() throws {
+    let key = try PrivateKey(type: .ed25519).publicKey
+    #expect(key.rawBytes.count == 32)
+    let expected = PublicKey.thumbprint(members: [
+      ("crv", "Ed25519"),
+      ("kty", "OKP"),
+      ("x", base64URLEncoded(key.rawBytes)),
+    ])
+    #expect(try key.jwkThumbprint == expected)
+  }
+}


### PR DESCRIPTION
This PR adds RFC 7638 JWK thumbprints for AT Protocol signing keys.

- Add `PublicKey.jwkThumbprint`, computing the RFC 7638 JWK thumbprint (base64url, no padding) for `p256`, `secp256k1`, and `ed25519` keys.
- Add an `uncompressedBytes` helper on `P256K.Signing.PublicKey` to read the raw EC coordinates a `secp256k1` thumbprint needs, re-parsing from the compressed encoding the same way `compressed` already does.
- Document `jwkThumbprint` in the `SigningAndVerifying` DocC article, covering how it's used to match a `cnf.jkt` claim against a held key.