### PR TITLE
feat: route XRPC calls across multiple hosts

### DIFF
--- a/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
@@ -34,7 +34,8 @@ attach credentials and retry once after a refresh.
 ## Build the request
 
 ``XRPCRequestComponents`` is the whole request in transport-neutral form: the
-NSID, query items, `HTTPFields` headers, method, and an optional body. Its
+NSID, query items, `HTTPFields` headers, method, an optional body, and an
+optional ``XRPCRequestDestination``. Its
 ``XRPCRequestComponents/relativePath`` is `/xrpc/<nsid>`, which you join to your
 service endpoint.
 
@@ -46,6 +47,41 @@ except for two cases that pass through unchanged — a `Data` input, and an
 Responses are decoded with the AT Protocol data encoding strategy and with
 ``LexiconDecodingMode/permissive``, so a server that exceeds an authoring
 constraint does not break decoding. See <doc:DecodingLexiconRecords>.
+
+## Route to repo and space hosts
+
+Permissioned data has no relay, so one client may need to call its default PDS,
+a space authority's host, and each member's repository host. Implement
+``DIDDocumentResolver/resolveDIDDocument(for:)`` and use its host helpers to
+derive a destination from the appropriate DID:
+
+```swift
+let repoHost = try await resolver.resolveRepoHost(for: memberDID)
+let repo = try await client.call(
+  ComAtprotoSpaceGetRepo.self,
+  input: input,
+  destination: repoHost
+)
+```
+
+``DIDDocumentResolver/resolveRepoHost(for:)`` derives the endpoint from
+``DIDDocument/pdsUrl``. ``DIDDocumentResolver/resolveSpaceHost(for:)`` uses
+``DIDDocument/spaceHostUrl``, including its PDS fallback. The destination keeps
+the logical host kind and DID even when both resolve to the same URL, allowing a
+request authorizer to select the appropriate credential.
+
+The destination arrives unchanged in `response(_:)`. A transport that also
+conforms to ``ATPClientProtocol`` chooses its base URL without changing the
+existing default path:
+
+```swift
+let endpoint = requestComponents.destination?.serviceEndpoint ?? serviceEndpoint
+```
+
+Calls that omit `destination` leave it `nil`, so generated method signatures and
+single-host clients continue to use ``ATPClientProtocol/serviceEndpoint``.
+Resolver implementations own caching and invalidation of DID documents or
+resolved destinations.
 
 ## Route through a proxy
 

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -41,6 +41,7 @@ let posts = try await client.call(
 - ``XRPCInputQuery``
 - ``XRPCProcedure``
 - ``XRPCRequestComponents``
+- ``XRPCRequestDestination``
 - ``XRPCBlobUpload``
 - ``EmptyResponse``
 - ``Parameters``
@@ -127,6 +128,7 @@ let posts = try await client.call(
 - ``DocService``
 - ``DocVerificationMethod``
 - ``DIDHandleResolver``
+- ``DIDDocumentResolver``
 - ``ServiceIdentifier``
 
 ### Errors

--- a/Sources/SwiftAtproto/XRPCRequestComponents.swift
+++ b/Sources/SwiftAtproto/XRPCRequestComponents.swift
@@ -18,18 +18,23 @@ public struct XRPCRequestComponents: Sendable {
   public var method: HTTPRequest.Method
   /// The encoded request body, or `nil` for a query.
   public var body: Data?
+  /// An explicitly resolved host for this request, or `nil` to use the
+  /// client's default service endpoint.
+  public var destination: XRPCRequestDestination?
 
   public init(
     nsId: String,
     queryItems: [URLQueryItem],
     headers: HTTPFields,
     method: HTTPRequest.Method,
-    body: Data? = nil
+    body: Data? = nil,
+    destination: XRPCRequestDestination? = nil
   ) {
     self.nsId = nsId
     self.queryItems = queryItems
     self.headers = headers
     self.method = method
     self.body = body
+    self.destination = destination
   }
 }

--- a/Sources/SwiftAtproto/XRPCRequestDestination.swift
+++ b/Sources/SwiftAtproto/XRPCRequestDestination.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// A resolved host for one XRPC request.
+///
+/// The case preserves why the host was selected even when a space host falls
+/// back to the same URL as its PDS. Request authorizers can therefore select a
+/// credential from the logical destination as well as build an absolute URL
+/// from ``serviceEndpoint``.
+public enum XRPCRequestDestination: Sendable, Hashable {
+  /// A member's permissioned repository host, resolved from its
+  /// `#atproto_pds` service.
+  case repoHost(did: DID, serviceEndpoint: URL)
+  /// A space authority's host, resolved from `#atproto_space_host` or its PDS
+  /// fallback.
+  case spaceHost(did: DID, serviceEndpoint: URL)
+
+  /// The DID whose document supplied this destination.
+  public var did: DID {
+    switch self {
+    case .repoHost(let did, _), .spaceHost(let did, _): did
+    }
+  }
+
+  /// The base URL to which the request's `/xrpc/<nsid>` path is appended.
+  public var serviceEndpoint: URL {
+    switch self {
+    case .repoHost(_, let serviceEndpoint), .spaceHost(_, let serviceEndpoint):
+      serviceEndpoint
+    }
+  }
+}
+
+/// Resolves DIDs to documents used for XRPC host discovery.
+///
+/// Implementations own caching and cache invalidation. The default host
+/// helpers validate that the returned document belongs to the requested DID,
+/// then use ``DIDDocument/pdsUrl`` and ``DIDDocument/spaceHostUrl`` to derive
+/// validated endpoints.
+public protocol DIDDocumentResolver: Sendable {
+  /// Fetches the current document for `did`.
+  func resolveDIDDocument(for did: DID) async throws -> DIDDocument
+}
+
+extension DIDDocumentResolver {
+  /// Resolves `did` to its permissioned repository host.
+  ///
+  /// Errors from document retrieval pass through unchanged. Invalid or missing
+  /// document entries throw the corresponding ``DIDDocument/VerifyError``.
+  public func resolveRepoHost(for did: DID) async throws -> XRPCRequestDestination {
+    let document = try await matchingDocument(for: did)
+    return .repoHost(did: did, serviceEndpoint: try document.pdsUrl)
+  }
+
+  /// Resolves `did` to its space host, falling back to its PDS when the
+  /// document publishes no `#atproto_space_host` service.
+  ///
+  /// Errors from document retrieval pass through unchanged. Invalid or missing
+  /// document entries throw the corresponding ``DIDDocument/VerifyError``.
+  public func resolveSpaceHost(for did: DID) async throws -> XRPCRequestDestination {
+    let document = try await matchingDocument(for: did)
+    return .spaceHost(did: did, serviceEndpoint: try document.spaceHostUrl)
+  }
+
+  private func matchingDocument(for did: DID) async throws -> DIDDocument {
+    let document = try await resolveDIDDocument(for: did)
+    guard document.did.typed == did else {
+      throw DIDDocument.VerifyError.invalidDID
+    }
+    return document
+  }
+}

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -28,8 +28,20 @@ public protocol _XRPCCallable: Sendable {
   func response(_ requestComponents: XRPCRequestComponents) async throws -> Data
   /// Calls a query, encoding `input` as query items.
   func call<X: XRPCQuery>(_ request: X.Type, input: X.Input.Query) async throws -> X.ResponseBody
+  /// Calls a query at an explicitly resolved destination.
+  func call<X: XRPCQuery>(
+    _ request: X.Type,
+    input: X.Input.Query,
+    destination: XRPCRequestDestination
+  ) async throws -> X.ResponseBody
   /// Calls a procedure, encoding `input` into the request body.
   func call<X: XRPCProcedure>(_ request: X.Type, input: X.RequestBody?) async throws -> X.ResponseBody
+  /// Calls a procedure at an explicitly resolved destination.
+  func call<X: XRPCProcedure>(
+    _ request: X.Type,
+    input: X.RequestBody?,
+    destination: XRPCRequestDestination
+  ) async throws -> X.ResponseBody
 }
 
 extension _XRPCCallable {
@@ -38,9 +50,25 @@ extension _XRPCCallable {
 
 extension _XRPCCallable {
   public func call<X: XRPCQuery>(_ query: X.Type, input: X.Input.Query) async throws -> X.ResponseBody {
+    try await call(query, input: input, destination: nil)
+  }
+
+  public func call<X: XRPCQuery>(
+    _ query: X.Type,
+    input: X.Input.Query,
+    destination: XRPCRequestDestination
+  ) async throws -> X.ResponseBody {
+    try await call(query, input: input, destination: Optional(destination))
+  }
+
+  private func call<X: XRPCQuery>(
+    _ query: X.Type,
+    input: X.Input.Query,
+    destination: XRPCRequestDestination?
+  ) async throws -> X.ResponseBody {
     let proxy = getProxy(nsid: X.id)
     try enforceRpcScopeGuard(X.self, proxy: proxy)
-    var request = try constructRequest(query, input: input)
+    var request = try constructRequest(query, input: input, destination: destination)
     if let proxy {
       request.headers[.atprotoProxy] = proxy
     }
@@ -48,11 +76,27 @@ extension _XRPCCallable {
   }
 
   public func call<X: XRPCProcedure>(_ procedure: X.Type, input: X.RequestBody?) async throws -> X.ResponseBody {
+    try await call(procedure, input: input, destination: nil)
+  }
+
+  public func call<X: XRPCProcedure>(
+    _ procedure: X.Type,
+    input: X.RequestBody?,
+    destination: XRPCRequestDestination
+  ) async throws -> X.ResponseBody {
+    try await call(procedure, input: input, destination: Optional(destination))
+  }
+
+  private func call<X: XRPCProcedure>(
+    _ procedure: X.Type,
+    input: X.RequestBody?,
+    destination: XRPCRequestDestination?
+  ) async throws -> X.ResponseBody {
     let proxy = getProxy(nsid: X.id)
     try enforceRpcScopeGuard(X.self, proxy: proxy)
     try enforceRepoScopeGuard(input as? any RepoWriteOperationDescribing)
     try enforceBlobScopeGuard(input as? XRPCBlobUpload)
-    var request = try constructRequest(procedure, input: input)
+    var request = try constructRequest(procedure, input: input, destination: destination)
     if let proxy {
       request.headers[.atprotoProxy] = proxy
     }
@@ -107,6 +151,7 @@ extension _XRPCCallable {
   func constructRequest<X: XRPCQuery>(
     _ request: X.Type,
     input: X.Input.Query,
+    destination: XRPCRequestDestination? = nil,
   ) throws -> XRPCRequestComponents {
     let queryItems = input.asParameters.map({ Self.makeParameters(params: $0) }) ?? .init()
     return .init(
@@ -116,12 +161,14 @@ extension _XRPCCallable {
         dictionaryLiteral: (.accept, "json/application")
       ),
       method: .get,
+      destination: destination
     )
   }
 
   func constructRequest<X: XRPCProcedure>(
     _ request: X.Type,
     input: X.RequestBody?,
+    destination: XRPCRequestDestination? = nil,
   ) throws -> XRPCRequestComponents {
     var headerFields = HTTPFields()
     let encoder = JSONEncoder()
@@ -148,7 +195,8 @@ extension _XRPCCallable {
       queryItems: .init(),
       headers: headerFields,
       method: .post,
-      body: body
+      body: body,
+      destination: destination
     )
   }
 

--- a/Tests/SwiftAtprotoTests/XRPCMultiHostRoutingTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCMultiHostRoutingTests.swift
@@ -1,0 +1,305 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import SwiftAtproto
+
+@Suite("XRPC multi-host routing")
+struct XRPCMultiHostRoutingTests {
+  @Test("one client routes requests to distinct resolved hosts")
+  func routesOneClientToMultipleHosts() async throws {
+    let recorder = RoutingRequestRecorder()
+    let client = RoutingClient(recorder: recorder, proxy: "did:web:proxy.example#service")
+    let memberDID = try DID(string: "did:plc:member")
+    let authorityDID = try DID(string: "did:plc:authority")
+    let firstRepo = XRPCRequestDestination.repoHost(
+      did: memberDID,
+      serviceEndpoint: URL(string: "https://repo-one.example")!)
+    let secondRepo = XRPCRequestDestination.repoHost(
+      did: memberDID,
+      serviceEndpoint: URL(string: "https://repo-two.example")!)
+    let spaceHost = XRPCRequestDestination.spaceHost(
+      did: authorityDID,
+      serviceEndpoint: URL(string: "https://space.example")!)
+
+    _ = try await client.call(RoutingQuery.self, input: .init(), destination: firstRepo)
+    _ = try await client.call(RoutingQuery.self, input: .init(), destination: secondRepo)
+    _ = try await client.call(RoutingProcedure.self, input: nil, destination: spaceHost)
+
+    let requests = await recorder.requests
+    #expect(requests.map(\.destination) == [firstRepo, secondRepo, spaceHost])
+    #expect(
+      requests.map { $0.destination?.serviceEndpoint } == [
+        URL(string: "https://repo-one.example"),
+        URL(string: "https://repo-two.example"),
+        URL(string: "https://space.example"),
+      ])
+    #expect(
+      requests.allSatisfy {
+        $0.headers[.atprotoProxy] == "did:web:proxy.example#service"
+      })
+  }
+
+  @Test("calls without a destination preserve the default route")
+  func defaultCallHasNoExplicitDestination() async throws {
+    let recorder = RoutingRequestRecorder()
+    let client = RoutingClient(recorder: recorder)
+
+    _ = try await client.call(RoutingQuery.self, input: .init())
+    _ = try await client.call(RoutingProcedure.self, input: nil)
+
+    let requests = await recorder.requests
+    #expect(requests.count == 2)
+    #expect(requests.allSatisfy { $0.destination == nil })
+  }
+
+  @Test("repo and space hosts are derived from DID documents")
+  func resolvesDedicatedHosts() async throws {
+    let did = try DID(string: "did:plc:authority")
+    let resolver = StaticDIDDocumentResolver(
+      document: document(
+        did: did,
+        services: [
+          pds("https://repo.example"),
+          .init(
+            id: "#atproto_space_host",
+            type: "AtprotoSpaceHost",
+            serviceEndpoint: "https://space.example"),
+        ]))
+
+    let repo = try await resolver.resolveRepoHost(for: did)
+    let space = try await resolver.resolveSpaceHost(for: did)
+
+    #expect(repo == .repoHost(did: did, serviceEndpoint: URL(string: "https://repo.example")!))
+    #expect(space == .spaceHost(did: did, serviceEndpoint: URL(string: "https://space.example")!))
+  }
+
+  @Test("space host fallback retains its logical destination")
+  func spaceHostFallsBackToPDS() async throws {
+    let did = try DID(string: "did:plc:authority")
+    let resolver = StaticDIDDocumentResolver(
+      document: document(
+        did: did,
+        services: [pds("https://pds.example")]))
+
+    let destination = try await resolver.resolveSpaceHost(for: did)
+
+    #expect(
+      destination
+        == .spaceHost(
+          did: did,
+          serviceEndpoint: URL(string: "https://pds.example")!))
+  }
+
+  @Test("document retrieval failures pass through unchanged")
+  func documentFailureIsDistinct() async throws {
+    let did = try DID(string: "did:plc:member")
+    let resolver = FailingDIDDocumentResolver()
+
+    await #expect(throws: ResolutionFailure.offline) {
+      _ = try await resolver.resolveRepoHost(for: did)
+    }
+  }
+
+  @Test("a resolver cannot return another DID's document")
+  func rejectsMismatchedDocument() async throws {
+    let requested = try DID(string: "did:plc:member")
+    let other = try DID(string: "did:plc:other")
+    let resolver = StaticDIDDocumentResolver(
+      document: document(
+        did: other,
+        services: [pds("https://other.example")]))
+
+    await expectVerifyError(.invalidDID) {
+      _ = try await resolver.resolveRepoHost(for: requested)
+    }
+  }
+
+  @Test("missing and invalid repo endpoints remain distinguishable")
+  func distinguishesRepoEndpointFailures() async throws {
+    let did = try DID(string: "did:plc:member")
+    let missing = StaticDIDDocumentResolver(document: document(did: did))
+    let invalid = StaticDIDDocumentResolver(
+      document: document(
+        did: did,
+        services: [pds("ftp://repo.example")]))
+
+    await expectVerifyError(.missingPDSService) {
+      _ = try await missing.resolveRepoHost(for: did)
+    }
+    await expectVerifyError(.invalidPDSEndpoint) {
+      _ = try await invalid.resolveRepoHost(for: did)
+    }
+  }
+
+  @Test("an invalid dedicated space endpoint does not fall back")
+  func rejectsInvalidDedicatedSpaceEndpoint() async throws {
+    let did = try DID(string: "did:plc:authority")
+    let resolver = StaticDIDDocumentResolver(
+      document: document(
+        did: did,
+        services: [
+          pds("https://pds.example"),
+          .init(
+            id: "#atproto_space_host",
+            type: "AtprotoSpaceHost",
+            serviceEndpoint: "/xrpc"),
+        ]))
+
+    await expectVerifyError(.invalidServiceEndpoint) {
+      _ = try await resolver.resolveSpaceHost(for: did)
+    }
+  }
+
+  @Test("subscriptions continue to use the client's service endpoint")
+  func subscriptionUsesDefaultEndpoint() async throws {
+    let client = DefaultSubscriptionClient()
+    let request = try await client.prepareSubscriptionRequest(
+      .init(
+        nsId: "com.example.subscribe",
+        queryItems: [.init(name: "cursor", value: "1")],
+        headers: .init()))
+
+    #expect(request.url.absoluteString == "wss://default.example/xrpc/com.example.subscribe?cursor=1")
+  }
+}
+
+private actor RoutingRequestRecorder {
+  private(set) var requests: [XRPCRequestComponents] = []
+
+  func record(_ request: XRPCRequestComponents) {
+    requests.append(request)
+  }
+}
+
+private struct RoutingClient: _XRPCCallable {
+  let recorder: RoutingRequestRecorder
+  let proxy: String?
+
+  init(recorder: RoutingRequestRecorder, proxy: String? = nil) {
+    self.recorder = recorder
+    self.proxy = proxy
+  }
+
+  func getProxy(nsid _: String) -> String? { proxy }
+
+  func response(_ requestComponents: XRPCRequestComponents) async throws -> Data {
+    await recorder.record(requestComponents)
+    return Data()
+  }
+}
+
+private struct RoutingQuery: XRPCQuery {
+  static let id = "com.example.query"
+  typealias Input = RoutingQueryInput
+  typealias ResponseBody = EmptyResponse
+  typealias Error = RoutingError
+}
+
+private struct RoutingQueryInput: XRPCQueryInput {
+  struct Query: XRPCInputQuery {
+    var asParameters: Parameters? { nil }
+  }
+
+  let query = Query()
+}
+
+private struct RoutingProcedure: XRPCProcedure {
+  static let id = "com.example.procedure"
+  static let contentType = "application/json"
+  typealias RequestBody = EmptyResponse
+  typealias ResponseBody = EmptyResponse
+  typealias Error = RoutingError
+}
+
+private enum RoutingError: XRPCError {
+  case unexpected(error: String?, message: String?)
+
+  init(error: UnExpectedError) {
+    self = .unexpected(error: error.error, message: error.message)
+  }
+
+  var error: String? {
+    if case .unexpected(let error, _) = self { return error }
+    return nil
+  }
+
+  var message: String? {
+    if case .unexpected(_, let message) = self { return message }
+    return nil
+  }
+}
+
+private struct StaticDIDDocumentResolver: DIDDocumentResolver {
+  let document: DIDDocument
+
+  func resolveDIDDocument(for _: DID) async throws -> DIDDocument { document }
+}
+
+private struct FailingDIDDocumentResolver: DIDDocumentResolver {
+  func resolveDIDDocument(for _: DID) async throws -> DIDDocument {
+    throw ResolutionFailure.offline
+  }
+}
+
+private enum ResolutionFailure: Error, Equatable {
+  case offline
+}
+
+private func document(did: DID, services: [DocService] = []) -> DIDDocument {
+  DIDDocument(context: [], did: FormatString(did), service: services)
+}
+
+private func pds(_ endpoint: String) -> DocService {
+  DocService(
+    id: "#atproto_pds",
+    type: "AtprotoPersonalDataServer",
+    serviceEndpoint: endpoint)
+}
+
+private func expectVerifyError(
+  _ expected: DIDDocument.VerifyError,
+  performing operation: () async throws -> Void
+) async {
+  do {
+    try await operation()
+    Issue.record("Expected \(expected)")
+  } catch let error as DIDDocument.VerifyError {
+    #expect(sameVerifyError(error, expected))
+  } catch {
+    Issue.record("Expected DIDDocument.VerifyError, got \(error)")
+  }
+}
+
+private func sameVerifyError(
+  _ lhs: DIDDocument.VerifyError,
+  _ rhs: DIDDocument.VerifyError
+) -> Bool {
+  switch (lhs, rhs) {
+  case (.missingPDSService, .missingPDSService),
+    (.invalidPDSEndpoint, .invalidPDSEndpoint),
+    (.invalidDID, .invalidDID),
+    (.invalidServiceEndpoint, .invalidServiceEndpoint):
+    true
+  default:
+    false
+  }
+}
+
+private struct DefaultSubscriptionClient: ATPClientProtocol, XRPCSubscriptionCallable {
+  let serviceEndpoint = URL(string: "https://default.example")!
+  let decoder = JSONDecoder()
+  let subscriptionTransport: any XRPCSubscriptionTransport = UnusedSubscriptionTransport()
+
+  func tokenIsExpired(error _: some XRPCError) -> Bool { false }
+  func getAuthorization(endpoint _: String) -> String? { nil }
+  func refreshSession() async -> Bool { false }
+  func response(_: XRPCRequestComponents) async throws -> Data { Data() }
+}
+
+private struct UnusedSubscriptionTransport: XRPCSubscriptionTransport {
+  func connect(_: XRPCWebSocketRequest) async throws -> XRPCWebSocketConnection {
+    Issue.record("Unexpected subscription connection")
+    return .init(messages: .init { $0.finish() }, close: {})
+  }
+}


### PR DESCRIPTION
Adds per-request XRPC routing to resolved repo and space hosts while preserving the client's default endpoint and existing proxy behavior.