### PR TITLE
feat: introspect space tokens without verifying signatures

### DIFF
--- a/Sources/SwiftAtproto/Documentation.docc/Articles/SpaceAuthorities.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/SpaceAuthorities.md
@@ -53,7 +53,8 @@ misconfigured one would send space-host traffic to the PDS.
 Verification is the other direction and does not fall back. A space token names
 the key that signed it in its `kid`, so
 ``DIDDocument/spaceSigningKey(keyId:)`` resolves that key and treats a missing
-entry as an error. Only `atproto` and `atproto_space` are accepted.
+entry as an error. Only `atproto` and `atproto_space` are accepted. Getting that
+`kid` out of a token in the first place is <doc:SpaceCredentials>.
 
 ## Addressing
 

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/SpaceCredentials.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/SpaceCredentials.md
@@ -1,0 +1,126 @@
+# Reading space credentials
+
+Read what a space token says without pretending to know that it is genuine.
+
+## Overview
+
+> Important: Space credentials come from the permissioned data proposal, not from
+> the ratified AT Protocol.
+
+Permissioned data introduces three JWT credential classes. An application signs
+one of them itself and receives the other two, and what it does with each one
+depends on reading a handful of claims out of it.
+
+| Credential | Signed by | The application |
+|------------|-----------|-----------------|
+| delegation token | the user's PDS | forwards it to the space authority |
+| client attestation | the application | signs it and sends it |
+| space credential | the space authority | holds it and reads it |
+
+``UnverifiedSpaceCredential``, ``UnverifiedSpaceDelegationToken``, and
+``UnverifiedClientAttestation`` each take a compact JWT and give back its claims:
+
+```swift
+let credential = try UnverifiedSpaceCredential(introspecting: jwt)
+
+credential.issuer              // DID — the space authority
+credential.space               // SpaceRef — the space it reads
+credential.boundKeyThumbprint  // String — the key it is bound to
+credential.expiresAt           // Date
+```
+
+## Nothing here is verified
+
+Reading a token establishes only that it is well-formed. It says nothing about
+who signed it, because checking that means resolving the issuer to a DID
+document, taking the key the token names, and testing the signature against it —
+a network round trip and a decision that belongs to the service the token is
+addressed to, not to the party holding it.
+
+That is why every type is named `Unverified…` and every initializer is labelled
+`introspecting:`: a value read out of a token must never be mistaken at a call
+site for one that was verified.
+
+``UnverifiedSpaceCredential/keyID`` is the near end of the verifying side. It
+carries the token's `kid`, which
+``DIDDocument/spaceSigningKey(keyId:)`` resolves to the entry that published the
+key. Turning that entry into a key means handing its `publicKeyMultibase` to
+`ATProtoCrypto`, which this module does not depend on. See
+<doc:SpaceAuthorities> for the resolution rules.
+
+## What each class requires
+
+The three share a wire shape and differ only in who signs them, who they are
+addressed to, and how long they live:
+
+| Credential | `typ` | `aud` | `cnf.jkt` | `jti` |
+|------------|-------|-------|-----------|-------|
+| delegation token | `atproto-space-delegation+jwt` | required | — | required |
+| client attestation | `atproto-client-attestation+jwt` | required | — | required |
+| space credential | `atproto-space-credential+jwt` | — | required | optional |
+
+`alg`, `iss`, `sub`, and `exp` are required of all three. A missing one throws
+``SpaceTokenError/missingClaim(_:)``; a claim that is present but malformed
+throws the error of its own identifier type, so an `iss` that is not a DID fails
+as ``LexiconStringFormatError`` rather than being smuggled through as a string.
+
+A credential carries no `aud` because it is presented to every repo host serving
+a repo in the space, and no host is named in advance. It is bound to the holder's
+DPoP key instead. It also needs no `jti`: a nonce exists so a recipient can
+refuse a replay, and a credential is meant to be reused.
+
+A client attestation writes the `client_id` into both `iss` and `sub`, so
+``UnverifiedClientAttestation/clientID`` is one property rather than two, and a
+token whose two disagree is rejected with
+``SpaceTokenError/clientIDMismatch``.
+
+## Using a credential
+
+Three questions a holder asks, in the order they come up:
+
+```swift
+// Is it still worth sending?
+credential.isExpired()
+
+// Is it for the space I asked about?
+credential.authorizes(requestedSpace)
+
+// Is it bound to my key?
+credential.isBound(toKeyThumbprint: myKeyThumbprint)
+```
+
+``UnverifiedSpaceCredential/isExpired(at:clockSkew:)`` applies five seconds of
+clock skew by default, and it applies them in the permissive direction: the
+credential still counts as live for five seconds past
+``UnverifiedSpaceCredential/expiresAt``, so a clock running slightly fast does
+not throw away a credential the issuer considers valid. A holder deciding when to
+renew wants the opposite, and asks for it by passing a negative skew:
+
+```swift
+// Renew a minute before it lapses.
+if credential.isExpired(clockSkew: -60) { … }
+```
+
+``UnverifiedSpaceCredential/isBound(toKeyThumbprint:)`` compares against the RFC
+7638 thumbprint of the holder's own DPoP key, which `ATProtoCrypto` computes.
+Thumbprints are base64url, so the comparison is exact and case-sensitive.
+
+## Keeping credentials out of logs
+
+A credential is a capability. These types are built so that handling one does not
+leak it:
+
+- None of them conforms to `Codable`, so a credential does not fall into a state
+  file by being a stored property of something that does.
+- None of them keeps the JWT it was read from.
+- ``SpaceTokenError`` carries no part of a token, so an error is safe to log.
+- `description` names the space and the expiry and stops. The reflected
+  description Swift would print by default includes `cnf.jkt` and `jti`, which is
+  exactly how a credential reaches a log.
+
+## The other direction
+
+Signing a client attestation is `ATProtoCrypto.ClientAttestation`, in the module
+that holds the keys. The two sides never share a type — they meet as a JWT
+string — so the introspection here works on an attestation regardless of who
+produced it.

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -91,6 +91,13 @@ let posts = try await client.call(
 - ``LexSpace``
 - ``LexRecordKeyType``
 
+### Space credentials
+
+- <doc:SpaceCredentials>
+- ``UnverifiedSpaceCredential``
+- ``UnverifiedSpaceDelegationToken``
+- ``UnverifiedClientAttestation``
+
 ### Event streams
 
 - <doc:Subscriptions>
@@ -129,4 +136,5 @@ let posts = try await client.call(
 - ``LexiconConstraintError``
 - ``LexiconStringFormatError``
 - ``OAuthScopeError``
+- ``SpaceTokenError``
 - ``XRPCSubscriptionStreamError``

--- a/Sources/SwiftAtproto/SpaceToken.swift
+++ b/Sources/SwiftAtproto/SpaceToken.swift
@@ -1,0 +1,364 @@
+import Foundation
+
+// Introspection for the three JWT credential classes of the permissioned data proposal. The
+// `SpaceCredentials` article describes what each one is for and how they fit together.
+//
+// Nothing in this file checks a signature. Doing that means resolving the issuer's DID to a
+// document and testing the signature against a key published there, which is the receiving
+// service's job, not the holder's; a holder only needs to read what it was handed. Every type here
+// is named `Unverified…` and every entry point is labelled `introspecting:` so that a parsed token
+// cannot be mistaken for a verified one at a call site.
+
+/// A failure to read a space token.
+///
+/// A claim that is present but malformed throws the error of its own identifier type instead:
+/// ``LexiconStringFormatError`` for `iss` and `sub`, ``DIDDocument/VerifyError`` for `aud`.
+///
+/// No case carries the token or any part of it, because a credential must not reach a log through
+/// an error message.
+public enum SpaceTokenError: Error, Hashable, Sendable {
+  /// The token is not three base64url segments, a segment is not JSON, or the signature segment is
+  /// empty.
+  case malformed
+  /// The `typ` header names a different credential class than the one being read.
+  case wrongType(expected: String, found: String?)
+  /// A claim this credential class requires is absent or empty. The payload names the claim, e.g.
+  /// `exp` or `cnf.jkt`.
+  case missingClaim(String)
+  /// A client attestation whose `iss` and `sub` disagree. Both are the `client_id`.
+  case clientIDMismatch
+}
+
+// MARK: - Credential classes
+
+/// What separates one credential class from another on the wire.
+///
+/// The three share a shape and differ only in who signs them, who they are addressed to, and how
+/// long they live, so the differences are data here rather than three parsers.
+private struct SpaceTokenSpec {
+  let typ: String
+  let requiresAudience: Bool
+  let requiresBoundKey: Bool
+  /// A single-use token carries the `jti` its recipient remembers in order to refuse a replay. A
+  /// credential is reused across hosts and needs none.
+  let requiresTokenID: Bool
+
+  static let delegation = SpaceTokenSpec(
+    typ: "atproto-space-delegation+jwt",
+    requiresAudience: true,
+    requiresBoundKey: false,
+    requiresTokenID: true)
+
+  static let credential = SpaceTokenSpec(
+    typ: "atproto-space-credential+jwt",
+    requiresAudience: false,
+    requiresBoundKey: true,
+    requiresTokenID: false)
+
+  static let clientAttestation = SpaceTokenSpec(
+    typ: "atproto-client-attestation+jwt",
+    requiresAudience: true,
+    requiresBoundKey: false,
+    requiresTokenID: true)
+}
+
+// MARK: - Shared parsing
+
+/// The claims of a space token as written, with the checks its class prescribes applied and
+/// nothing interpreted yet.
+private struct SpaceTokenClaims {
+  let algorithm: String
+  let keyID: String?
+  let issuer: String
+  let subject: String
+  let audience: String?
+  let issuedAt: Date?
+  let expiresAt: Date
+  let tokenID: String?
+  let boundKeyThumbprint: String?
+}
+
+extension SpaceTokenClaims {
+  private struct Header: Decodable {
+    let alg: String?
+    let typ: String?
+    let kid: String?
+  }
+
+  private struct Payload: Decodable {
+    struct Confirmation: Decodable {
+      let jkt: String?
+    }
+
+    let iss: String?
+    let sub: String?
+    let aud: String?
+    let iat: Int?
+    let exp: Int?
+    let jti: String?
+    let cnf: Confirmation?
+  }
+
+  init(introspecting token: String, as spec: SpaceTokenSpec) throws {
+    // Empty subsequences are kept so that an empty segment fails to decode rather than shifting
+    // the count and turning a malformed token into a differently malformed one.
+    let segments = token.split(separator: ".", omittingEmptySubsequences: false)
+    guard segments.count == 3,
+      let headerData = base64URLDecoded(segments[0]),
+      let payloadData = base64URLDecoded(segments[1]),
+      let signature = base64URLDecoded(segments[2]), !signature.isEmpty
+    else {
+      throw SpaceTokenError.malformed
+    }
+
+    let header: Header
+    let payload: Payload
+    do {
+      let decoder = JSONDecoder()
+      header = try decoder.decode(Header.self, from: headerData)
+      payload = try decoder.decode(Payload.self, from: payloadData)
+    } catch {
+      // The decoding error names a coding path inside the token, so it is dropped rather than
+      // wrapped: an error a caller may log must not carry claims.
+      throw SpaceTokenError.malformed
+    }
+
+    guard header.typ == spec.typ else {
+      throw SpaceTokenError.wrongType(expected: spec.typ, found: header.typ)
+    }
+    guard let algorithm = header.alg?.nonEmpty else { throw SpaceTokenError.missingClaim("alg") }
+    guard let issuer = payload.iss?.nonEmpty else { throw SpaceTokenError.missingClaim("iss") }
+    guard let subject = payload.sub?.nonEmpty else { throw SpaceTokenError.missingClaim("sub") }
+    guard let expiry = payload.exp else { throw SpaceTokenError.missingClaim("exp") }
+
+    let audience = payload.aud?.nonEmpty
+    let thumbprint = payload.cnf?.jkt?.nonEmpty
+    let tokenID = payload.jti?.nonEmpty
+    if spec.requiresAudience, audience == nil { throw SpaceTokenError.missingClaim("aud") }
+    if spec.requiresBoundKey, thumbprint == nil { throw SpaceTokenError.missingClaim("cnf.jkt") }
+    if spec.requiresTokenID, tokenID == nil { throw SpaceTokenError.missingClaim("jti") }
+
+    self.algorithm = algorithm
+    self.issuer = issuer
+    self.subject = subject
+    self.audience = audience
+    self.tokenID = tokenID
+    boundKeyThumbprint = thumbprint
+    keyID = header.kid?.nonEmpty
+    // JWT spells both instants as whole seconds since the Unix epoch.
+    issuedAt = payload.iat.map { Date(timeIntervalSince1970: TimeInterval($0)) }
+    expiresAt = Date(timeIntervalSince1970: TimeInterval(expiry))
+  }
+}
+
+extension String {
+  /// `nil` for the empty string, so that a claim written as `""` reads as absent. An empty `iss`
+  /// names no one, and treating it as a value would let it satisfy a required claim.
+  fileprivate var nonEmpty: String? { isEmpty ? nil : self }
+}
+
+// MARK: - Space credential
+
+/// A space credential as its holder reads it: the claims are parsed, the signature is not checked.
+///
+/// A space authority issues one in exchange for a delegation token, and an application presents it
+/// to every repo host serving a repo in the space until it expires. The holder reads three things
+/// from it — when to renew (``isExpired(at:clockSkew:)``), which space it covers
+/// (``authorizes(_:)``), and which key it is bound to (``isBound(toKeyThumbprint:)``).
+///
+/// - Important: Parsing establishes nothing about who issued this. Verifying the signature means
+///   resolving ``issuer`` to a DID document, taking the key ``keyID`` names, and checking the
+///   signature against it — the receiving service's side of the exchange.
+public struct UnverifiedSpaceCredential: Sendable, Hashable {
+  /// `iss`: the space authority that issued the credential.
+  public let issuer: DID
+  /// `sub`: the space this credential reads.
+  public let space: SpaceRef
+  /// `cnf.jkt`: the JWK thumbprint of the key the credential is bound to. A credential is a
+  /// whole-space capability presented to many hosts, so it is bound to the holder's DPoP key
+  /// rather than being a bearer token.
+  public let boundKeyThumbprint: String
+  /// `iat`, when the credential carries one.
+  public let issuedAt: Date?
+  /// `exp`.
+  public let expiresAt: Date
+  /// `jti`, when the credential carries one. A credential is multi-use, so it need not.
+  public let tokenID: String?
+  /// `alg`: the JOSE algorithm the signature was produced with.
+  public let algorithm: String
+  /// `kid`: the entry in the issuer's DID document that names the signing key. Pass it to
+  /// ``DIDDocument/spaceSigningKey(keyId:)``.
+  public let keyID: String?
+
+  /// Reads a compact JWT as a space credential.
+  ///
+  /// - Throws: ``SpaceTokenError`` when the structure or a required claim is wrong,
+  ///   ``LexiconStringFormatError`` when `iss` is not a DID or `sub` is not a space ref.
+  public init(introspecting token: String) throws {
+    let claims = try SpaceTokenClaims(introspecting: token, as: .credential)
+    issuer = try DID(string: claims.issuer)
+    space = try SpaceRef(string: claims.subject)
+    // The credential spec requires a bound key, so the claims parser has already refused a token
+    // without one — the force-unwrap documents that invariant.
+    boundKeyThumbprint = claims.boundKeyThumbprint!
+    issuedAt = claims.issuedAt
+    expiresAt = claims.expiresAt
+    tokenID = claims.tokenID
+    algorithm = claims.algorithm
+    keyID = claims.keyID
+  }
+}
+
+extension UnverifiedSpaceCredential {
+  /// The tolerance ``isExpired(at:clockSkew:)`` applies unless told otherwise: five seconds.
+  public static let defaultClockSkew: TimeInterval = 5
+
+  /// Whether the credential's lifetime has run out by `instant`.
+  ///
+  /// `clockSkew` widens the window in the permissive direction: the credential still counts as
+  /// live for that long past ``expiresAt``, so a clock running a few seconds fast does not discard
+  /// one the issuer considers valid. A holder deciding when to renew wants the opposite and should
+  /// pass a negative `clockSkew`, or compare against ``expiresAt`` itself.
+  public func isExpired(
+    at instant: Date = Date(), clockSkew: TimeInterval = defaultClockSkew
+  ) -> Bool {
+    instant.addingTimeInterval(-clockSkew) >= expiresAt
+  }
+
+  /// Whether this credential covers `space`.
+  ///
+  /// The check a holder makes against the space it asked for, so that a credential minted for a
+  /// different space is never presented to a repo host.
+  public func authorizes(_ space: SpaceRef) -> Bool {
+    self.space == space
+  }
+
+  /// Whether this credential is bound to the key with `thumbprint`.
+  ///
+  /// `thumbprint` is the RFC 7638 thumbprint of the holder's own DPoP key. It is base64url and
+  /// therefore case-sensitive, so the comparison is exact.
+  public func isBound(toKeyThumbprint thumbprint: String) -> Bool {
+    boundKeyThumbprint == thumbprint
+  }
+}
+
+extension UnverifiedSpaceCredential: CustomStringConvertible {
+  /// Names the space and the expiry and stops there. The default reflected description would print
+  /// ``boundKeyThumbprint`` and ``tokenID``, which is how a credential ends up in a log.
+  public var description: String {
+    "UnverifiedSpaceCredential(space: \(space.rawValue), expiresAt: \(expiresAt))"
+  }
+}
+
+// MARK: - Delegation token
+
+/// A delegation token as a forwarder reads it: the claims are parsed, the signature is not checked.
+///
+/// A user's PDS mints one to assert that an application is acting on that user's behalf, and the
+/// application forwards it to the space authority in exchange for a credential. It is single-use
+/// and short-lived.
+///
+/// - Important: Parsing establishes nothing about who issued this. The authority the token is
+///   addressed to is the party that verifies it.
+public struct UnverifiedSpaceDelegationToken: Sendable, Hashable {
+  /// `iss`: the user delegating.
+  public let issuer: DID
+  /// `sub`: the space the token is bound to.
+  public let space: SpaceRef
+  /// `aud`: the space host the token is addressed to, which is
+  /// ``DIDDocument/spaceHostAudience`` of the authority.
+  public let audience: ServiceIdentifier
+  /// `iat`, when the token carries one.
+  public let issuedAt: Date?
+  /// `exp`.
+  public let expiresAt: Date
+  /// `jti`: the nonce the authority remembers in order to refuse a replay.
+  public let tokenID: String
+  /// `alg`: the JOSE algorithm the signature was produced with.
+  public let algorithm: String
+  /// `kid`: the entry in the issuer's DID document that names the signing key.
+  public let keyID: String?
+
+  /// Reads a compact JWT as a delegation token.
+  ///
+  /// - Throws: ``SpaceTokenError`` when the structure or a required claim is wrong,
+  ///   ``LexiconStringFormatError`` when `iss` is not a DID or `sub` is not a space ref, and
+  ///   ``DIDDocument/VerifyError/invalidServiceIdentifier`` when `aud` is not a service identifier.
+  public init(introspecting token: String) throws {
+    let claims = try SpaceTokenClaims(introspecting: token, as: .delegation)
+    issuer = try DID(string: claims.issuer)
+    space = try SpaceRef(string: claims.subject)
+    // The delegation spec requires both, so the claims parser has already refused a token missing
+    // either — the force-unwraps document that invariant.
+    audience = try ServiceIdentifier(string: claims.audience!)
+    tokenID = claims.tokenID!
+    issuedAt = claims.issuedAt
+    expiresAt = claims.expiresAt
+    algorithm = claims.algorithm
+    keyID = claims.keyID
+  }
+}
+
+extension UnverifiedSpaceDelegationToken: CustomStringConvertible {
+  /// Withholds ``tokenID`` for the reason ``UnverifiedSpaceCredential/description`` withholds its
+  /// own: a replay nonce is not something to print.
+  public var description: String {
+    "UnverifiedSpaceDelegationToken(space: \(space.rawValue), audience: \(audience.rawValue), expiresAt: \(expiresAt))"
+  }
+}
+
+// MARK: - Client attestation
+
+/// A client attestation as a reader parses it: the claims are read, the signature is not checked.
+///
+/// An application signs one of these itself to tell a space authority which application is asking.
+/// Producing one is `ATProtoCrypto.ClientAttestation`; the two sides meet only as a JWT string.
+///
+/// - Important: Parsing establishes nothing about which application signed this. Verifying the
+///   signature means resolving ``clientID`` to its metadata document, fetching the JWKS it
+///   publishes, and checking the signature against the key ``keyID`` names — all of it the
+///   authority's side of the exchange, and none of it possible without network access.
+public struct UnverifiedClientAttestation: Sendable, Hashable {
+  /// The `client_id` the application publishes its metadata at. `iss` and `sub` both carry it, and
+  /// an attestation whose two disagree is rejected, so there is one value here rather than two.
+  public let clientID: String
+  /// `aud`: the space host the attestation is addressed to.
+  public let audience: ServiceIdentifier
+  /// `iat`, when the attestation carries one.
+  public let issuedAt: Date?
+  /// `exp`.
+  public let expiresAt: Date
+  /// `jti`: the nonce the authority remembers in order to refuse a replay.
+  public let tokenID: String
+  /// `alg`: the JOSE algorithm the signature was produced with.
+  public let algorithm: String
+  /// `kid`: the key in the client's published JWKS that signed the attestation.
+  public let keyID: String?
+
+  /// Reads a compact JWT as a client attestation.
+  ///
+  /// - Throws: ``SpaceTokenError`` when the structure or a required claim is wrong — including
+  ///   ``SpaceTokenError/clientIDMismatch`` when `iss` and `sub` disagree — and
+  ///   ``DIDDocument/VerifyError/invalidServiceIdentifier`` when `aud` is not a service identifier.
+  public init(introspecting token: String) throws {
+    let claims = try SpaceTokenClaims(introspecting: token, as: .clientAttestation)
+    guard claims.issuer == claims.subject else { throw SpaceTokenError.clientIDMismatch }
+    clientID = claims.issuer
+    // The attestation spec requires both, so the claims parser has already refused a token missing
+    // either — the force-unwraps document that invariant.
+    audience = try ServiceIdentifier(string: claims.audience!)
+    tokenID = claims.tokenID!
+    issuedAt = claims.issuedAt
+    expiresAt = claims.expiresAt
+    algorithm = claims.algorithm
+    keyID = claims.keyID
+  }
+}
+
+extension UnverifiedClientAttestation: CustomStringConvertible {
+  /// Withholds ``tokenID`` for the reason ``UnverifiedSpaceCredential/description`` withholds its
+  /// own: a replay nonce is not something to print.
+  public var description: String {
+    "UnverifiedClientAttestation(clientID: \(clientID), audience: \(audience.rawValue), expiresAt: \(expiresAt))"
+  }
+}

--- a/Sources/SwiftAtproto/_Base64URL.swift
+++ b/Sources/SwiftAtproto/_Base64URL.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+// base64url is the only encoding JOSE spells its segments in, and this module had no decoder for
+// it. Neither of the two nearby candidates fits:
+//
+//   - the base64 in `JSONEncoder+XRPC.swift` uses the standard alphabet the Lexicon `bytes` type is
+//     written in, which a JOSE segment must not carry;
+//   - `Base64` reaches the build graph transitively through `CID`, but it is not a declared
+//     dependency of this target, and its `.url` variant is padding-tolerant and decodes `+` and `/`
+//     as well — the two things RFC 7515 forbids a segment to contain.
+
+/// Decodes an unpadded URL-safe base64 string, or `nil` when `string` is not one.
+///
+/// Strict on purpose. JOSE writes every segment with the URL-safe alphabet and no padding, so `+`,
+/// `/`, and `=` are rejected rather than quietly accepted: a token that only this decoder can read
+/// is a token no peer can.
+func base64URLDecoded(_ string: some StringProtocol) -> Data? {
+  var standard = ""
+  standard.reserveCapacity(string.utf8.count + 2)
+  for byte in string.utf8 {
+    switch byte {
+    case UInt8(ascii: "-"):
+      standard.append("+")
+    case UInt8(ascii: "_"):
+      standard.append("/")
+    case let byte where isAlphanumeric(byte):
+      standard.append(Character(UnicodeScalar(byte)))
+    default:
+      return nil
+    }
+  }
+
+  // A base64 quantum is 2, 3, or 4 characters wide; a remainder of 1 encodes no whole byte and so
+  // cannot be the tail of anything that was encoded.
+  switch standard.utf8.count % 4 {
+  case 0: break
+  case 2: standard += "=="
+  case 3: standard += "="
+  default: return nil
+  }
+  return Data(base64Encoded: standard)
+}

--- a/Tests/SwiftAtprotoTests/Base64URLTests.swift
+++ b/Tests/SwiftAtprotoTests/Base64URLTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// The decoder is deliberately narrow: JOSE writes every segment with the URL-safe alphabet and no
+// padding, so anything else is refused rather than repaired.
+struct Base64URLTests {
+  @Test func decodesTheRFC4648TestVectors() {
+    #expect(base64URLDecoded("") == Data())
+    #expect(base64URLDecoded("Zg") == Data("f".utf8))
+    #expect(base64URLDecoded("Zm8") == Data("fo".utf8))
+    #expect(base64URLDecoded("Zm9v") == Data("foo".utf8))
+    #expect(base64URLDecoded("Zm9vYg") == Data("foob".utf8))
+    #expect(base64URLDecoded("Zm9vYmE") == Data("fooba".utf8))
+    #expect(base64URLDecoded("Zm9vYmFy") == Data("foobar".utf8))
+  }
+
+  @Test func decodesTheTwoCharactersThatMakeTheAlphabetURLSafe() {
+    // The same bytes are `+_8` and `-/8` in the standard alphabet, which is why accepting both
+    // alphabets would let one string decode two ways.
+    #expect(base64URLDecoded("-_8") == Data([0xFB, 0xFF]))
+  }
+
+  @Test func rejectsPadding() {
+    #expect(base64URLDecoded("Zg==") == nil)
+    #expect(base64URLDecoded("Zm8=") == nil)
+  }
+
+  @Test func rejectsTheStandardAlphabet() {
+    #expect(base64URLDecoded("+_8") == nil)
+    #expect(base64URLDecoded("-/8") == nil)
+  }
+
+  @Test func rejectsWhitespace() {
+    #expect(base64URLDecoded("Zm 9v") == nil)
+    #expect(base64URLDecoded("Zm9v\n") == nil)
+    #expect(base64URLDecoded(" Zm9v") == nil)
+  }
+
+  @Test func rejectsALengthOfOneModuloFour() {
+    // No base64 quantum is one character wide, so such a string encodes nothing.
+    #expect(base64URLDecoded("Z") == nil)
+    #expect(base64URLDecoded("Zm9vY") == nil)
+  }
+}

--- a/Tests/SwiftAtprotoTests/SpaceTokenIntrospectionTests.swift
+++ b/Tests/SwiftAtprotoTests/SpaceTokenIntrospectionTests.swift
@@ -1,0 +1,350 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+// Introspection reads a token; it never verifies one. Every fixture here therefore carries a
+// signature segment that is only shaped like a signature.
+struct SpaceTokenIntrospectionTests {
+  static let spaceDID = "did:plc:ewvi7nxzyoun6zhxrhs64oiz"
+  // The proposal writes this space type as `com.example.space_type`, which is not an NSID — a name
+  // segment admits no underscore — so the fixture uses the space ref the other tests in this
+  // target share.
+  static let spaceRef = "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/space/com.example.forum/self"
+  static let otherSpaceRef = "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/space/com.example.forum/other"
+  static let thumbprint = "0ZcOCORZNYy-DWpqq30jZyJGHTN0d2HglBV3uiguA4I"
+  static let clientID = "https://app.example.com/client-metadata.json"
+  static let spaceHost = "did:plc:ewvi7nxzyoun6zhxrhs64oiz#atproto_space_host"
+  static let nonce = "9f8e7d6c5b4a3210fedcba9876543210"
+  static let issuedAt = Date(timeIntervalSince1970: 1_738_368_000)
+  static let expiresAt = Date(timeIntervalSince1970: 1_738_375_200)
+
+  // Raw string literals with `##` delimiters: the JSON carries `"#`, which would close a `#"`
+  // literal early.
+  static let credentialHeader = ##"""
+    {"typ":"atproto-space-credential+jwt","alg":"ES256K","kid":"#atproto_space"}
+    """##
+
+  static let credentialPayload = ##"""
+    {"iss":"\##(spaceDID)","sub":"\##(spaceRef)","cnf":{"jkt":"\##(thumbprint)"},\##
+    "iat":1738368000,"exp":1738375200,"jti":"\##(nonce)"}
+    """##
+
+  static let delegationHeader = ##"""
+    {"typ":"atproto-space-delegation+jwt","alg":"ES256K","kid":"#atproto"}
+    """##
+
+  static let delegationPayload = ##"""
+    {"iss":"did:plc:44ybard66vv44zksje25o7dz","sub":"\##(spaceRef)","aud":"\##(spaceHost)",\##
+    "iat":1738368000,"exp":1738375200,"jti":"\##(nonce)"}
+    """##
+
+  static let attestationHeader = ##"""
+    {"typ":"atproto-client-attestation+jwt","alg":"ES256","kid":"key-1"}
+    """##
+
+  static let attestationPayload = ##"""
+    {"iss":"\##(clientID)","sub":"\##(clientID)","aud":"\##(spaceHost)",\##
+    "iat":1738368000,"exp":1738375200,"jti":"\##(nonce)"}
+    """##
+
+  // MARK: - Structure
+
+  @Test func rejectsATokenThatIsNotThreeSegments() {
+    for jwt in ["", "abc", "\(Self.encoded(Self.credentialHeader)).\(Self.encoded(Self.credentialPayload))", "a.b.c.d"] {
+      #expect(throws: SpaceTokenError.malformed) {
+        try UnverifiedSpaceCredential(introspecting: jwt)
+      }
+    }
+  }
+
+  @Test func rejectsASegmentThatIsNotUnpaddedURLSafeBase64() {
+    let payload = Self.encoded(Self.credentialPayload)
+    // The standard alphabet, padding, and a character outside both alphabets.
+    for header in ["ab+c", "ab/c", "\(Self.encoded(Self.credentialHeader))==", "ab c"] {
+      #expect(throws: SpaceTokenError.malformed) {
+        try UnverifiedSpaceCredential(introspecting: "\(header).\(payload).c2ln")
+      }
+    }
+  }
+
+  @Test func rejectsAnEmptySignatureSegment() {
+    let jwt = "\(Self.encoded(Self.credentialHeader)).\(Self.encoded(Self.credentialPayload))."
+    #expect(throws: SpaceTokenError.malformed) {
+      try UnverifiedSpaceCredential(introspecting: jwt)
+    }
+  }
+
+  @Test func rejectsASegmentThatIsNotJSON() {
+    #expect(throws: SpaceTokenError.malformed) {
+      try UnverifiedSpaceCredential(introspecting: Self.token(header: "not json", payload: Self.credentialPayload))
+    }
+    #expect(throws: SpaceTokenError.malformed) {
+      try UnverifiedSpaceCredential(introspecting: Self.token(header: Self.credentialHeader, payload: "[]"))
+    }
+  }
+
+  @Test func rejectsAnotherCredentialClass() {
+    let jwt = Self.token(header: Self.delegationHeader, payload: Self.delegationPayload)
+    #expect(
+      throws: SpaceTokenError.wrongType(
+        expected: "atproto-space-credential+jwt", found: "atproto-space-delegation+jwt")
+    ) {
+      try UnverifiedSpaceCredential(introspecting: jwt)
+    }
+  }
+
+  // MARK: - Required claims
+
+  @Test func requiresAlgIssSubAndExp() {
+    let cases: [(String, String, String)] = [
+      ("alg", ##"{"typ":"atproto-space-credential+jwt"}"##, Self.credentialPayload),
+      ("iss", Self.credentialHeader, Self.credentialPayload(dropping: "iss")),
+      ("sub", Self.credentialHeader, Self.credentialPayload(dropping: "sub")),
+      ("exp", Self.credentialHeader, Self.credentialPayload(dropping: "exp")),
+    ]
+    for (claim, header, payload) in cases {
+      #expect(throws: SpaceTokenError.missingClaim(claim)) {
+        try UnverifiedSpaceCredential(introspecting: Self.token(header: header, payload: payload))
+      }
+    }
+  }
+
+  @Test func requiresTheBoundKeyOnACredential() {
+    let payload = Self.credentialPayload(dropping: "cnf")
+    #expect(throws: SpaceTokenError.missingClaim("cnf.jkt")) {
+      try UnverifiedSpaceCredential(
+        introspecting: Self.token(header: Self.credentialHeader, payload: payload))
+    }
+  }
+
+  @Test func acceptsACredentialWithoutATokenID() throws {
+    // A credential is reused across every repo host serving the space, so it needs no replay nonce.
+    let payload = Self.credentialPayload(dropping: "jti")
+    let credential = try UnverifiedSpaceCredential(
+      introspecting: Self.token(header: Self.credentialHeader, payload: payload))
+    #expect(credential.tokenID == nil)
+  }
+
+  @Test func requiresAnAudienceAndATokenIDOnADelegationToken() {
+    for claim in ["aud", "jti"] {
+      let payload = Self.delegationPayload(dropping: claim)
+      #expect(throws: SpaceTokenError.missingClaim(claim)) {
+        try UnverifiedSpaceDelegationToken(
+          introspecting: Self.token(header: Self.delegationHeader, payload: payload))
+      }
+    }
+  }
+
+  @Test func requiresAnAudienceAndATokenIDOnAClientAttestation() {
+    for claim in ["aud", "jti"] {
+      let payload = Self.attestationPayload(dropping: claim)
+      #expect(throws: SpaceTokenError.missingClaim(claim)) {
+        try UnverifiedClientAttestation(
+          introspecting: Self.token(header: Self.attestationHeader, payload: payload))
+      }
+    }
+  }
+
+  // MARK: - Typed claims
+
+  @Test func readsEveryClaimOfASpaceCredential() throws {
+    let credential = try UnverifiedSpaceCredential(
+      introspecting: Self.token(header: Self.credentialHeader, payload: Self.credentialPayload))
+    #expect(credential.issuer.rawValue == Self.spaceDID)
+    #expect(credential.space.rawValue == Self.spaceRef)
+    #expect(credential.space.skey.rawValue == "self")
+    #expect(credential.boundKeyThumbprint == Self.thumbprint)
+    #expect(credential.issuedAt == Self.issuedAt)
+    #expect(credential.expiresAt == Self.expiresAt)
+    #expect(credential.tokenID == Self.nonce)
+    #expect(credential.algorithm == "ES256K")
+    // The `kid` is what `DIDDocument.spaceSigningKey(keyId:)` takes.
+    #expect(credential.keyID == "#atproto_space")
+  }
+
+  @Test func readsADelegationToken() throws {
+    let token = try UnverifiedSpaceDelegationToken(
+      introspecting: Self.token(header: Self.delegationHeader, payload: Self.delegationPayload))
+    #expect(token.issuer.rawValue == "did:plc:44ybard66vv44zksje25o7dz")
+    #expect(token.space.rawValue == Self.spaceRef)
+    #expect(token.audience.did.rawValue == Self.spaceDID)
+    #expect(token.audience.fragment == "atproto_space_host")
+    #expect(token.tokenID == Self.nonce)
+  }
+
+  @Test func rejectsASubjectThatIsNotASpaceRef() {
+    // A record URI within a space is not the space itself.
+    let payload = Self.credentialPayload(
+      replacing: "sub", with: "at://\(Self.spaceDID)/app.bsky.feed.post/3jui7kd54zh2y")
+    #expect(throws: LexiconStringFormatError.self) {
+      try UnverifiedSpaceCredential(
+        introspecting: Self.token(header: Self.credentialHeader, payload: payload))
+    }
+  }
+
+  @Test func rejectsAnIssuerThatIsNotADID() {
+    let payload = Self.credentialPayload(replacing: "iss", with: "alice.example.com")
+    #expect(throws: LexiconStringFormatError.self) {
+      try UnverifiedSpaceCredential(
+        introspecting: Self.token(header: Self.credentialHeader, payload: payload))
+    }
+  }
+
+  @Test func rejectsAnAudienceThatIsNotAServiceIdentifier() {
+    let payload = Self.delegationPayload(replacing: "aud", with: "\(Self.spaceDID)#")
+    #expect(throws: DIDDocument.VerifyError.self) {
+      try UnverifiedSpaceDelegationToken(
+        introspecting: Self.token(header: Self.delegationHeader, payload: payload))
+    }
+  }
+
+  @Test func acceptsAHeaderWithoutAKeyID() throws {
+    let header = ##"{"typ":"atproto-space-credential+jwt","alg":"ES256K"}"##
+    let credential = try UnverifiedSpaceCredential(
+      introspecting: Self.token(header: header, payload: Self.credentialPayload))
+    #expect(credential.keyID == nil)
+  }
+
+  // MARK: - Client attestation
+
+  @Test func readsAClientAttestation() throws {
+    let attestation = try UnverifiedClientAttestation(
+      introspecting: Self.token(header: Self.attestationHeader, payload: Self.attestationPayload))
+    #expect(attestation.clientID == Self.clientID)
+    #expect(attestation.audience.rawValue == Self.spaceHost)
+    #expect(attestation.algorithm == "ES256")
+    #expect(attestation.keyID == "key-1")
+    #expect(attestation.tokenID == Self.nonce)
+  }
+
+  @Test func rejectsAClientAttestationWhoseIssuerAndSubjectDisagree() {
+    let payload = Self.attestationPayload(
+      replacing: "sub", with: "https://other.example.com/client-metadata.json")
+    #expect(throws: SpaceTokenError.clientIDMismatch) {
+      try UnverifiedClientAttestation(
+        introspecting: Self.token(header: Self.attestationHeader, payload: payload))
+    }
+  }
+
+  @Test func readsAnAttestationSignedByATProtoCrypto() throws {
+    // Recorded from `ATProtoCrypto.ClientAttestation.signed(with:)`. This target does not depend on
+    // that module, so a recorded token is the only way to hold the two sides to one wire format.
+    let jwt = """
+      eyJhbGciOiJFUzI1NiIsImtpZCI6ImtleS0xIiwidHlwIjoiYXRwcm90by1jbGllbnQtYXR0ZXN0YXRpb24rand0In0\
+      .eyJhdWQiOiJkaWQ6cGxjOmV3dmk3bnh6eW91bjZ6aHhyaHM2NG9peiNhdHByb3RvX3NwYWNlX2hvc3QiLCJleHAiOjE\
+      3MzgzNjgwNjAsImlhdCI6MTczODM2ODAwMCwiaXNzIjoiaHR0cHM6Ly9hcHAuZXhhbXBsZS5jb20vY2xpZW50LW1ldGF\
+      kYXRhLmpzb24iLCJqdGkiOiJiM2M0ZDVlNmY3YThiOWMwZDFlMmYzYTRiNWM2ZDdlOCIsInN1YiI6Imh0dHBzOi8vYXB\
+      wLmV4YW1wbGUuY29tL2NsaWVudC1tZXRhZGF0YS5qc29uIn0\
+      .P9qkLdP-Qyl5v7lt47puZeMBfRDLcDEyVX5Fyrno9mJoCqZuMh4k_A3wW6rjB50h9BqZl6BDi6xZce4qma88rg
+      """
+    let attestation = try UnverifiedClientAttestation(introspecting: jwt)
+    #expect(attestation.clientID == Self.clientID)
+    #expect(attestation.audience.rawValue == Self.spaceHost)
+    #expect(attestation.tokenID == "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8")
+    #expect(attestation.issuedAt == Date(timeIntervalSince1970: 1_738_368_000))
+    #expect(attestation.expiresAt == Date(timeIntervalSince1970: 1_738_368_060))
+    #expect(attestation.algorithm == "ES256")
+    #expect(attestation.keyID == "key-1")
+  }
+
+  // MARK: - Credential checks
+
+  @Test func reportsExpiryWithTheDefaultClockSkew() throws {
+    let credential = try Self.credential()
+    #expect(!credential.isExpired(at: Self.expiresAt))
+    // The default skew is permissive: the credential still counts as live for five seconds past
+    // `exp`, and not one second longer.
+    #expect(!credential.isExpired(at: Self.expiresAt.addingTimeInterval(4)))
+    #expect(credential.isExpired(at: Self.expiresAt.addingTimeInterval(5)))
+  }
+
+  @Test func reportsExpiryWithAnExplicitClockSkew() throws {
+    let credential = try Self.credential()
+    #expect(credential.isExpired(at: Self.expiresAt, clockSkew: 0))
+    // A holder that wants to renew early asks for the window to close early.
+    #expect(credential.isExpired(at: Self.expiresAt.addingTimeInterval(-60), clockSkew: -120))
+  }
+
+  @Test func authorizesOnlyTheSpaceItNames() throws {
+    let credential = try Self.credential()
+    #expect(credential.authorizes(try SpaceRef(string: Self.spaceRef)))
+    #expect(!credential.authorizes(try SpaceRef(string: Self.otherSpaceRef)))
+  }
+
+  @Test func isBoundOnlyToItsOwnKeyThumbprint() throws {
+    let credential = try Self.credential()
+    #expect(credential.isBound(toKeyThumbprint: Self.thumbprint))
+    // A thumbprint is base64url, so the comparison is case-sensitive.
+    #expect(!credential.isBound(toKeyThumbprint: Self.thumbprint.lowercased()))
+    #expect(!credential.isBound(toKeyThumbprint: "not-the-same-key"))
+  }
+
+  // MARK: - Redaction
+
+  @Test func descriptionsWithholdNoncesAndThumbprints() throws {
+    let credential = try Self.credential()
+    let delegation = try UnverifiedSpaceDelegationToken(
+      introspecting: Self.token(header: Self.delegationHeader, payload: Self.delegationPayload))
+    let attestation = try UnverifiedClientAttestation(
+      introspecting: Self.token(header: Self.attestationHeader, payload: Self.attestationPayload))
+
+    for description in [credential.description, delegation.description, attestation.description] {
+      #expect(!description.contains(Self.nonce))
+      #expect(!description.contains(Self.thumbprint))
+    }
+    #expect(credential.description.contains(Self.spaceRef))
+  }
+
+}
+
+// MARK: - Fixtures
+
+extension SpaceTokenIntrospectionTests {
+  static func encoded(_ json: String) -> String {
+    Data(json.utf8).base64EncodedString()
+      .replacingOccurrences(of: "+", with: "-")
+      .replacingOccurrences(of: "/", with: "_")
+      .replacingOccurrences(of: "=", with: "")
+  }
+
+  static func token(header: String, payload: String) -> String {
+    "\(encoded(header)).\(encoded(payload)).c2lnbmF0dXJl"
+  }
+
+  static func credential() throws -> UnverifiedSpaceCredential {
+    try UnverifiedSpaceCredential(introspecting: token(header: credentialHeader, payload: credentialPayload))
+  }
+
+  /// Rewrites a payload by round-tripping it through `JSONSerialization`, so that a test can name
+  /// the claim it is interested in instead of restating the whole object.
+  private static func rewrite(_ payload: String, _ transform: (inout [String: Any]) -> Void) -> String {
+    var object = try! JSONSerialization.jsonObject(with: Data(payload.utf8)) as! [String: Any]
+    transform(&object)
+    return String(data: try! JSONSerialization.data(withJSONObject: object), encoding: .utf8)!
+  }
+
+  static func credentialPayload(dropping claim: String) -> String {
+    rewrite(credentialPayload) { $0[claim] = nil }
+  }
+
+  static func credentialPayload(replacing claim: String, with value: String) -> String {
+    rewrite(credentialPayload) { $0[claim] = value }
+  }
+
+  static func delegationPayload(dropping claim: String) -> String {
+    rewrite(delegationPayload) { $0[claim] = nil }
+  }
+
+  static func delegationPayload(replacing claim: String, with value: String) -> String {
+    rewrite(delegationPayload) { $0[claim] = value }
+  }
+
+  static func attestationPayload(dropping claim: String) -> String {
+    rewrite(attestationPayload) { $0[claim] = nil }
+  }
+
+  static func attestationPayload(replacing claim: String, with value: String) -> String {
+    rewrite(attestationPayload) { $0[claim] = value }
+  }
+}


### PR DESCRIPTION
Adds UnverifiedSpaceCredential, UnverifiedSpaceDelegationToken, and UnverifiedClientAttestation, which read the claims of a permissioned data space token — when it expires, which space it covers, and which key it is bound to — without checking its signature. Verifying one means resolving the issuer to a DID document and fetching a key, so that stays with the service the token is addressed to.