### PR TITLE
feat: add XRPC request authorizers

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -101,6 +101,7 @@ let package = Package(
     .testTarget(
       name: "SwiftAtprotoTests",
       dependencies: [
+        "ATProtoCrypto",
         "SwiftAtproto",
         .product(name: "SwiftCbor", package: "swift-cbor"),
       ]

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
@@ -48,6 +48,50 @@ Responses are decoded with the AT Protocol data encoding strategy and with
 ``LexiconDecodingMode/permissive``, so a server that exceeds an authoring
 constraint does not break decoding. See <doc:DecodingLexiconRecords>.
 
+## Authorize the complete request
+
+``XRPCRequestAuthorizer`` receives the complete request after any
+`atproto-proxy` header has been applied. It also receives the resolved service
+endpoint, so it can combine that base URL with the request's relative path and
+build the absolute `htu` of a DPoP proof. Its `async throws` boundary allows the
+implementation to load a signing key and generate a fresh proof before every
+attempt.
+
+``ATPClientProtocol`` conforms to the authorizer protocol. Its default
+implementation preserves existing clients by reading the raw token from
+``ATPClientProtocol/getAuthorization(endpoint:)`` and applying it as
+`Authorization: Bearer <token>`. A client that needs permissioned data overrides
+the authorizer method and can select an ``XRPCCredential`` from both the logical
+destination and the NSID:
+
+```swift
+func authorize(
+  _ request: XRPCRequestComponents,
+  serviceEndpoint: URL
+) async throws -> XRPCRequestComponents {
+  var request = request
+  let credential = try await credentials.credential(for: request.destination)
+
+  switch credential {
+  case .spaceDelegationToken(let token):
+    request.headers[.authorization] = "Bearer \(token)"
+    request.headers[.dpop] = try await proof(for: request, at: serviceEndpoint)
+  case .spaceCredential(let token):
+    request.headers[.authorization] = "DPoP \(token)"
+    request.headers[.dpop] = try await proof(for: request, at: serviceEndpoint)
+  default:
+    break
+  }
+  return request
+}
+```
+
+The proof crosses this boundary as a `String`. It may come from
+`ATProtoCrypto`, an OAuth package, or another producer; `SwiftAtproto` does not
+depend on a cryptography implementation. A client attestation is also a
+distinct credential case, but it belongs in the `getSpaceCredential` request
+body rather than an authorization header.
+
 ## Route to repo and space hosts
 
 Permissioned data has no relay, so one client may need to call its default PDS,

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/Subscriptions.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/Subscriptions.md
@@ -28,8 +28,10 @@ and with a NIO-based client on Linux is the usual arrangement.
 ``ATPClientProtocol`` already implements
 ``XRPCSubscriptionCallable/prepareSubscriptionRequest(_:)`` for you: it appends
 `xrpc/<nsid>` to the service endpoint, rewrites the scheme from `https` to `wss`
-(or `http` to `ws`), attaches the query items, and adds the `Authorization`
-header from ``ATPClientProtocol/getAuthorization(endpoint:)``.
+(or `http` to `ws`), attaches the query items, and passes the handshake headers
+through ``XRPCRequestAuthorizer``. The default authorizer reads the raw token
+from ``ATPClientProtocol/getAuthorization(endpoint:)`` and sends it as a Bearer
+credential, matching ordinary XRPC calls.
 
 ## Frame handling
 

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -42,6 +42,8 @@ let posts = try await client.call(
 - ``XRPCProcedure``
 - ``XRPCRequestComponents``
 - ``XRPCRequestDestination``
+- ``XRPCRequestAuthorizer``
+- ``XRPCCredential``
 - ``XRPCBlobUpload``
 - ``EmptyResponse``
 - ``Parameters``

--- a/Sources/SwiftAtproto/XRPCRequestAuthorizer.swift
+++ b/Sources/SwiftAtproto/XRPCRequestAuthorizer.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Adds credentials and proof headers to a prepared XRPC request.
+///
+/// The request already contains its method, path, query, body, logical
+/// destination, and proxy header. `serviceEndpoint` is the resolved base URL
+/// used to turn ``XRPCRequestComponents/relativePath`` into the absolute target
+/// URI required by DPoP.
+public protocol XRPCRequestAuthorizer: Sendable {
+  /// Returns the request to send after applying credentials for its destination.
+  ///
+  /// Implementations may perform asynchronous key access or proof generation
+  /// and may throw without invoking the transport.
+  func authorize(
+    _ requestComponents: XRPCRequestComponents,
+    serviceEndpoint: URL
+  ) async throws -> XRPCRequestComponents
+}
+
+/// A credential selected for an XRPC request or permissioned-data exchange.
+///
+/// The cases keep ordinary access tokens separate from the three credential
+/// classes introduced by permissioned data. This type does not decide how a
+/// credential travels: an authorizer applies access and delegation tokens as
+/// appropriate, applies a space credential with its DPoP proof, and passes a
+/// client attestation in the credential-exchange request body.
+public enum XRPCCredential: Sendable, Hashable {
+  /// An ordinary access token for the client's own session.
+  case accessToken(String)
+  /// A user's delegation token forwarded to a space authority.
+  case spaceDelegationToken(String)
+  /// A space authority credential presented to a repository host.
+  case spaceCredential(String)
+  /// An application attestation passed in a space-credential exchange body.
+  case clientAttestation(String)
+
+  /// The credential's wire value.
+  public var value: String {
+    switch self {
+    case .accessToken(let value), .spaceDelegationToken(let value),
+      .spaceCredential(let value), .clientAttestation(let value):
+      value
+    }
+  }
+}
+
+extension XRPCCredential: CustomStringConvertible, CustomDebugStringConvertible,
+  CustomReflectable
+{
+  /// Identifies the credential class without revealing its value.
+  public var description: String {
+    switch self {
+    case .accessToken: "XRPCCredential.accessToken(<redacted>)"
+    case .spaceDelegationToken: "XRPCCredential.spaceDelegationToken(<redacted>)"
+    case .spaceCredential: "XRPCCredential.spaceCredential(<redacted>)"
+    case .clientAttestation: "XRPCCredential.clientAttestation(<redacted>)"
+    }
+  }
+
+  /// Identifies the credential class without revealing its value.
+  public var debugDescription: String { description }
+
+  /// Prevents reflection-based logging from exposing the credential value.
+  public var customMirror: Mirror {
+    Mirror(self, children: ["description": description], displayStyle: .enum)
+  }
+}

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -3,6 +3,8 @@ import HTTPTypes
 
 extension HTTPField.Name {
   static var atprotoProxy: Self { .init("atproto-proxy")! }
+  /// A proof of possession for a DPoP-bound authorization credential.
+  public static var dpop: Self { .init("dpop")! }
 }
 
 /// The minimum a client has to provide in order to make XRPC calls.
@@ -17,6 +19,11 @@ public protocol _XRPCCallable: Sendable {
   /// The OAuth session whose granted scopes gate outgoing calls, or `nil` to
   /// skip scope enforcement entirely. Defaults to `nil`.
   var oauthSession: (any OAuthSession)? { get }
+  /// Applies credentials and proof headers after the request and proxy header
+  /// have been prepared. The default leaves the request unchanged.
+  func authorize(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCRequestComponents
   /// The service to proxy this method to via the `atproto-proxy` header, or
   /// `nil` to send it to the client's own endpoint.
   func getProxy(nsid: String) -> String?
@@ -46,6 +53,12 @@ public protocol _XRPCCallable: Sendable {
 
 extension _XRPCCallable {
   public var oauthSession: (any OAuthSession)? { nil }
+
+  public func authorize(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCRequestComponents {
+    requestComponents
+  }
 }
 
 extension _XRPCCallable {
@@ -72,6 +85,7 @@ extension _XRPCCallable {
     if let proxy {
       request.headers[.atprotoProxy] = proxy
     }
+    request = try await authorize(request)
     return try await send(query, for: request)
   }
 
@@ -100,6 +114,7 @@ extension _XRPCCallable {
     if let proxy {
       request.headers[.atprotoProxy] = proxy
     }
+    request = try await authorize(request)
     return try await send(procedure, for: request)
   }
 

--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -5,7 +5,7 @@ import Foundation
 /// Refines the callable infrastructure with the endpoint and session hooks a
 /// transport needs. Implementing `response(_:)` is still the only
 /// transport-specific work; see <doc:MakingXRPCCalls>.
-public protocol ATPClientProtocol: _XRPCCallable {
+public protocol ATPClientProtocol: _XRPCCallable, XRPCRequestAuthorizer {
   /// The service base URL that `/xrpc/<nsid>` is appended to.
   var serviceEndpoint: URL { get }
   /// The decoder used for response payloads.
@@ -14,8 +14,12 @@ public protocol ATPClientProtocol: _XRPCCallable {
   /// Whether this error means the access token needs refreshing, so the call
   /// can be retried after ``refreshSession()``.
   func tokenIsExpired(error: some XRPCError) -> Bool
-  /// The `Authorization` header value to send for this method, or `nil` for an
+  /// The raw bearer token to send for this method, or `nil` for an
   /// unauthenticated call.
+  ///
+  /// The default request authorizer prefixes this value with `Bearer`. Override
+  /// ``XRPCRequestAuthorizer/authorize(_:serviceEndpoint:)`` to select
+  /// destination-specific credentials or add DPoP proofs.
   func getAuthorization(endpoint: String) -> String?
 
   /// Refreshes the session, returning whether it succeeded.
@@ -37,6 +41,24 @@ public protocol _XRPCClientProtocol: ATPClientProtocol {
 
 extension ATPClientProtocol {
   public func getProxy(nsid _: String) -> String? { nil }
+
+  public func authorize(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCRequestComponents {
+    let endpoint = requestComponents.destination?.serviceEndpoint ?? serviceEndpoint
+    return try await authorize(requestComponents, serviceEndpoint: endpoint)
+  }
+
+  public func authorize(
+    _ requestComponents: XRPCRequestComponents,
+    serviceEndpoint _: URL
+  ) async throws -> XRPCRequestComponents {
+    var requestComponents = requestComponents
+    if let token = getAuthorization(endpoint: requestComponents.nsId) {
+      requestComponents.headers[.authorization] = "Bearer \(token)"
+    }
+    return requestComponents
+  }
 }
 
 extension ATPClientProtocol where Self: XRPCSubscriptionCallable {
@@ -55,11 +77,14 @@ extension ATPClientProtocol where Self: XRPCSubscriptionCallable {
     guard let url = urlComponents?.url else {
       throw URLError(.badURL)
     }
-    var headers = components.headers
-    if let authorization = getAuthorization(endpoint: components.nsId) {
-      headers[.authorization] = authorization
-    }
-    return XRPCWebSocketRequest(url: url, headers: headers)
+    let requestComponents = try await authorize(
+      XRPCRequestComponents(
+        nsId: components.nsId,
+        queryItems: components.queryItems,
+        headers: components.headers,
+        method: .get),
+      serviceEndpoint: serviceEndpoint)
+    return XRPCWebSocketRequest(url: url, headers: requestComponents.headers)
   }
 }
 

--- a/Tests/SwiftAtprotoTests/XRPCRequestAuthorizerTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCRequestAuthorizerTests.swift
@@ -1,0 +1,343 @@
+import ATProtoCrypto
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import SwiftAtproto
+
+@Suite("XRPC request authorization")
+struct XRPCRequestAuthorizerTests {
+  @Test("selects credentials from the logical destination")
+  func selectsCredentialsByDestination() async throws {
+    let authorizationRecorder = AuthorizationRecorder()
+    let transportRecorder = RequestRecorder()
+    let client = AuthorizingClient(
+      serviceEndpoint: URL(string: "https://pds.example")!,
+      proxy: "did:web:proxy.example#service",
+      authorizer: DestinationAuthorizer(recorder: authorizationRecorder),
+      recorder: transportRecorder)
+    let spaceDID = try DID(string: "did:plc:space")
+    let repoDID = try DID(string: "did:plc:member")
+
+    _ = try await client.call(AuthorizationQuery.self, input: .init())
+    _ = try await client.call(
+      AuthorizationQuery.self,
+      input: .init(),
+      destination: .spaceHost(
+        did: spaceDID,
+        serviceEndpoint: URL(string: "https://space.example")!))
+    _ = try await client.call(
+      AuthorizationQuery.self,
+      input: .init(),
+      destination: .repoHost(
+        did: repoDID,
+        serviceEndpoint: URL(string: "https://repo.example")!))
+
+    let authorizations = await authorizationRecorder.snapshots
+    #expect(
+      authorizations.map(\.serviceEndpoint.absoluteString) == [
+        "https://pds.example", "https://space.example", "https://repo.example",
+      ])
+    #expect(
+      authorizations.allSatisfy {
+        $0.request.headers[.atprotoProxy] == "did:web:proxy.example#service"
+      })
+    #expect(authorizations[0].request.destination == nil)
+    #expect(
+      authorizations[1].request.destination
+        == .spaceHost(
+          did: spaceDID,
+          serviceEndpoint: URL(string: "https://space.example")!))
+    #expect(
+      authorizations[2].request.destination
+        == .repoHost(
+          did: repoDID,
+          serviceEndpoint: URL(string: "https://repo.example")!))
+
+    let requests = await transportRecorder.requests
+    #expect(requests[0].headers[.authorization] == "Bearer access-token")
+    #expect(requests[0].headers[.dpop] == nil)
+    #expect(requests[1].headers[.authorization] == "Bearer delegation-token")
+    #expect(requests[1].headers[.dpop] == "delegation-proof")
+    #expect(requests[2].headers[.authorization] == "DPoP space-credential")
+    #expect(requests[2].headers[.dpop] == "credential-proof")
+  }
+
+  @Test("passes proofs from ATProtoCrypto and other producers unchanged")
+  func acceptsProofStringsFromAnyProducer() async throws {
+    let endpoint = URL(string: "https://repo.example")!
+    let target = endpoint.appending(path: "xrpc/\(AuthorizationQuery.id)")
+    let cryptoProof = try DPoPProof(
+      httpMethod: "GET",
+      url: target,
+      issuedAt: Date(timeIntervalSince1970: 1_738_368_000),
+      tokenID: "b3c4d5e6f7a8b9c0d1e2f3a4b5c6d7e8",
+      credential: "space-credential"
+    ).signed(with: PrivateKey(type: .p256))
+
+    for proof in [cryptoProof, "consumer-produced-proof"] {
+      let recorder = RequestRecorder()
+      let client = AuthorizingClient(
+        serviceEndpoint: endpoint,
+        authorizer: StaticDPoPAuthorizer(proof: proof),
+        recorder: recorder)
+
+      _ = try await client.call(AuthorizationQuery.self, input: .init())
+
+      let request = try #require(await recorder.requests.first)
+      #expect(request.headers[.authorization] == "DPoP space-credential")
+      #expect(request.headers[.dpop] == proof)
+    }
+  }
+
+  @Test("preserves a procedure body while authorizing")
+  func preservesProcedureBody() async throws {
+    let recorder = RequestRecorder()
+    let client = AuthorizingClient(
+      serviceEndpoint: URL(string: "https://pds.example")!,
+      authorizer: StaticDPoPAuthorizer(proof: "proof"),
+      recorder: recorder)
+    let input = AuthorizationProcedureBody(value: "kept")
+
+    _ = try await client.call(AuthorizationProcedure.self, input: input)
+
+    let request = try #require(await recorder.requests.first)
+    #expect(request.method == .post)
+    #expect(try JSONDecoder().decode(AuthorizationProcedureBody.self, from: #require(request.body)) == input)
+  }
+
+  @Test("does not invoke the transport when authorization fails")
+  func propagatesAuthorizationErrors() async {
+    let recorder = RequestRecorder()
+    let client = AuthorizingClient(
+      serviceEndpoint: URL(string: "https://pds.example")!,
+      authorizer: FailingAuthorizer(),
+      recorder: recorder)
+
+    await #expect(throws: AuthorizationFailure.missingCredential) {
+      _ = try await client.call(AuthorizationQuery.self, input: .init())
+    }
+    #expect(await recorder.requests.isEmpty)
+  }
+
+  @Test("bridges legacy bearer tokens for calls and subscriptions")
+  func migratesLegacyBearerTokens() async throws {
+    let recorder = RequestRecorder()
+    let client = LegacyAuthorizationClient(recorder: recorder)
+
+    _ = try await client.call(AuthorizationQuery.self, input: .init())
+    let unary = try #require(await recorder.requests.first)
+    #expect(unary.headers[.authorization] == "Bearer raw-token")
+
+    let subscription = try await client.prepareSubscriptionRequest(
+      .init(nsId: "com.example.subscribe", queryItems: [], headers: .init()))
+    #expect(subscription.headers[.authorization] == "Bearer raw-token")
+  }
+
+  @Test("keeps credential values out of descriptions and reflection")
+  func redactsCredentialValues() {
+    let credentials: [XRPCCredential] = [
+      .accessToken("access-secret"),
+      .spaceDelegationToken("delegation-secret"),
+      .spaceCredential("credential-secret"),
+      .clientAttestation("attestation-secret"),
+    ]
+
+    for credential in credentials {
+      let secret = credential.value
+      #expect(!credential.description.contains(secret))
+      #expect(!credential.debugDescription.contains(secret))
+      #expect(!String(reflecting: credential).contains(secret))
+      #expect(
+        !Mirror(reflecting: credential).children.contains {
+          String(describing: $0.value).contains(secret)
+        })
+    }
+  }
+}
+
+private struct DestinationAuthorizer: XRPCRequestAuthorizer {
+  let recorder: AuthorizationRecorder
+
+  func authorize(
+    _ requestComponents: XRPCRequestComponents,
+    serviceEndpoint: URL
+  ) async throws -> XRPCRequestComponents {
+    await recorder.record(requestComponents, serviceEndpoint: serviceEndpoint)
+    var request = requestComponents
+    let credential: XRPCCredential
+    let proof: String?
+    switch request.destination {
+    case nil:
+      credential = .accessToken("access-token")
+      proof = nil
+    case .spaceHost:
+      credential = .spaceDelegationToken("delegation-token")
+      proof = "delegation-proof"
+    case .repoHost:
+      credential = .spaceCredential("space-credential")
+      proof = "credential-proof"
+    }
+    switch credential {
+    case .accessToken(let token), .spaceDelegationToken(let token):
+      request.headers[.authorization] = "Bearer \(token)"
+    case .spaceCredential(let token):
+      request.headers[.authorization] = "DPoP \(token)"
+    case .clientAttestation:
+      break
+    }
+    request.headers[.dpop] = proof
+    return request
+  }
+}
+
+private struct StaticDPoPAuthorizer: XRPCRequestAuthorizer {
+  let proof: String
+
+  func authorize(
+    _ requestComponents: XRPCRequestComponents,
+    serviceEndpoint _: URL
+  ) async throws -> XRPCRequestComponents {
+    var request = requestComponents
+    request.headers[.authorization] = "DPoP space-credential"
+    request.headers[.dpop] = proof
+    return request
+  }
+}
+
+private struct FailingAuthorizer: XRPCRequestAuthorizer {
+  func authorize(
+    _: XRPCRequestComponents,
+    serviceEndpoint _: URL
+  ) async throws -> XRPCRequestComponents {
+    throw AuthorizationFailure.missingCredential
+  }
+}
+
+private enum AuthorizationFailure: Error, Equatable {
+  case missingCredential
+}
+
+private struct AuthorizingClient: ATPClientProtocol {
+  let serviceEndpoint: URL
+  let proxy: String?
+  let authorizer: any XRPCRequestAuthorizer
+  let recorder: RequestRecorder
+  let decoder = JSONDecoder()
+
+  init(
+    serviceEndpoint: URL,
+    proxy: String? = nil,
+    authorizer: any XRPCRequestAuthorizer,
+    recorder: RequestRecorder
+  ) {
+    self.serviceEndpoint = serviceEndpoint
+    self.proxy = proxy
+    self.authorizer = authorizer
+    self.recorder = recorder
+  }
+
+  func getProxy(nsid _: String) -> String? { proxy }
+  func getAuthorization(endpoint _: String) -> String? { nil }
+  func tokenIsExpired(error _: some XRPCError) -> Bool { false }
+  func refreshSession() async -> Bool { false }
+
+  func authorize(
+    _ requestComponents: XRPCRequestComponents,
+    serviceEndpoint: URL
+  ) async throws -> XRPCRequestComponents {
+    try await authorizer.authorize(requestComponents, serviceEndpoint: serviceEndpoint)
+  }
+
+  func response(_ requestComponents: XRPCRequestComponents) async throws -> Data {
+    await recorder.record(requestComponents)
+    return Data()
+  }
+}
+
+private struct LegacyAuthorizationClient: ATPClientProtocol, XRPCSubscriptionCallable {
+  let recorder: RequestRecorder
+  let serviceEndpoint = URL(string: "https://pds.example")!
+  let decoder = JSONDecoder()
+  let subscriptionTransport: any XRPCSubscriptionTransport = UnusedSubscriptionTransport()
+
+  func getProxy(nsid _: String) -> String? { nil }
+  func getAuthorization(endpoint _: String) -> String? { "raw-token" }
+  func tokenIsExpired(error _: some XRPCError) -> Bool { false }
+  func refreshSession() async -> Bool { false }
+
+  func response(_ requestComponents: XRPCRequestComponents) async throws -> Data {
+    await recorder.record(requestComponents)
+    return Data()
+  }
+}
+
+private struct UnusedSubscriptionTransport: XRPCSubscriptionTransport {
+  func connect(_: XRPCWebSocketRequest) async throws -> XRPCWebSocketConnection {
+    throw AuthorizationFailure.missingCredential
+  }
+}
+
+private actor AuthorizationRecorder {
+  private(set) var snapshots: [AuthorizationSnapshot] = []
+
+  func record(_ request: XRPCRequestComponents, serviceEndpoint: URL) {
+    snapshots.append(.init(request: request, serviceEndpoint: serviceEndpoint))
+  }
+}
+
+private struct AuthorizationSnapshot: Sendable {
+  let request: XRPCRequestComponents
+  let serviceEndpoint: URL
+}
+
+private actor RequestRecorder {
+  private(set) var requests: [XRPCRequestComponents] = []
+
+  func record(_ request: XRPCRequestComponents) {
+    requests.append(request)
+  }
+}
+
+private struct AuthorizationQuery: XRPCQuery {
+  static let id = "com.example.authorization"
+  typealias Input = AuthorizationQueryInput
+  typealias ResponseBody = EmptyResponse
+  typealias Error = AuthorizationError
+}
+
+private struct AuthorizationQueryInput: XRPCQueryInput {
+  struct Query: XRPCInputQuery {
+    var asParameters: Parameters? { nil }
+  }
+
+  let query = Query()
+}
+
+private struct AuthorizationProcedure: XRPCProcedure {
+  static let id = "com.example.authorizationProcedure"
+  static let contentType = "application/json"
+  typealias RequestBody = AuthorizationProcedureBody
+  typealias ResponseBody = EmptyResponse
+  typealias Error = AuthorizationError
+}
+
+private struct AuthorizationProcedureBody: Codable, Sendable, Hashable {
+  let value: String
+}
+
+private enum AuthorizationError: XRPCError {
+  case unexpected(error: String?, message: String?)
+
+  init(error: UnExpectedError) {
+    self = .unexpected(error: error.error, message: error.message)
+  }
+
+  var error: String? {
+    if case .unexpected(let error, _) = self { error } else { nil }
+  }
+
+  var message: String? {
+    if case .unexpected(_, let message) = self { message } else { nil }
+  }
+}


### PR DESCRIPTION
Adds an async request authorization boundary that receives complete XRPC request context and supports destination-specific credentials and DPoP proofs. Preserves legacy Bearer-token clients while normalizing subscription authorization and documenting the migration path.