### PR TITLE
feat: generate client attestations

### DIFF
--- a/Sources/ATProtoCrypto/ClientAttestation.swift
+++ b/Sources/ATProtoCrypto/ClientAttestation.swift
@@ -1,0 +1,129 @@
+#if !canImport(Darwin)
+  import FoundationEssentials
+#else
+  import Foundation
+#endif
+
+/// A short-lived, single-use JWT an application signs with its own key to tell a
+/// space authority which application is acting.
+///
+/// A space authority that gates on client app identity asks for this alongside
+/// the delegation token that carries the user's delegation. The two are signed
+/// by different parties and evaluated independently: the delegation token says
+/// nothing about the application, and this says nothing about the user.
+///
+/// See <doc:ClientAttestations>.
+public struct ClientAttestation: Sendable, Hashable {
+  /// The application's `client_id`, the URL its client metadata document is
+  /// published at.
+  ///
+  /// This is written to both `iss` and `sub`, which a client assertion requires
+  /// to hold the same value.
+  public let clientID: String
+
+  /// How the space host being asked for a credential is addressed, which is its
+  /// authority's DID with the `#atproto_space_host` fragment.
+  ///
+  /// `SwiftAtproto` derives this from a resolved DID document as
+  /// `DIDDocument.spaceHostAudience`. It is taken as a string here because
+  /// `ATProtoCrypto` does not depend on that module.
+  public let audience: String
+
+  /// The `kid` naming the key within the JWKS the application publishes.
+  ///
+  /// The authority fetches that JWKS to verify the signature, so this has to
+  /// name the public half of the key passed to ``signed(with:)``.
+  public let keyID: String
+
+  /// When the attestation was issued.
+  public let issuedAt: Date
+
+  /// When the attestation stops being accepted.
+  ///
+  /// An attestation is meant to be short-lived — on the order of a minute.
+  public let expiresAt: Date
+
+  /// The `jti` nonce that makes the attestation single-use.
+  ///
+  /// An authority rejects a repeat, so a value must never be reused across
+  /// attestations. ``randomTokenID()`` produces a suitable one.
+  public let tokenID: String
+
+  /// Describes an attestation. Nothing is signed until ``signed(with:)``.
+  ///
+  /// Every claim is supplied by the caller, including the two that a general
+  /// purpose JWT library would fill in on its own: an attestation is short-lived
+  /// and single-use, so its lifetime and its nonce are the caller's to control.
+  public init(
+    clientID: String,
+    audience: String,
+    keyID: String,
+    issuedAt: Date,
+    expiresAt: Date,
+    tokenID: String
+  ) {
+    self.clientID = clientID
+    self.audience = audience
+    self.keyID = keyID
+    self.issuedAt = issuedAt
+    self.expiresAt = expiresAt
+    self.tokenID = tokenID
+  }
+
+  /// Signs the attestation with `key`, returning it as a compact JWS.
+  ///
+  /// ``keyID`` has to name `key`'s public half in the JWKS the application
+  /// publishes; that pairing is not checked here, because this module has no way
+  /// to see the JWKS.
+  ///
+  /// ``issuedAt`` and ``expiresAt`` become `iat` and `exp`, which JWT spells as
+  /// whole seconds since the Unix epoch, so any sub-second part is truncated.
+  ///
+  /// - Throws: whatever ``PrivateKey/sign(_:)`` throws for `key`'s type.
+  public func signed(with key: PrivateKey) throws -> String {
+    try compactJWS(
+      header: Header(alg: key.type.jwsAlgorithm, kid: keyID),
+      payload: Payload(
+        aud: audience,
+        exp: Int(expiresAt.timeIntervalSince1970),
+        iat: Int(issuedAt.timeIntervalSince1970),
+        iss: clientID,
+        jti: tokenID,
+        sub: clientID),
+      signedWith: key)
+  }
+
+  /// A fresh `jti`: 16 random bytes as lowercase hexadecimal.
+  ///
+  /// Each attestation needs its own, so call this once per attestation rather
+  /// than holding onto a value.
+  public static func randomTokenID() -> String {
+    var generator = SystemRandomNumberGenerator()
+    let digits = "0123456789abcdef"
+    var hex = ""
+    hex.reserveCapacity(32)
+    for _ in 0..<16 {
+      let byte: UInt8 = generator.next()
+      hex.append(digits[digits.index(digits.startIndex, offsetBy: Int(byte >> 4))])
+      hex.append(digits[digits.index(digits.startIndex, offsetBy: Int(byte & 0x0F))])
+    }
+    return hex
+  }
+
+  private struct Header: Encodable {
+    // Fixed by the proposal: the same shape as an OAuth client assertion, but
+    // typed so that a space host cannot be handed one addressed elsewhere.
+    let typ = "atproto-client-attestation+jwt"
+    let alg: String
+    let kid: String
+  }
+
+  private struct Payload: Encodable {
+    let aud: String
+    let exp: Int
+    let iat: Int
+    let iss: String
+    let jti: String
+    let sub: String
+  }
+}

