### PR TITLE
feat: generate DPoP proofs for space credentials

### DIFF
--- a/Sources/ATProtoCrypto/ClientAttestation.swift
+++ b/Sources/ATProtoCrypto/ClientAttestation.swift
@@ -98,16 +98,7 @@ public struct ClientAttestation: Sendable, Hashable {
   /// Each attestation needs its own, so call this once per attestation rather
   /// than holding onto a value.
   public static func randomTokenID() -> String {
-    var generator = SystemRandomNumberGenerator()
-    let digits = "0123456789abcdef"
-    var hex = ""
-    hex.reserveCapacity(32)
-    for _ in 0..<16 {
-      let byte: UInt8 = generator.next()
-      hex.append(digits[digits.index(digits.startIndex, offsetBy: Int(byte >> 4))])
-      hex.append(digits[digits.index(digits.startIndex, offsetBy: Int(byte & 0x0F))])
-    }
-    return hex
+    randomHexTokenID()
   }
 
   private struct Header: Encodable {

--- a/Sources/ATProtoCrypto/DPoPProof.swift
+++ b/Sources/ATProtoCrypto/DPoPProof.swift
@@ -1,0 +1,195 @@
+import Crypto
+
+#if !canImport(Darwin)
+  import FoundationEssentials
+#else
+  import Foundation
+#endif
+
+/// Why a proof cannot be spelled at all, before any signing is attempted.
+public enum DPoPProofError: Error, Hashable, Sendable {
+  /// The target URL has no scheme or no host, so there is no origin to write an
+  /// `htu` from. A `mailto:` or a relative URL lands here.
+  case unsupportedTargetURL
+}
+
+/// A single-use JWT that proves possession of the key a space credential is
+/// bound to, sent alongside the credential on every request (RFC 9449).
+///
+/// A space credential reads a whole space and is presented to every repo host in
+/// it. As a bearer token it would be a shared secret: a host handed one to serve
+/// its own repo could replay it against every other host in the space. Binding
+/// the credential to a key the holder alone controls, and proving possession of
+/// that key per request, is what stops that.
+///
+/// A proof covers one method and one URL and is not reusable, so build one per
+/// request. See <doc:DPoPProofs>.
+public struct DPoPProof: Sendable, Hashable {
+  /// The HTTP method of the request this proof covers, as `htm`.
+  ///
+  /// Written verbatim and compared verbatim, so it has to be spelled the way the
+  /// request line spells it — `GET`, not `get`.
+  public let httpMethod: String
+
+  /// The URL of the request this proof covers.
+  ///
+  /// Only its origin and path reach the wire; see ``httpTargetURI``.
+  public let url: URL
+
+  /// When the proof was issued.
+  ///
+  /// A proof has no `exp`. A verifier accepts one for ``maximumAge`` past this
+  /// instant and no longer, so a proof kept around is a proof about to be
+  /// rejected.
+  public let issuedAt: Date
+
+  /// The `jti` nonce that makes the proof single-use.
+  ///
+  /// A verifier remembers it in order to reject a replay, so a value must never
+  /// be reused across proofs. ``randomTokenID()`` produces a suitable one.
+  public let tokenID: String
+
+  /// The credential this proof is presented with, or `nil` when the request is
+  /// the exchange that obtains one.
+  ///
+  /// Only its SHA-256 digest reaches the wire, as `ath`; the credential itself
+  /// is never written into the proof. A verifier requires the two to agree, and
+  /// requires `ath` to be *absent* when no credential is being presented, so
+  /// this has to track what the request actually carries.
+  public let credential: String?
+
+  /// Describes a proof. Nothing is signed until ``signed(with:)``.
+  ///
+  /// Every claim is supplied by the caller, including the nonce: a proof is
+  /// single-use, so reusing one is a mistake this type cannot detect for you.
+  public init(
+    httpMethod: String,
+    url: URL,
+    issuedAt: Date,
+    tokenID: String,
+    credential: String? = nil
+  ) {
+    self.httpMethod = httpMethod
+    self.url = url
+    self.issuedAt = issuedAt
+    self.tokenID = tokenID
+    self.credential = credential
+  }
+
+  /// The `htu` this proof carries: ``url`` reduced to its origin and path.
+  ///
+  /// RFC 9449 §4.2 strips the query and the fragment, so one proof covers a path
+  /// whatever query is on it. That is not a relaxation the client may decline:
+  /// an XRPC query carries its parameters in the query string, and a proof that
+  /// kept them would never match what the verifier computes.
+  ///
+  /// The scheme and host are lowercased and a default port is dropped, because
+  /// the verifier derives its side of the comparison from a parsed URL and gets
+  /// a normalized origin either way.
+  ///
+  /// - Throws: ``DPoPProofError/unsupportedTargetURL`` when ``url`` has no
+  ///   scheme or no host.
+  public var httpTargetURI: String {
+    get throws {
+      guard let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+        let scheme = components.scheme?.lowercased(),
+        let host = components.percentEncodedHost?.lowercased(),
+        !host.isEmpty
+      else {
+        throw DPoPProofError.unsupportedTargetURL
+      }
+      var uri = "\(scheme)://\(host)"
+      if let port = components.port, port != Self.defaultPort(forScheme: scheme) {
+        uri += ":\(port)"
+      }
+      // An origin with nothing after it still has a path, and it is `/`.
+      let path = components.percentEncodedPath
+      return uri + (path.isEmpty ? "/" : path)
+    }
+  }
+
+  /// Signs the proof with `key`, returning it as a compact JWS.
+  ///
+  /// The public half of `key` is embedded in the `jwk` header, which is how a
+  /// verifier checks the signature without having been told the key in advance.
+  /// It then compares that key's thumbprint against the `cnf.jkt` of the
+  /// credential being presented, so `key` has to be the key the credential was
+  /// bound to.
+  ///
+  /// ``issuedAt`` becomes `iat`, which JWT spells as whole seconds since the
+  /// Unix epoch, so any sub-second part is truncated.
+  ///
+  /// - Throws: ``DPoPProofError/unsupportedTargetURL`` when ``url`` cannot be
+  ///   written as an `htu`, and whatever ``PrivateKey/sign(_:)`` throws for
+  ///   `key`'s type.
+  public func signed(with key: PrivateKey) throws -> String {
+    try compactJWS(
+      header: Header(alg: key.type.jwsAlgorithm, jwk: key.publicKey.bareJWK),
+      payload: Payload(
+        ath: credential.map(Self.credentialHash),
+        htm: httpMethod,
+        htu: httpTargetURI,
+        iat: Int(issuedAt.timeIntervalSince1970),
+        jti: tokenID),
+      signedWith: key)
+  }
+
+  /// A fresh `jti`: 16 random bytes as lowercase hexadecimal.
+  ///
+  /// Each proof needs its own, so call this once per proof rather than holding
+  /// onto a value.
+  public static func randomTokenID() -> String {
+    randomHexTokenID()
+  }
+
+  /// The longest a verifier accepts a proof after its `iat` — 60 seconds.
+  ///
+  /// A proof carries no `exp` of its own, so this is the lifetime, and it is the
+  /// verifier's constant rather than something the holder can extend.
+  public static let maximumAge: TimeInterval = 60
+
+  /// The `ath` claim for `credential`: the base64url SHA-256 of its octets.
+  private static func credentialHash(_ credential: String) -> String {
+    base64URLEncoded(Data(SHA256.hash(data: Data(credential.utf8))))
+  }
+
+  private static func defaultPort(forScheme scheme: String) -> Int? {
+    switch scheme {
+    case "https": 443
+    case "http": 80
+    default: nil
+    }
+  }
+
+  private struct Header: Encodable {
+    // Fixed by RFC 9449 §4.2. A verifier rejects any other `typ`, which is what
+    // keeps a proof from being accepted anywhere a JWT is read.
+    let typ = "dpop+jwt"
+    let alg: String
+    // No `kid`: the key travels in the proof itself, so there is nothing to name
+    // it against.
+    let jwk: BareJWK
+  }
+
+  private struct Payload: Encodable {
+    // Absent when obtaining a credential rather than presenting one, which the
+    // synthesized encoding gives us for a `nil` optional.
+    let ath: String?
+    let htm: String
+    let htu: String
+    let iat: Int
+    let jti: String
+  }
+}
+
+extension DPoPProof: CustomStringConvertible {
+  /// Withholds ``credential`` and ``tokenID``. The default reflected description
+  /// would print both, and a proof is most likely to be described while being
+  /// logged.
+  public var description: String {
+    """
+    DPoPProof(httpMethod: \(httpMethod), url: \(url), issuedAt: \(issuedAt), \
+    presentsCredential: \(credential != nil))
+    """
+  }
+}

--- a/Sources/ATProtoCrypto/Documentation.docc/ATProtoCrypto.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/ATProtoCrypto.md
@@ -33,6 +33,8 @@ key.publicKey.did                                                   // "did:key:
 
 - <doc:ClientAttestations>
 - ``ClientAttestation``
+- <doc:DPoPProofs>
+- ``DPoPProof``
 
 ### Identifiers
 
@@ -47,4 +49,5 @@ key.publicKey.did                                                   // "did:key:
 
 ### Errors
 
+- ``DPoPProofError``
 - ``VarintError``

--- a/Sources/ATProtoCrypto/Documentation.docc/Articles/DPoPProofs.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/Articles/DPoPProofs.md
@@ -1,0 +1,119 @@
+# DPoP proofs
+
+Prove possession of the key a space credential is bound to, once per request.
+
+## Overview
+
+> Important: Space credentials come from the permissioned data proposal, not from
+> the ratified AT Protocol. What a space host accepts is the part most likely to
+> change.
+
+A space credential reads a whole space, and the same credential is presented to
+every repo host in that space. As a bearer token it would be a shared secret: a
+host handed one to serve its own repo could replay it against every other host in
+the space. So the credential is bound to a key its holder alone controls, by the
+``PublicKey/jwkThumbprint`` of that key in the credential's `cnf.jkt`, and every
+request carries a fresh **DPoP proof** (RFC 9449) signed with the matching
+private key.
+
+The proof is what makes the binding mean something. Without it the credential is
+still a bearer token; with it, a stolen credential is useless to anyone who does
+not also hold the key.
+
+## Building one
+
+``DPoPProof`` holds the claims; ``DPoPProof/signed(with:)`` encodes and signs
+them. Each request needs its own, and they come in two shapes, told apart by
+whether the proof carries an `ath` claim.
+
+The exchange that obtains a credential proves the key without presenting
+anything:
+
+```swift
+let proof = DPoPProof(
+  httpMethod: "POST",
+  url: URL(string: "https://space.example.com/xrpc/com.atproto.space.getSpaceCredential")!,
+  issuedAt: Date(),
+  tokenID: DPoPProof.randomTokenID())
+
+let jwt = try proof.signed(with: key)
+```
+
+Every later request presents the credential it obtained, and says so:
+
+```swift
+let proof = DPoPProof(
+  httpMethod: "GET",
+  url: URL(string: "https://repo.example.com/xrpc/com.atproto.repo.getRecord?rkey=self")!,
+  issuedAt: Date(),
+  tokenID: DPoPProof.randomTokenID(),
+  credential: credential)
+```
+
+``DPoPProof/credential`` becomes `ath`, the base64url SHA-256 of the credential's
+octets — never the credential itself. A verifier requires `ath` to match what the
+request carries, and requires it to be *absent* when no credential is being
+presented, so the two cases are not interchangeable.
+
+The signing key has to be the key the credential was bound to. Its public half
+travels in the proof's `jwk` header, which is how a verifier checks the signature
+without having been told the key in advance; it then compares that key's
+thumbprint against the credential's `cnf.jkt`. Only the members RFC 7638 takes a
+thumbprint over are embedded — `kty`, `crv`, `x`, and `y` for an EC key — so no
+private material and nothing else rides along.
+
+## The target URI
+
+``DPoPProof/httpTargetURI`` is what reaches the wire as `htu`: the URL reduced to
+its origin and path. RFC 9449 §4.2 drops the query and the fragment, and that is
+not a relaxation a client may decline — an XRPC query carries its parameters in
+the query string, so a proof that kept them would never match what the verifier
+computes for the same request.
+
+The scheme and host are lowercased and a default port is dropped, for the same
+reason: the verifier derives its side of the comparison from a parsed URL and
+gets a normalized origin either way.
+
+``DPoPProof/httpMethod`` is not normalized. It is compared verbatim, so it has to
+be spelled the way the request line spells it.
+
+A URL with no scheme or no host has no origin to write, and throws
+``DPoPProofError/unsupportedTargetURL``.
+
+## Lifetime and replay
+
+A proof covers one method and one URL and is good for one request:
+
+- ``DPoPProof/issuedAt`` becomes `iat`. There is no `exp` — a verifier accepts a
+  proof for ``DPoPProof/maximumAge`` past its `iat` and no longer, so a proof
+  held onto is a proof about to be rejected. JWT spells `iat` as whole seconds
+  since the Unix epoch, so a sub-second part is truncated.
+- ``DPoPProof/tokenID`` becomes `jti`, the nonce a verifier remembers in order to
+  reject a replay. Never reuse one.
+  ``DPoPProof/randomTokenID()`` produces a fresh value: 16 random bytes as
+  lowercase hexadecimal.
+
+There is no `nonce` claim. RFC 9449 lets an authorization server or a resource
+server demand one with a `DPoP-Nonce` challenge, but the space exchange in the
+reference implementation of the proposal issues no such challenge, so nothing
+here emits one.
+
+## Algorithms
+
+As with a client attestation, the `alg` header comes from the signing key through
+``KeyType/jwsAlgorithm``, and any of the three key types produces a well-formed
+proof. What a given verifier accepts is narrower: the space host in the reference
+implementation of the proposal accepts `ES256` alone, so a DPoP key is in
+practice a ``KeyType/p256`` key.
+
+## What is not here
+
+Verifying a proof is the receiving side of the exchange — checking the signature
+against the embedded key, rejecting one whose `iat` is too old, comparing `htm`,
+`htu`, and `ath` against the request, and remembering `jti` long enough to catch
+a replay. This module signs; it does not verify what someone else signed, and it
+keeps no record of what it has issued.
+
+Putting the proof on a request is not here either. `SwiftAtproto` owns the XRPC
+transport and does not depend on this module, so the `DPoP` header is set on the
+client side of that boundary, with the proof passed across as a string.

--- a/Sources/ATProtoCrypto/JWK.swift
+++ b/Sources/ATProtoCrypto/JWK.swift
@@ -6,7 +6,67 @@ import Crypto
   import Foundation
 #endif
 
+/// The RFC 7638 required members of a public JWK, and nothing else.
+///
+/// Both callers want exactly this member set: a thumbprint is defined over the
+/// required members alone, and the `jwk` header of a DPoP proof has to carry the
+/// public key by itself — no `use`, no `kid`, and above all no private material.
+///
+/// ``y`` is absent for `OKP`, whose curves have a single coordinate.
+struct BareJWK: Encodable, Hashable {
+  let crv: String
+  let kty: String
+  let x: String
+  let y: String?
+
+  init(crv: String, kty: String, x: String, y: String? = nil) {
+    self.crv = crv
+    self.kty = kty
+    self.x = x
+    self.y = y
+  }
+
+  /// The members in the order RFC 7638 §3.2 prescribes for this key type, which
+  /// for both `EC` and `OKP` happens to be lexicographic order.
+  var thumbprintMembers: [(name: String, value: String)] {
+    var members: [(name: String, value: String)] = [("crv", crv), ("kty", kty), ("x", x)]
+    if let y {
+      members.append(("y", y))
+    }
+    return members
+  }
+}
+
 extension PublicKey {
+  /// The public half of this key as a bare JWK.
+  ///
+  /// - Throws: `secp256k1Error.underlyingCryptoError` when a `secp256k1` point
+  ///   cannot be re-serialized to read its coordinates.
+  var bareJWK: BareJWK {
+    get throws {
+      switch raw {
+      case .p256:
+        // `rawRepresentation` is the two 32-byte coordinates, `x` then `y`.
+        let bytes = rawBytes
+        return BareJWK(
+          crv: "P-256",
+          kty: "EC",
+          x: base64URLEncoded(bytes.prefix(32)),
+          y: base64URLEncoded(bytes.suffix(32)))
+      case .secp256k1(let key):
+        // Drop the `0x04` prefix of the uncompressed encoding.
+        let bytes = try key.uncompressedBytes.dropFirst()
+        return BareJWK(
+          crv: "secp256k1",
+          kty: "EC",
+          x: base64URLEncoded(bytes.prefix(32)),
+          y: base64URLEncoded(bytes.suffix(32)))
+      case .ed25519:
+        return BareJWK(crv: "Ed25519", kty: "OKP", x: base64URLEncoded(rawBytes))
+      }
+    }
+  }
+
   /// The RFC 7638 JWK thumbprint of this key, base64url-encoded without padding.
   ///
   /// This is the value a `cnf.jkt` claim carries: comparing it against the
@@ -19,35 +79,7 @@ extension PublicKey {
   ///   cannot be re-serialized to read its coordinates.
   public var jwkThumbprint: String {
     get throws {
-      switch raw {
-      case .p256:
-        // `rawRepresentation` is the two 32-byte coordinates, `x` then `y`.
-        let bytes = rawBytes
-        return Self.thumbprint(
-          members: [
-            ("crv", "P-256"),
-            ("kty", "EC"),
-            ("x", base64URLEncoded(bytes.prefix(32))),
-            ("y", base64URLEncoded(bytes.suffix(32))),
-          ])
-      case .secp256k1(let key):
-        // Drop the `0x04` prefix of the uncompressed encoding.
-        let bytes = try key.uncompressedBytes.dropFirst()
-        return Self.thumbprint(
-          members: [
-            ("crv", "secp256k1"),
-            ("kty", "EC"),
-            ("x", base64URLEncoded(bytes.prefix(32))),
-            ("y", base64URLEncoded(bytes.suffix(32))),
-          ])
-      case .ed25519:
-        return Self.thumbprint(
-          members: [
-            ("crv", "Ed25519"),
-            ("kty", "OKP"),
-            ("x", base64URLEncoded(rawBytes)),
-          ])
-      }
+      Self.thumbprint(members: try bareJWK.thumbprintMembers)
     }
   }
 

--- a/Sources/ATProtoCrypto/_TokenID.swift
+++ b/Sources/ATProtoCrypto/_TokenID.swift
@@ -1,0 +1,19 @@
+// Both JWTs this module signs carry a `jti` and want the same thing from it: a value no other
+// token has used, drawn from a source an observer cannot predict. The generator lives here rather
+// than on either type so that the two cannot drift apart in length or alphabet.
+
+/// 16 random bytes as lowercase hexadecimal — 128 bits, which is what the OAuth and DPoP specs
+/// ask of a nonce.
+func randomHexTokenID() -> String {
+  var generator = SystemRandomNumberGenerator()
+  var hex = ""
+  hex.reserveCapacity(32)
+  for _ in 0..<16 {
+    // A nibble is one hex digit, so `String(_:radix:)` — which is lowercase already — needs no
+    // padding, and rendering the two halves separately needs no digit table.
+    let byte: UInt8 = generator.next()
+    hex.append(String(byte >> 4, radix: 16))
+    hex.append(String(byte & 0x0F, radix: 16))
+  }
+  return hex
+}

--- a/Tests/ATProtoCryptoTests/ClientAttestationTests.swift
+++ b/Tests/ATProtoCryptoTests/ClientAttestationTests.swift
@@ -154,17 +154,6 @@ struct ClientAttestationTests {
 
   // MARK: - Helpers
 
-  // `ATProtoCrypto` only encodes base64url — reading a token back is the job of
-  // the introspection side, in `SwiftAtproto` — so the tests decode their own.
-  private func decodedSegment(_ jwt: String, _ index: Int) -> Data? {
-    let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
-    guard segments.indices.contains(index) else { return nil }
-    var base64 = segments[index].replacingOccurrences(of: "-", with: "+")
-      .replacingOccurrences(of: "_", with: "/")
-    base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
-    return Data(base64Encoded: base64)
-  }
-
   private struct DecodedHeader: Decodable, Equatable {
     let typ: String
     let alg: String
@@ -186,28 +175,5 @@ struct ClientAttestationTests {
 
   private func payload(of jwt: String) throws -> DecodedPayload {
     try JSONDecoder().decode(DecodedPayload.self, from: #require(decodedSegment(jwt, 1)))
-  }
-
-  // The two decoders above ignore any member they do not name, so the member
-  // sets are checked separately. This reads the names alone rather than decoding
-  // the values as `Any`, which would compare JSON numbers through a box whose
-  // type differs between Darwin and swift-corelibs-foundation.
-  private struct MemberNames: Decodable {
-    let sorted: [String]
-
-    private struct AnyKey: CodingKey {
-      let stringValue: String
-      var intValue: Int? { nil }
-      init?(stringValue: String) { self.stringValue = stringValue }
-      init?(intValue: Int) { nil }
-    }
-
-    init(from decoder: any Decoder) throws {
-      sorted = try decoder.container(keyedBy: AnyKey.self).allKeys.map(\.stringValue).sorted()
-    }
-  }
-
-  private func memberNames(of jwt: String, _ index: Int) throws -> [String] {
-    try JSONDecoder().decode(MemberNames.self, from: #require(decodedSegment(jwt, index))).sorted
   }
 }

--- a/Tests/ATProtoCryptoTests/DPoPProofTests.swift
+++ b/Tests/ATProtoCryptoTests/DPoPProofTests.swift
@@ -1,0 +1,291 @@
+import Foundation
+import Testing
+
+@testable import ATProtoCrypto
+
+struct DPoPProofTests {
+  private static let url = URL(string: "https://repo.example.com/xrpc/com.atproto.repo.getRecord")!
+  private static let issuedAt = Date(timeIntervalSince1970: 1_738_368_000)
+  private static let tokenID = "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8"
+
+  // An opaque stand-in for a space credential; only its digest is ever encoded.
+  // The expected `ath` is `base64url(SHA-256(utf8(credential)))`, computed
+  // independently of this module.
+  private static let credential = "a-space-credential-jwt"
+  private static let credentialHash = "bks-F6oDLcO-nvmRslqy5tPdSGUG6sxi-WTRDYCG1Pc"
+
+  private func proof(
+    httpMethod: String = "GET",
+    url: URL = DPoPProofTests.url,
+    credential: String? = nil
+  ) -> DPoPProof {
+    DPoPProof(
+      httpMethod: httpMethod,
+      url: url,
+      issuedAt: Self.issuedAt,
+      tokenID: Self.tokenID,
+      credential: credential)
+  }
+
+  // `KeyType` is not `Sendable`, so these iterate a local list rather than going
+  // through `@Test(arguments:)`.
+  private var keyTypes: [KeyType] { [.p256, .secp256k1, .ed25519] }
+
+  // MARK: - Claims
+
+  @Test func carriesTheMemberSetRFC9449Prescribes() throws {
+    let jwt = try proof().signed(with: PrivateKey(type: .p256))
+
+    #expect(try memberNames(of: jwt, 0) == ["alg", "jwk", "typ"])
+    #expect(try header(of: jwt).typ == "dpop+jwt")
+    #expect(try header(of: jwt).alg == "ES256")
+
+    // No `exp` — a proof is bounded by its `iat` — and no `nonce`, which the
+    // space exchange does not use.
+    #expect(try memberNames(of: jwt, 1) == ["htm", "htu", "iat", "jti"])
+    let claims = try payload(of: jwt)
+    #expect(claims.htm == "GET")
+    #expect(claims.htu == "https://repo.example.com/xrpc/com.atproto.repo.getRecord")
+    #expect(claims.iat == 1_738_368_000)
+    #expect(claims.jti == Self.tokenID)
+    #expect(claims.ath == nil)
+  }
+
+  @Test func carriesTheCallersMethod() throws {
+    let jwt = try proof(httpMethod: "POST").signed(with: PrivateKey(type: .p256))
+    #expect(try payload(of: jwt).htm == "POST")
+  }
+
+  // JWT spells `iat` as whole seconds, so a `Date` carrying a fractional part
+  // has to lose it rather than encode as a decimal.
+  @Test func truncatesSubSecondTimestamps() throws {
+    let proof = DPoPProof(
+      httpMethod: "GET",
+      url: Self.url,
+      issuedAt: Date(timeIntervalSince1970: 1_700_000_000.75),
+      tokenID: Self.tokenID)
+    #expect(try payload(of: proof.signed(with: PrivateKey(type: .p256))).iat == 1_700_000_000)
+  }
+
+  // MARK: - Credential binding
+
+  // The exchange that obtains a credential has none to hash yet, and a verifier
+  // rejects a proof that carries `ath` anyway.
+  @Test func omitsAthWhenObtainingACredential() throws {
+    let jwt = try proof().signed(with: PrivateKey(type: .p256))
+    #expect(!(try memberNames(of: jwt, 1).contains("ath")))
+  }
+
+  @Test func hashesTheCredentialIntoAth() throws {
+    let jwt = try proof(credential: Self.credential).signed(with: PrivateKey(type: .p256))
+    #expect(try memberNames(of: jwt, 1) == ["ath", "htm", "htu", "iat", "jti"])
+    #expect(try payload(of: jwt).ath == Self.credentialHash)
+  }
+
+  // `ath` is a digest, so the credential itself must not survive anywhere in the
+  // proof — nor in the description a holder is most likely to log.
+  @Test func withholdsTheCredentialAndTheNonce() throws {
+    let proof = proof(credential: Self.credential)
+    let jwt = try proof.signed(with: PrivateKey(type: .p256))
+    #expect(!jwt.contains(Self.credential))
+    #expect(!proof.description.contains(Self.credential))
+    #expect(!proof.description.contains(Self.tokenID))
+    #expect(proof.description.contains("presentsCredential: true"))
+  }
+
+  // MARK: - Target URI
+
+  // RFC 9449 §4.2. An XRPC query carries its parameters in the query string, so
+  // a proof that kept them would never match what the verifier computes.
+  @Test func dropsTheQueryAndFragmentFromTheTargetURI() throws {
+    let url = URL(string: "https://repo.example.com/xrpc/com.atproto.repo.getRecord?rkey=self#f")!
+    #expect(try proof(url: url).httpTargetURI == Self.url.absoluteString)
+  }
+
+  @Test func suppliesARootPathForABareOrigin() throws {
+    let url = URL(string: "https://repo.example.com")!
+    #expect(try proof(url: url).httpTargetURI == "https://repo.example.com/")
+  }
+
+  @Test func dropsADefaultPortAndKeepsAnyOther() throws {
+    #expect(
+      try proof(url: URL(string: "https://repo.example.com:443/xrpc/a")!).httpTargetURI
+        == "https://repo.example.com/xrpc/a")
+    #expect(
+      try proof(url: URL(string: "http://repo.example.com:80/xrpc/a")!).httpTargetURI
+        == "http://repo.example.com/xrpc/a")
+    #expect(
+      try proof(url: URL(string: "https://repo.example.com:8443/xrpc/a")!).httpTargetURI
+        == "https://repo.example.com:8443/xrpc/a")
+  }
+
+  // The verifier derives its side from a parsed URL, which normalizes both.
+  @Test func lowercasesTheSchemeAndHost() throws {
+    let url = URL(string: "HTTPS://Repo.Example.COM/xrpc/a")!
+    #expect(try proof(url: url).httpTargetURI == "https://repo.example.com/xrpc/a")
+  }
+
+  @Test func rejectsAURLWithNoOrigin() throws {
+    #expect(throws: DPoPProofError.unsupportedTargetURL) {
+      try proof(url: URL(string: "mailto:someone@example.com")!).httpTargetURI
+    }
+    #expect(throws: DPoPProofError.unsupportedTargetURL) {
+      try proof(url: URL(string: "/xrpc/a")!).signed(with: PrivateKey(type: .p256))
+    }
+  }
+
+  // An `htu` is a URL, and escaping its slashes would still parse but would not
+  // match the bytes any other implementation produces.
+  @Test func doesNotEscapeSlashesInTheTargetURI() throws {
+    let jwt = try proof().signed(with: PrivateKey(type: .p256))
+    let segment = try #require(decodedSegment(jwt, 1))
+    let json = try #require(String(data: segment, encoding: .utf8))
+    #expect(json.contains(Self.url.absoluteString))
+    #expect(!json.contains("\\/"))
+  }
+
+  // MARK: - Embedded key
+
+  // A verifier checks the signature against the proof's own `jwk`, so the header
+  // has to carry the public key — and nothing beyond the members a thumbprint is
+  // taken over.
+  @Test func embedsTheBarePublicKey() throws {
+    for type in keyTypes {
+      let jwt = try proof().signed(with: PrivateKey(type: type))
+      let jwk = try header(of: jwt).jwk
+      switch type {
+      case .p256:
+        #expect(jwk.crv == "P-256")
+        #expect(jwk.kty == "EC")
+        #expect(jwk.y != nil)
+      case .secp256k1:
+        #expect(jwk.crv == "secp256k1")
+        #expect(jwk.kty == "EC")
+        #expect(jwk.y != nil)
+      case .ed25519:
+        #expect(jwk.crv == "Ed25519")
+        #expect(jwk.kty == "OKP")
+        #expect(jwk.y == nil)
+      }
+      let expected = jwk.y == nil ? ["crv", "kty", "x"] : ["crv", "kty", "x", "y"]
+      #expect(try jwkMemberNames(of: jwt) == expected)
+    }
+  }
+
+  // The private half must never reach the wire, whatever the member set check
+  // above happens to name.
+  @Test func neverEmbedsPrivateMaterial() throws {
+    for type in keyTypes {
+      let key = try PrivateKey(type: type)
+      let jwt = try proof().signed(with: key)
+      let segment = try #require(decodedSegment(jwt, 0))
+      let json = try #require(String(data: segment, encoding: .utf8))
+      #expect(!json.contains("\"d\""))
+      #expect(!json.contains(base64URLEncoded(key.rawRepresentation)))
+    }
+  }
+
+  // The credential names its key by thumbprint in `cnf.jkt`, so the key the
+  // proof embeds has to hash to the same value.
+  @Test func embeddedKeyMatchesTheThumbprintOfTheSigningKey() throws {
+    for type in keyTypes {
+      let key = try PrivateKey(type: type)
+      let jwt = try proof().signed(with: key)
+      let jwk = try header(of: jwt).jwk
+      var members: [(name: String, value: String)] = [
+        ("crv", jwk.crv), ("kty", jwk.kty), ("x", jwk.x),
+      ]
+      if let y = jwk.y {
+        members.append(("y", y))
+      }
+      #expect(try PublicKey.thumbprint(members: members) == key.publicKey.jwkThumbprint)
+    }
+  }
+
+  @Test func headerCarriesTheAlgorithmOfTheSigningKey() throws {
+    for type in keyTypes {
+      let jwt = try proof().signed(with: PrivateKey(type: type))
+      #expect(try header(of: jwt).alg == type.jwsAlgorithm)
+    }
+  }
+
+  // MARK: - Signature
+
+  @Test func verifiesAgainstTheEmbeddedKey() throws {
+    for type in keyTypes {
+      let key = try PrivateKey(type: type)
+      let jwt = try proof(credential: Self.credential).signed(with: key)
+      let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+      let signingInput = Data(segments[0..<2].joined(separator: ".").utf8)
+      let signature = try #require(decodedSegment(jwt, 2))
+      #expect(key.publicKey.isValidSignature(signature: signature, for: signingInput))
+
+      let other = try PrivateKey(type: type).publicKey
+      #expect(!other.isValidSignature(signature: signature, for: signingInput))
+    }
+  }
+
+  @Test func isThreeUnpaddedBase64URLSegments() throws {
+    for type in keyTypes {
+      let jwt = try proof(credential: Self.credential).signed(with: PrivateKey(type: type))
+      let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+      #expect(segments.count == 3)
+      #expect(segments.allSatisfy { !$0.isEmpty })
+      #expect(!jwt.contains("+"))
+      #expect(!jwt.contains("/"))
+      #expect(!jwt.contains("="))
+    }
+  }
+
+  // MARK: - Nonces
+
+  @Test func randomTokenIDIsHexAndDoesNotRepeat() {
+    let tokenID = DPoPProof.randomTokenID()
+    #expect(tokenID.count == 32)
+    #expect(tokenID.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+    #expect(tokenID != DPoPProof.randomTokenID())
+  }
+
+  // MARK: - Helpers
+
+  private struct DecodedJWK: Decodable, Equatable {
+    let crv: String
+    let kty: String
+    let x: String
+    let y: String?
+  }
+
+  private struct DecodedHeader: Decodable, Equatable {
+    let typ: String
+    let alg: String
+    let jwk: DecodedJWK
+  }
+
+  private struct DecodedPayload: Decodable, Equatable {
+    let ath: String?
+    let htm: String
+    let htu: String
+    let iat: Int
+    let jti: String
+  }
+
+  private func header(of jwt: String) throws -> DecodedHeader {
+    try JSONDecoder().decode(DecodedHeader.self, from: #require(decodedSegment(jwt, 0)))
+  }
+
+  private func payload(of jwt: String) throws -> DecodedPayload {
+    try JSONDecoder().decode(DecodedPayload.self, from: #require(decodedSegment(jwt, 1)))
+  }
+
+  // `memberNames(of:_:)` reads a whole segment; the `jwk` member set is a level
+  // down, so it is unwrapped here first.
+  private struct JWKMemberNames: Decodable {
+    let jwk: [String: String]
+  }
+
+  private func jwkMemberNames(of jwt: String) throws -> [String] {
+    try JSONDecoder()
+      .decode(JWKMemberNames.self, from: #require(decodedSegment(jwt, 0)))
+      .jwk.keys.sorted()
+  }
+}

--- a/Tests/ATProtoCryptoTests/JWTSegments.swift
+++ b/Tests/ATProtoCryptoTests/JWTSegments.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// `ATProtoCrypto` only encodes base64url — reading a token back is the job of the
+// introspection side, in `SwiftAtproto` — so the tests decode their own.
+func decodedSegment(_ jwt: String, _ index: Int) -> Data? {
+  let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+  guard segments.indices.contains(index) else { return nil }
+  var base64 = segments[index].replacingOccurrences(of: "-", with: "+")
+    .replacingOccurrences(of: "_", with: "/")
+  base64 += String(repeating: "=", count: (4 - base64.count % 4) % 4)
+  return Data(base64Encoded: base64)
+}
+
+struct UndecodableSegment: Error {
+  let index: Int
+}
+
+// A `Decodable` struct ignores any member it does not name, so the member sets
+// are checked separately. This reads the names alone rather than decoding the
+// values as `Any`, which would compare JSON numbers through a box whose type
+// differs between Darwin and swift-corelibs-foundation.
+func memberNames(of jwt: String, _ index: Int) throws -> [String] {
+  guard let data = decodedSegment(jwt, index) else { throw UndecodableSegment(index: index) }
+  return try JSONDecoder().decode(MemberNames.self, from: data).sorted
+}
+
+private struct MemberNames: Decodable {
+  let sorted: [String]
+
+  private struct AnyKey: CodingKey {
+    let stringValue: String
+    var intValue: Int? { nil }
+    init?(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue: Int) { nil }
+  }
+
+  init(from decoder: any Decoder) throws {
+    sorted = try decoder.container(keyedBy: AnyKey.self).allKeys.map(\.stringValue).sorted()
+  }
+}


### PR DESCRIPTION
A space credential is bound to a holder key by its `cnf.jkt`, so every request that presents one has to carry a fresh DPoP proof signed with that key; this adds `DPoPProof` to `ATProtoCrypto`, which embeds the bare public JWK in the header and normalizes `htu` to origin and path as RFC 9449 requires. Putting the proof on an XRPC request is left to a follow-up, since `SwiftAtproto` does not depend on this module.