### PR TITLE
test: replace third-party NSID fixtures with example authorities

### DIFF
--- a/Tests/SwiftAtprotoLexTests/SchemaPrefixTests.swift
+++ b/Tests/SwiftAtprotoLexTests/SchemaPrefixTests.swift
@@ -6,17 +6,17 @@ import XCTest
 final class SchemaPrefixTests: XCTestCase {
   func testDerivePrefixKeepsAuthorityForFourSegmentIds() {
     XCTAssertEqual(Schema.derivePrefix(from: "com.atproto.repo.strongRef"), "com.atproto")
-    XCTAssertEqual(Schema.derivePrefix(from: "app.bsky.feed.like"), "app.bsky")
-    XCTAssertEqual(Schema.derivePrefix(from: "sh.tangled.repo.knots"), "sh.tangled")
+    XCTAssertEqual(Schema.derivePrefix(from: "org.example.feed.like"), "org.example")
+    XCTAssertEqual(Schema.derivePrefix(from: "com.example.repo.knots"), "com.example")
   }
 
   func testDerivePrefixDropsSingleSegmentForShortIds() {
-    XCTAssertEqual(Schema.derivePrefix(from: "sh.tangled.string"), "sh.tangled")
+    XCTAssertEqual(Schema.derivePrefix(from: "com.example.string"), "com.example")
     XCTAssertEqual(Schema.derivePrefix(from: "com.example"), "com")
   }
 
   func testDerivePrefixDropsTwoSegmentsForDeeperIds() {
-    XCTAssertEqual(Schema.derivePrefix(from: "sh.tangled.git.temp.getEntry"), "sh.tangled.git")
+    XCTAssertEqual(Schema.derivePrefix(from: "com.example.git.temp.getEntry"), "com.example.git")
   }
 
   func testDerivePrefixHandlesShortIds() {

--- a/Tests/SwiftAtprotoTests/LexiconBytesTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconBytesTests.swift
@@ -74,6 +74,27 @@ private enum RawBinaryProcedure: XRPCProcedure {
   typealias Error = UnExpectedError
 }
 
+// The wire form is the point, so `$bytes` stays a `String` here. Decoding it
+// through `xrpcDecoder()` would turn it back into `Data` and hide the encoding
+// under test.
+private struct EncodedBytesRecord: Decodable, Equatable {
+  let type: String
+  let tag: EncodedBytes
+
+  struct EncodedBytes: Decodable, Equatable {
+    let bytes: String
+
+    enum CodingKeys: String, CodingKey {
+      case bytes = "$bytes"
+    }
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case type = "$type"
+    case tag
+  }
+}
+
 private final class BytesRequestRecorder: @unchecked Sendable {
   var lastRequest: XRPCRequestComponents?
 }
@@ -200,12 +221,9 @@ struct LexiconBytesTests {
 
     let request = try #require(recorder.lastRequest)
     let body = try #require(request.body)
-    let requestObject = try #require(
-      JSONSerialization.jsonObject(with: body) as? [String: Any]
-    )
-    let requestTag = try #require(requestObject["tag"] as? [String: String])
-    #expect(requestObject["$type"] as? String == "com.example.repo.artifact")
-    #expect(requestTag == ["$bytes": "AQID"])
+    let sent = try JSONDecoder().decode(EncodedBytesRecord.self, from: body)
+    #expect(sent.type == GeneratedBytesRecord.nsId)
+    #expect(sent.tag == EncodedBytesRecord.EncodedBytes(bytes: "AQID"))
     #expect(response.tag == Data([0x04, 0x05, 0x06]))
   }
 

--- a/Tests/SwiftAtprotoTests/LexiconBytesTests.swift
+++ b/Tests/SwiftAtprotoTests/LexiconBytesTests.swift
@@ -4,7 +4,7 @@ import Testing
 @testable import SwiftAtproto
 
 private struct GeneratedBytesRecord: ATProtoRecord {
-  static let nsId = "sh.tangled.repo.artifact"
+  static let nsId = "com.example.repo.artifact"
 
   let type: String
   let tag: Data
@@ -59,7 +59,7 @@ private struct ConstrainedBytesRecord: Codable, Hashable, Sendable {
 }
 
 private enum BytesProcedure: XRPCProcedure {
-  static let id = "sh.tangled.repo.putArtifact"
+  static let id = "com.example.repo.putArtifact"
   static let contentType = "application/json"
   typealias RequestBody = GeneratedBytesRecord
   typealias ResponseBody = GeneratedBytesRecord
@@ -157,7 +157,7 @@ struct LexiconBytesTests {
 
     #expect(
       String(decoding: encoded, as: UTF8.self)
-        == #"{"$type":"sh.tangled.repo.artifact","tag":{"$bytes":"AQID"}}"#
+        == #"{"$type":"com.example.repo.artifact","tag":{"$bytes":"AQID"}}"#
     )
     #expect(try xrpcDecoder().decode(GeneratedBytesRecord.self, from: encoded) == record)
   }
@@ -186,7 +186,7 @@ struct LexiconBytesTests {
 
   @Test func xrpcRequestAndResponseUseCanonicalBytesForm() async throws {
     let responseJSON =
-      #"{"$type":"sh.tangled.repo.artifact","tag":{"$bytes":"BAUG"}}"#
+      #"{"$type":"com.example.repo.artifact","tag":{"$bytes":"BAUG"}}"#
     let recorder = BytesRequestRecorder()
     let client = BytesTestClient(
       responseData: Data(responseJSON.utf8),
@@ -204,7 +204,7 @@ struct LexiconBytesTests {
       JSONSerialization.jsonObject(with: body) as? [String: Any]
     )
     let requestTag = try #require(requestObject["tag"] as? [String: String])
-    #expect(requestObject["$type"] as? String == "sh.tangled.repo.artifact")
+    #expect(requestObject["$type"] as? String == "com.example.repo.artifact")
     #expect(requestTag == ["$bytes": "AQID"])
     #expect(response.tag == Data([0x04, 0x05, 0x06]))
   }


### PR DESCRIPTION
This PR replaces the `sh.tangled` and `app.bsky` NSIDs used as test fixtures with reserved `example` authorities. It also reads the recorded XRPC request body through a private `Decodable` struct instead of casting an untyped `JSONSerialization` result.