--- a/Sources/ATProtoCrypto/Documentation.docc/ATProtoCrypto.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/ATProtoCrypto.md
@@ -29,6 +29,11 @@ key.publicKey.did                                                   // "did:key:
 - ``PrivateKey``
 - ``PublicKey``
 
+### Credentials
+
+- <doc:ClientAttestations>
+- ``ClientAttestation``
+
 ### Identifiers
 
 - ``DID``

--- a/Sources/ATProtoCrypto/Documentation.docc/Articles/ClientAttestations.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/Articles/ClientAttestations.md
@@ -1,0 +1,92 @@
+# Client attestations
+
+Sign the JWT that tells a space authority which application is asking.
+
+## Overview
+
+Permissioned data separates two questions an authority has to answer before it
+issues a space credential: *which user* is being acted for, and *which
+application* is acting. A delegation token, signed by the user's PDS, answers the
+first. A **client attestation**, signed by the application itself, answers the
+second. They are presented together but signed by different parties and
+evaluated independently.
+
+Only spaces that gate on client app identity ask for an attestation. A space open
+to any application does not, which is what lets public clients — the ones with no
+key to sign with — reach it at all.
+
+An attestation is structurally a `private_key_jwt` client assertion, the same
+shape an AT Protocol confidential client already presents to its authorization
+server. The difference is where it is addressed: a space host rather than an
+authorization server, named by the `#atproto_space_host` entry of the authority's
+DID document.
+
+## Building one
+
+``ClientAttestation`` holds the claims; ``ClientAttestation/signed(with:)``
+encodes and signs them:
+
+```swift
+let now = Date()
+let attestation = ClientAttestation(
+  clientID: "https://app.example.com/client-metadata.json",
+  audience: "did:example:space_did#atproto_space_host",
+  keyID: "key-1",
+  issuedAt: now,
+  expiresAt: now.addingTimeInterval(60),
+  tokenID: ClientAttestation.randomTokenID())
+
+let jwt = try attestation.signed(with: key)
+```
+
+``ClientAttestation/clientID`` is the URL the application publishes its client
+metadata at. It is written to both `iss` and `sub`, which a client assertion
+requires to carry the same value, so there is no way to make the two disagree.
+
+``ClientAttestation/audience`` names the space host. `SwiftAtproto` derives it
+from a resolved DID document as `DIDDocument.spaceHostAudience`, which is always
+that document's DID with the `#atproto_space_host` fragment, whether or not the
+document declares such an entry. It is taken as a string here because
+`ATProtoCrypto` does not depend on that module.
+
+``ClientAttestation/keyID`` becomes the `kid` header. The authority resolves
+``ClientAttestation/clientID`` to the client metadata document, fetches the JWKS
+it publishes, and verifies the signature against the key that `kid` names — so it
+has to name the public half of the key passed to
+``ClientAttestation/signed(with:)``. That pairing cannot be checked here, because
+this module never sees the JWKS.
+
+## Lifetime and replay
+
+An attestation is short-lived and single-use, so neither its lifetime nor its
+nonce is filled in for you:
+
+- ``ClientAttestation/issuedAt`` and ``ClientAttestation/expiresAt`` become `iat`
+  and `exp`. A minute is a typical span. JWT spells both as whole seconds since
+  the Unix epoch, so a sub-second part is truncated.
+- ``ClientAttestation/tokenID`` becomes `jti`, the nonce an authority remembers
+  in order to reject a repeat. Never reuse one.
+  ``ClientAttestation/randomTokenID()`` produces a fresh value: 16 random bytes
+  as lowercase hexadecimal.
+
+## Algorithms
+
+The `alg` header comes from the signing key rather than the caller, through
+``KeyType/jwsAlgorithm``:
+
+| ``KeyType`` | `alg` |
+|-------------|-------|
+| ``KeyType/p256`` | `ES256` |
+| ``KeyType/secp256k1`` | `ES256K` |
+| ``KeyType/ed25519`` | `EdDSA` |
+
+``PrivateKey/sign(_:)`` already produces what each of these requires: the two
+ECDSA cases hash with SHA-256 and return the 64-byte `r‖s` concatenation JWS
+asks for, and Ed25519 signs the message directly.
+
+## What is not here
+
+Verifying an attestation is the authority's side of the exchange — resolving a
+`client_id` to its metadata, fetching a JWKS over the network, and checking a
+signature against a key found there. This module signs; it makes no network
+requests and does not verify what someone else signed.

