### PR TITLE
fix: read the lexicon id through Codable and report why a file was skipped

### DIFF
--- a/Sources/SourceControl/misc.swift
+++ b/Sources/SourceControl/misc.swift
@@ -97,16 +97,20 @@ func collectLexiconJSONFiles(under baseURL: URL) throws -> [URL] {
   return results.sorted { $0.path < $1.path }
 }
 
-// Extract the top-level `id` string from a lexicon JSON without materializing
-// the full Codable graph — SourceControl doesn't own the lexicon schema, so we
-// keep the read defensive and skip files where `id` is missing or not a string.
-func readLexiconNSID(at url: URL) throws -> NSID? {
+// Only `id` is read, so the rest of the schema stays out of SourceControl,
+// which doesn't own it.
+private struct LexiconIdentity: Decodable {
+  let id: String
+}
+
+// Read the NSID a lexicon declares. `id` is required — the Lexicon spec makes it
+// mandatory and SwiftAtprotoLex's own Schema decodes it the same way — so a file
+// without one is not a lexicon and this throws rather than reporting it as an
+// absence. Deciding what to do about that is the caller's, not this function's.
+func readLexiconNSID(at url: URL) throws -> NSID {
   let data = try Data(contentsOf: url)
-  let object = try? JSONSerialization.jsonObject(with: data)
-  guard let dict = object as? [String: Any], let id = dict["id"] as? String else {
-    return nil
-  }
-  return NSID(rawValue: id)
+  let identity = try JSONDecoder().decode(LexiconIdentity.self, from: data)
+  return NSID(rawValue: identity.id)
 }
 
 // Reject `..`, `.`, and absolute paths in any lexicon-supplied sub-path so a
@@ -273,11 +277,16 @@ public func main(configurationURL: URL, outdir: String?) throws -> LexiconConfig
       // migration on the caller's side.
       var idIndex: [String: URL] = [:]
       for srcURL in try collectLexiconJSONFiles(under: srcBaseURL) {
-        guard let nsId = try readLexiconNSID(at: srcURL) else {
+        let nsId: NSID
+        do {
+          nsId = try readLexiconNSID(at: srcURL)
+        } catch {
+          // `path` is walked for every `*.json`, so a file that was never a
+          // lexicon can legitimately turn up here. Skip it rather than failing
+          // the install, but carry the error: without it a malformed lexicon
+          // and an unrelated file produce the same silent warning.
           FileHandle.standardError.write(
-            Data(
-              "warning: skipping \(srcURL.path()): JSON does not carry a top-level `id` string.\n"
-                .utf8))
+            Data("warning: skipping \(srcURL.path()): \(error)\n".utf8))
           continue
         }
         idIndex[nsId.rawValue] = srcURL

--- a/Tests/SourceControlTests/LocalLexiconInstallTests.swift
+++ b/Tests/SourceControlTests/LocalLexiconInstallTests.swift
@@ -378,6 +378,72 @@
       let attrs = try FileManager.default.attributesOfItem(atPath: installed.path)
       #expect(attrs[.type] as? FileAttributeType == .typeSymbolicLink)
     }
+
+    // MARK: - Reading the declared NSID
+
+    @Test func readsTheDeclaredNSID() throws {
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let lexFile = root.appendingPathComponent("post.json")
+      try Self.writeLexicon(at: lexFile, id: "com.example.feed.post")
+
+      #expect(try readLexiconNSID(at: lexFile).rawValue == "com.example.feed.post")
+    }
+
+    // `id` is required by the Lexicon spec, so each of these is a malformed
+    // lexicon rather than a lexicon that happens to lack an id. Reporting them
+    // as an absence would make them indistinguishable from an unrelated file.
+    @Test(arguments: [
+      #"{"lexicon":1,"defs":{}}"#,
+      #"{"lexicon":1,"id":42,"defs":{}}"#,
+      #"{"lexicon":1,"id":null,"defs":{}}"#,
+      #"["com.example.feed.post"]"#,
+      #"{"lexicon":1,"id":"#,
+    ])
+    func rejectsJSONThatDoesNotDeclareAnNSID(_ json: String) throws {
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let lexFile = root.appendingPathComponent("candidate.json")
+      try Data(json.utf8).write(to: lexFile)
+
+      #expect(throws: (any Error).self) {
+        try readLexiconNSID(at: lexFile)
+      }
+    }
+
+    @Test func skipsUnreadableJSONWithoutFailingTheInstall() throws {
+      // `path` is walked for every `*.json`, so a file that is not a lexicon can
+      // sit alongside the ones that are. It gets skipped with a warning and the
+      // rest still install.
+      let root = try Self.makeTempRoot()
+      defer { try? FileManager.default.removeItem(at: root) }
+      let project = root.appendingPathComponent("proj", isDirectory: true)
+      let source = root.appendingPathComponent("lex-src", isDirectory: true)
+      try FileManager.default.createDirectory(at: project, withIntermediateDirectories: true)
+      try Self.writeLexicon(at: source.appendingPathComponent("lexicons/com/example/feed/post.json"), id: "com.example.feed.post")
+      let stray = source.appendingPathComponent("lexicons/com/example/feed/notes.json")
+      try Data(#"{"note":"not a lexicon"}"#.utf8).write(to: stray)
+
+      let configURL = project.appendingPathComponent(".atproto.json")
+      let body = """
+        {
+          "generate": ["client"],
+          "dependencies": [{
+            "location": "file://\(source.path)",
+            "lexicons": [{ "path": "lexicons" }],
+            "state": { "tag": "local" }
+          }]
+        }
+        """
+      try body.write(to: configURL, atomically: true, encoding: .utf8)
+
+      _ = try main(configurationURL: configURL, outdir: nil)
+
+      let installed = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/post.json")
+      #expect(FileManager.default.fileExists(atPath: installed.path))
+      let strayInstalled = project.appendingPathComponent(".lexicons/lexicons/com/example/feed/notes.json")
+      #expect(!FileManager.default.fileExists(atPath: strayInstalled.path))
+    }
   }
 
 #endif


### PR DESCRIPTION
This PR reads the `id` a lexicon declares through a `Decodable` struct instead of casting an untyped `JSONSerialization` result, so a malformed lexicon now throws rather than being reported as a file that carries no id. The installer still skips such a file instead of failing, but the warning it prints now carries the decoding error.