--- a/Sources/ATProtoCrypto/JWS.swift
+++ b/Sources/ATProtoCrypto/JWS.swift
@@ -1,0 +1,48 @@
+#if !canImport(Darwin)
+  import FoundationEssentials
+#else
+  import Foundation
+#endif
+
+extension KeyType {
+  /// The JOSE algorithm identifier for this key type, as a JWS header spells it
+  /// in its `alg` member.
+  ///
+  /// `secp256k1` is `ES256K` (RFC 8812) rather than the `ES256` that names the
+  /// P-256 curve, so the two ECDSA cases are not interchangeable even though
+  /// both hash with SHA-256 and both produce a 64-byte signature.
+  public var jwsAlgorithm: String {
+    switch self {
+    case .secp256k1: "ES256K"
+    case .p256: "ES256"
+    case .ed25519: "EdDSA"
+    }
+  }
+}
+
+/// Serializes `header` and `payload` as a compact JWS signed with `key`.
+///
+/// The result is the three base64url segments JOSE prescribes, joined by dots.
+func compactJWS(
+  header: some Encodable,
+  payload: some Encodable,
+  signedWith key: PrivateKey
+) throws -> String {
+  let encoder = JSONEncoder()
+  // A `client_id` is a URL, and the default escapes every `/` in it as `\/`.
+  // That is legal JSON, but it makes the encoded segment differ from what every
+  // other implementation emits for the same claims. Sorting the keys is not
+  // required — a JWS member set is unordered — but it makes the segments
+  // reproducible for a given set of claims.
+  encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+
+  let signingInput =
+    "\(base64URLEncoded(try encoder.encode(header))).\(base64URLEncoded(try encoder.encode(payload)))"
+
+  // `PrivateKey.sign(_:)` already returns what JWS asks for on all three key
+  // types: the two ECDSA cases hash with SHA-256 internally and return the
+  // 64-byte `r‖s` concatenation that ES256 and ES256K require, and Ed25519
+  // signs the message directly as EdDSA does. No re-encoding is needed here.
+  let signature = try key.sign(Data(signingInput.utf8))
+  return "\(signingInput).\(base64URLEncoded(signature))"
+}

--- a/Tests/ATProtoCryptoTests/ClientAttestationTests.swift
+++ b/Tests/ATProtoCryptoTests/ClientAttestationTests.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Testing
+
+@testable import ATProtoCrypto
+
+struct ClientAttestationTests {
+  // The worked example in the permissioned data proposal. `iat` and `exp` are
+  // pinned so the encoded claims are reproducible.
+  private static let clientID = "https://app.example.com/client-metadata.json"
+  private static let audience = "did:example:space_did#atproto_space_host"
+  private static let issuedAt = Date(timeIntervalSince1970: 1_738_368_000)
+  private static let expiresAt = Date(timeIntervalSince1970: 1_738_368_060)
+  private static let tokenID = "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8"
+
+  private func attestation(keyID: String = "key-1") -> ClientAttestation {
+    ClientAttestation(
+      clientID: Self.clientID,
+      audience: Self.audience,
+      keyID: keyID,
+      issuedAt: Self.issuedAt,
+      expiresAt: Self.expiresAt,
+      tokenID: Self.tokenID)
+  }
+
+  // `KeyType` is not `Sendable`, so these iterate a local list rather than going
+  // through `@Test(arguments:)`.
+  private var keyTypes: [KeyType] { [.p256, .secp256k1, .ed25519] }
+
+  // MARK: - Claims
+
+  @Test func matchesTheProposalExample() throws {
+    let key = try PrivateKey(type: .p256)
+    let jwt = try attestation().signed(with: key)
+
+    #expect(try memberNames(of: jwt, 0) == ["alg", "kid", "typ"])
+    #expect(
+      try header(of: jwt)
+        == DecodedHeader(
+          typ: "atproto-client-attestation+jwt",
+          alg: "ES256",
+          kid: "key-1"))
+
+    #expect(try memberNames(of: jwt, 1) == ["aud", "exp", "iat", "iss", "jti", "sub"])
+    #expect(
+      try payload(of: jwt)
+        == DecodedPayload(
+          iss: Self.clientID,
+          sub: Self.clientID,
+          aud: Self.audience,
+          iat: 1_738_368_000,
+          exp: 1_738_368_060,
+          jti: Self.tokenID))
+  }
+
+  // A client assertion identifies the client in both claims, so there is no
+  // input that can make them disagree.
+  @Test func issuerAndSubjectAreBothTheClientID() throws {
+    let jwt = try attestation().signed(with: PrivateKey(type: .p256))
+    let claims = try payload(of: jwt)
+    #expect(claims.iss == Self.clientID)
+    #expect(claims.sub == Self.clientID)
+  }
+
+  @Test func carriesTheCallersNonceAndExpiry() throws {
+    let attestation = ClientAttestation(
+      clientID: Self.clientID,
+      audience: Self.audience,
+      keyID: "key-1",
+      issuedAt: Date(timeIntervalSince1970: 1_700_000_000),
+      expiresAt: Date(timeIntervalSince1970: 1_700_000_030),
+      tokenID: "a-caller-supplied-nonce")
+    let claims = try payload(of: attestation.signed(with: PrivateKey(type: .p256)))
+    #expect(claims.jti == "a-caller-supplied-nonce")
+    #expect(claims.exp == 1_700_000_030)
+    #expect(claims.iat == 1_700_000_000)
+  }
+
+  // JWT spells `iat` and `exp` as whole seconds, so a `Date` carrying a
+  // fractional part has to lose it rather than encode as a decimal.
+  @Test func truncatesSubSecondTimestamps() throws {
+    let attestation = ClientAttestation(
+      clientID: Self.clientID,
+      audience: Self.audience,
+      keyID: "key-1",
+      issuedAt: Date(timeIntervalSince1970: 1_700_000_000.75),
+      expiresAt: Date(timeIntervalSince1970: 1_700_000_030.75),
+      tokenID: Self.tokenID)
+    let claims = try payload(of: attestation.signed(with: PrivateKey(type: .p256)))
+    #expect(claims.iat == 1_700_000_000)
+    #expect(claims.exp == 1_700_000_030)
+  }
+
+  // The `client_id` is a URL, and escaping its slashes would still parse but
+  // would not match the bytes any other implementation produces.
+  @Test func doesNotEscapeSlashesInTheClientID() throws {
+    let jwt = try attestation().signed(with: PrivateKey(type: .p256))
+    let segment = try #require(decodedSegment(jwt, 1))
+    let json = try #require(String(data: segment, encoding: .utf8))
+    #expect(json.contains(Self.clientID))
+    #expect(!json.contains("\\/"))
+  }
+
+  // MARK: - Algorithms
+
+  @Test func namesTheJOSEAlgorithmForEachKeyType() {
+    #expect(KeyType.p256.jwsAlgorithm == "ES256")
+    #expect(KeyType.secp256k1.jwsAlgorithm == "ES256K")
+    #expect(KeyType.ed25519.jwsAlgorithm == "EdDSA")
+  }
+
+  @Test func headerCarriesTheAlgorithmOfTheSigningKey() throws {
+    for type in keyTypes {
+      let jwt = try attestation().signed(with: PrivateKey(type: type))
+      #expect(try header(of: jwt).alg == type.jwsAlgorithm)
+    }
+  }
+
+  // MARK: - Signature
+
+  @Test func verifiesAgainstTheMatchingPublicKey() throws {
+    for type in keyTypes {
+      let key = try PrivateKey(type: type)
+      let jwt = try attestation().signed(with: key)
+      let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+      let signingInput = Data(segments[0..<2].joined(separator: ".").utf8)
+      let signature = try #require(decodedSegment(jwt, 2))
+      #expect(key.publicKey.isValidSignature(signature: signature, for: signingInput))
+
+      let other = try PrivateKey(type: type).publicKey
+      #expect(!other.isValidSignature(signature: signature, for: signingInput))
+    }
+  }
+
+  @Test func isThreeUnpaddedBase64URLSegments() throws {
+    for type in keyTypes {
+      let jwt = try attestation().signed(with: PrivateKey(type: type))
+      let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+      #expect(segments.count == 3)
+      #expect(segments.allSatisfy { !$0.isEmpty })
+      #expect(!jwt.contains("+"))
+      #expect(!jwt.contains("/"))
+      #expect(!jwt.contains("="))
+    }
+  }
+
+  // MARK: - Nonces
+
+  @Test func randomTokenIDIsHexAndDoesNotRepeat() {
+    let tokenID = ClientAttestation.randomTokenID()
+    #expect(tokenID.count == 32)
+    #expect(tokenID.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    #expect(tokenID != ClientAttestation.randomTokenID())
+  }
+
+  // MARK: - Helpers
+
+  // `ATProtoCrypto` only encodes base64url — reading a token back is the job of
+  // the introspection side, in `SwiftAtproto` — so the tests decode their own.
+  private func decodedSegment(_ jwt: String, _ index: Int) -> Data? {
+    let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+    guard segments.indices.contains(index) else { return nil }
+    var base64 = segments[index].replacingOccurrences(of: "-", with: "+")
+      .replacingOccurrences(of: "_", with: "/")
+    base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+    return Data(base64Encoded: base64)
+  }
+
+  private struct DecodedHeader: Decodable, Equatable {
+    let typ: String
+    let alg: String
+    let kid: String
+  }
+
+  private struct DecodedPayload: Decodable, Equatable {
+    let iss: String
+    let sub: String
+    let aud: String
+    let iat: Int
+    let exp: Int
+    let jti: String
+  }
+
+  private func header(of jwt: String) throws -> DecodedHeader {
+    try JSONDecoder().decode(DecodedHeader.self, from: #require(decodedSegment(jwt, 0)))
+  }
+
+  private func payload(of jwt: String) throws -> DecodedPayload {
+    try JSONDecoder().decode(DecodedPayload.self, from: #require(decodedSegment(jwt, 1)))
+  }
+
+  // The two decoders above ignore any member they do not name, so the member
+  // sets are checked separately. This reads the names alone rather than decoding
+  // the values as `Any`, which would compare JSON numbers through a box whose
+  // type differs between Darwin and swift-corelibs-foundation.
+  private struct MemberNames: Decodable {
+    let sorted: [String]
+
+    private struct AnyKey: CodingKey {
+      let stringValue: String
+      var intValue: Int? { nil }
+      init?(stringValue: String) { self.stringValue = stringValue }
+      init?(intValue: Int) { nil }
+    }
+
+    init(from decoder: any Decoder) throws {
+      sorted = try decoder.container(keyedBy: AnyKey.self).allKeys.map(\.stringValue).sorted()
+    }
+  }
+
+  private func memberNames(of jwt: String, _ index: Int) throws -> [String] {
+    try JSONDecoder().decode(MemberNames.self, from: #require(decodedSegment(jwt, index))).sorted
+  }
+}


### PR DESCRIPTION
This PR adds `ClientAttestation`, which builds and signs the short-lived, single-use JWT an application presents to a space authority to identify itself. It also adds `KeyType.jwsAlgorithm` so the `alg` header comes from the signing key rather than the caller, mapping the three key types onto `ES256`, `ES256K`, and `EdDSA`.