### PR TITLE
feat: retry DPoP nonce challenges

### DIFF
--- a/Sources/ATProtoCrypto/DPoPProof.swift
+++ b/Sources/ATProtoCrypto/DPoPProof.swift
@@ -58,6 +58,13 @@ public struct DPoPProof: Sendable, Hashable {
   /// this has to track what the request actually carries.
   public let credential: String?
 
+  /// The server-provided nonce required after a `DPoP-Nonce` challenge.
+  ///
+  /// Leave this `nil` for the first attempt. When a service responds with
+  /// `use_dpop_nonce`, build a new proof with the response header's value and a
+  /// fresh ``tokenID``.
+  public let serverNonce: String?
+
   /// Describes a proof. Nothing is signed until ``signed(with:)``.
   ///
   /// Every claim is supplied by the caller, including the nonce: a proof is
@@ -67,13 +74,15 @@ public struct DPoPProof: Sendable, Hashable {
     url: URL,
     issuedAt: Date,
     tokenID: String,
-    credential: String? = nil
+    credential: String? = nil,
+    serverNonce: String? = nil
   ) {
     self.httpMethod = httpMethod
     self.url = url
     self.issuedAt = issuedAt
     self.tokenID = tokenID
     self.credential = credential
+    self.serverNonce = serverNonce
   }
 
   /// The `htu` this proof carries: ``url`` reduced to its origin and path.
@@ -130,7 +139,8 @@ public struct DPoPProof: Sendable, Hashable {
         htm: httpMethod,
         htu: httpTargetURI,
         iat: Int(issuedAt.timeIntervalSince1970),
-        jti: tokenID),
+        jti: tokenID,
+        nonce: serverNonce),
       signedWith: key)
   }
 
@@ -179,17 +189,28 @@ public struct DPoPProof: Sendable, Hashable {
     let htu: String
     let iat: Int
     let jti: String
+    let nonce: String?
   }
 }
 
-extension DPoPProof: CustomStringConvertible {
-  /// Withholds ``credential`` and ``tokenID``. The default reflected description
-  /// would print both, and a proof is most likely to be described while being
-  /// logged.
+extension DPoPProof: CustomStringConvertible, CustomDebugStringConvertible,
+  CustomReflectable
+{
+  /// Withholds ``credential``, ``tokenID``, and ``serverNonce``. The default
+  /// reflected description would print them, and a proof is most likely to be
+  /// described while being logged.
   public var description: String {
     """
     DPoPProof(httpMethod: \(httpMethod), url: \(url), issuedAt: \(issuedAt), \
     presentsCredential: \(credential != nil))
     """
+  }
+
+  /// Describes the proof without revealing credentials or nonce values.
+  public var debugDescription: String { description }
+
+  /// Prevents reflection-based logging from exposing credentials or nonces.
+  public var customMirror: Mirror {
+    Mirror(self, children: ["description": description], displayStyle: .struct)
   }
 }

--- a/Sources/ATProtoCrypto/Documentation.docc/Articles/DPoPProofs.md
+++ b/Sources/ATProtoCrypto/Documentation.docc/Articles/DPoPProofs.md
@@ -93,10 +93,11 @@ A proof covers one method and one URL and is good for one request:
   ``DPoPProof/randomTokenID()`` produces a fresh value: 16 random bytes as
   lowercase hexadecimal.
 
-There is no `nonce` claim. RFC 9449 lets an authorization server or a resource
-server demand one with a `DPoP-Nonce` challenge, but the space exchange in the
-reference implementation of the proposal issues no such challenge, so nothing
-here emits one.
+``DPoPProof/serverNonce`` is absent on the first attempt. If an authorization or
+resource server responds with the `use_dpop_nonce` error and a `DPoP-Nonce`
+header, store that value for the server and build one new proof with it. The
+retry still needs a fresh ``DPoPProof/tokenID``: the server nonce does not make a
+proof reusable.
 
 ## Algorithms
 

--- a/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
@@ -48,6 +48,12 @@ Responses are decoded with the AT Protocol data encoding strategy and with
 ``LexiconDecodingMode/permissive``, so a server that exceeds an authoring
 constraint does not break decoding. See <doc:DecodingLexiconRecords>.
 
+The original `response(_:)` transport requirement returns only `Data` and
+remains sufficient for clients that handle HTTP failures themselves. A
+transport that wants the runtime to inspect a failure overrides
+`responseWithMetadata(_:)` and returns ``XRPCResponseComponents`` for success
+and failure responses alike. Network and transport failures still throw.
+
 ## Authorize the complete request
 
 ``XRPCRequestAuthorizer`` receives the complete request after any
@@ -91,6 +97,21 @@ The proof crosses this boundary as a `String`. It may come from
 depend on a cryptography implementation. A client attestation is also a
 distinct credential case, but it belongs in the `getSpaceCredential` request
 body rather than an authorization header.
+
+## Retry a DPoP nonce challenge
+
+When a metadata response is unsuccessful, carries the `use_dpop_nonce` error,
+and includes a nonempty `DPoP-Nonce` header, the runtime offers that nonce to
+``XRPCRequestAuthorizer/storeDPoPNonce(_:for:serviceEndpoint:)``. Returning
+`true` promises that the next authorization pass will build a new proof with
+the stored nonce. The runtime then authorizes the original request components
+again and sends one retry.
+
+A second challenge is returned as the method's error without another store or
+retry. Missing headers, unrelated errors, and authorizers that return `false`
+also stop after the first response. Procedure bodies are immutable `Data` in
+``XRPCRequestComponents``, so the retry reuses the exact encoded bytes only
+after the server has explicitly rejected the first proof.
 
 ## Route to repo and space hosts
 

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -41,6 +41,7 @@ let posts = try await client.call(
 - ``XRPCInputQuery``
 - ``XRPCProcedure``
 - ``XRPCRequestComponents``
+- ``XRPCResponseComponents``
 - ``XRPCRequestDestination``
 - ``XRPCRequestAuthorizer``
 - ``XRPCCredential``

--- a/Sources/SwiftAtproto/XRPCRequestAuthorizer.swift
+++ b/Sources/SwiftAtproto/XRPCRequestAuthorizer.swift
@@ -15,6 +15,27 @@ public protocol XRPCRequestAuthorizer: Sendable {
     _ requestComponents: XRPCRequestComponents,
     serviceEndpoint: URL
   ) async throws -> XRPCRequestComponents
+
+  /// Stores a server-provided DPoP nonce for the request's destination.
+  ///
+  /// Return `true` only when a later call to ``authorize(_:serviceEndpoint:)``
+  /// will use `nonce` to build a new proof. The default returns `false`, which
+  /// leaves the challenge response untouched and prevents a retry.
+  func storeDPoPNonce(
+    _ nonce: String,
+    for requestComponents: XRPCRequestComponents,
+    serviceEndpoint: URL
+  ) async throws -> Bool
+}
+
+extension XRPCRequestAuthorizer {
+  public func storeDPoPNonce(
+    _: String,
+    for _: XRPCRequestComponents,
+    serviceEndpoint _: URL
+  ) async throws -> Bool {
+    false
+  }
 }
 
 /// A credential selected for an XRPC request or permissioned-data exchange.

--- a/Sources/SwiftAtproto/XRPCResponseComponents.swift
+++ b/Sources/SwiftAtproto/XRPCResponseComponents.swift
@@ -1,0 +1,23 @@
+import Foundation
+import HTTPTypes
+
+/// An XRPC response with the HTTP metadata needed by protocol-level handling.
+///
+/// A transport that supports DPoP nonce challenges returns this value from
+/// `_XRPCCallable.responseWithMetadata(_:)`, including non-success responses.
+/// Existing transports can continue implementing `_XRPCCallable.response(_:)`;
+/// its payload is treated as a successful response with no headers.
+public struct XRPCResponseComponents: Sendable {
+  /// The HTTP status code returned by the service.
+  public var statusCode: Int
+  /// The HTTP response headers.
+  public var headers: HTTPFields
+  /// The raw response body.
+  public var body: Data
+
+  public init(statusCode: Int, headers: HTTPFields = .init(), body: Data) {
+    self.statusCode = statusCode
+    self.headers = headers
+    self.body = body
+  }
+}

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -5,6 +5,8 @@ extension HTTPField.Name {
   static var atprotoProxy: Self { .init("atproto-proxy")! }
   /// A proof of possession for a DPoP-bound authorization credential.
   public static var dpop: Self { .init("dpop")! }
+  /// A server-provided nonce required in the next DPoP proof.
+  public static var dpopNonce: Self { .init("dpop-nonce")! }
 }
 
 /// The minimum a client has to provide in order to make XRPC calls.
@@ -24,6 +26,12 @@ public protocol _XRPCCallable: Sendable {
   func authorize(
     _ requestComponents: XRPCRequestComponents
   ) async throws -> XRPCRequestComponents
+  /// Stores a DPoP nonce for the request's destination when the authorizer can
+  /// rebuild its proof. The default returns `false`.
+  func storeDPoPNonce(
+    _ nonce: String,
+    for requestComponents: XRPCRequestComponents
+  ) async throws -> Bool
   /// The service to proxy this method to via the `atproto-proxy` header, or
   /// `nil` to send it to the client's own endpoint.
   func getProxy(nsid: String) -> String?
@@ -33,6 +41,14 @@ public protocol _XRPCCallable: Sendable {
   /// ``UnExpectedError`` for a failure the method's Lexicon does not describe;
   /// it is converted into the method's own error type.
   func response(_ requestComponents: XRPCRequestComponents) async throws -> Data
+  /// Sends a prepared request and returns its response metadata and payload.
+  ///
+  /// Override this to enable protocol-level handling of non-success responses,
+  /// including DPoP nonce challenges. The default wraps ``response(_:)`` as a
+  /// successful response with no headers.
+  func responseWithMetadata(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCResponseComponents
   /// Calls a query, encoding `input` as query items.
   func call<X: XRPCQuery>(_ request: X.Type, input: X.Input.Query) async throws -> X.ResponseBody
   /// Calls a query at an explicitly resolved destination.
@@ -58,6 +74,20 @@ extension _XRPCCallable {
     _ requestComponents: XRPCRequestComponents
   ) async throws -> XRPCRequestComponents {
     requestComponents
+  }
+
+  public func storeDPoPNonce(
+    _: String,
+    for _: XRPCRequestComponents
+  ) async throws -> Bool {
+    false
+  }
+
+  public func responseWithMetadata(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCResponseComponents {
+    let body = try await response(requestComponents)
+    return .init(statusCode: 200, body: body)
   }
 }
 
@@ -85,7 +115,6 @@ extension _XRPCCallable {
     if let proxy {
       request.headers[.atprotoProxy] = proxy
     }
-    request = try await authorize(request)
     return try await send(query, for: request)
   }
 
@@ -114,7 +143,6 @@ extension _XRPCCallable {
     if let proxy {
       request.headers[.atprotoProxy] = proxy
     }
-    request = try await authorize(request)
     return try await send(procedure, for: request)
   }
 
@@ -147,7 +175,16 @@ extension _XRPCCallable {
 
   private func send<X: XRPCRequest>(_: X.Type, for request: XRPCRequestComponents) async throws -> X.ResponseBody {
     do {
-      let data = try await response(request)
+      let firstResponse = try await perform(request)
+      let response: XRPCResponseComponents
+      if let nonce = dpopNonceChallenge(in: firstResponse),
+        try await storeDPoPNonce(nonce, for: request)
+      {
+        response = try await perform(request)
+      } else {
+        response = firstResponse
+      }
+      let data = try responseBody(from: response)
       if X.ResponseBody.self == EmptyResponse.self {
         return EmptyResponse() as! X.ResponseBody
       }
@@ -161,6 +198,37 @@ extension _XRPCCallable {
     } catch let error as UnExpectedError {
       throw X.Error(error: error)
     }
+  }
+
+  private func perform(
+    _ request: XRPCRequestComponents
+  ) async throws -> XRPCResponseComponents {
+    let authorizedRequest = try await authorize(request)
+    return try await responseWithMetadata(authorizedRequest)
+  }
+
+  private func dpopNonceChallenge(in response: XRPCResponseComponents) -> String? {
+    guard !(200...299).contains(response.statusCode),
+      let nonce = response.headers[.dpopNonce],
+      !nonce.isEmpty,
+      let error = try? JSONDecoder().decode(UnExpectedError.self, from: response.body),
+      error.error == "use_dpop_nonce"
+    else {
+      return nil
+    }
+    return nonce
+  }
+
+  private func responseBody(from response: XRPCResponseComponents) throws -> Data {
+    guard (200...299).contains(response.statusCode) else {
+      if let error = try? JSONDecoder().decode(UnExpectedError.self, from: response.body) {
+        throw error
+      }
+      throw UnExpectedError(
+        error: nil,
+        message: "HTTP request failed with status code \(response.statusCode).")
+    }
+    return response.body
   }
 
   func constructRequest<X: XRPCQuery>(

--- a/Sources/SwiftAtproto/_XRPCClientProtocol.swift
+++ b/Sources/SwiftAtproto/_XRPCClientProtocol.swift
@@ -59,6 +59,17 @@ extension ATPClientProtocol {
     }
     return requestComponents
   }
+
+  public func storeDPoPNonce(
+    _ nonce: String,
+    for requestComponents: XRPCRequestComponents
+  ) async throws -> Bool {
+    let endpoint = requestComponents.destination?.serviceEndpoint ?? serviceEndpoint
+    return try await storeDPoPNonce(
+      nonce,
+      for: requestComponents,
+      serviceEndpoint: endpoint)
+  }
 }
 
 extension ATPClientProtocol where Self: XRPCSubscriptionCallable {

--- a/Tests/ATProtoCryptoTests/DPoPProofTests.swift
+++ b/Tests/ATProtoCryptoTests/DPoPProofTests.swift
@@ -17,14 +17,16 @@ struct DPoPProofTests {
   private func proof(
     httpMethod: String = "GET",
     url: URL = DPoPProofTests.url,
-    credential: String? = nil
+    credential: String? = nil,
+    serverNonce: String? = nil
   ) -> DPoPProof {
     DPoPProof(
       httpMethod: httpMethod,
       url: url,
       issuedAt: Self.issuedAt,
       tokenID: Self.tokenID,
-      credential: credential)
+      credential: credential,
+      serverNonce: serverNonce)
   }
 
   // `KeyType` is not `Sendable`, so these iterate a local list rather than going
@@ -239,6 +241,24 @@ struct DPoPProofTests {
 
   // MARK: - Nonces
 
+  @Test func carriesAServerNonceOnlyWhenChallenged() throws {
+    let withoutNonce = try proof().signed(with: PrivateKey(type: .p256))
+    #expect(try payload(of: withoutNonce).nonce == nil)
+    #expect(!(try memberNames(of: withoutNonce, 1).contains("nonce")))
+
+    let withNonce = try proof(serverNonce: "server-secret-nonce")
+      .signed(with: PrivateKey(type: .p256))
+    #expect(try payload(of: withNonce).nonce == "server-secret-nonce")
+    #expect(try memberNames(of: withNonce, 1).contains("nonce"))
+    let challengedProof = proof(serverNonce: "server-secret-nonce")
+    #expect(!challengedProof.description.contains("server-secret-nonce"))
+    #expect(!String(reflecting: challengedProof).contains("server-secret-nonce"))
+    #expect(
+      !Mirror(reflecting: challengedProof).children.contains {
+        String(describing: $0.value).contains("server-secret-nonce")
+      })
+  }
+
   @Test func randomTokenIDIsHexAndDoesNotRepeat() {
     let tokenID = DPoPProof.randomTokenID()
     #expect(tokenID.count == 32)
@@ -267,6 +287,7 @@ struct DPoPProofTests {
     let htu: String
     let iat: Int
     let jti: String
+    let nonce: String?
   }
 
   private func header(of jwt: String) throws -> DecodedHeader {

--- a/Tests/SwiftAtprotoTests/XRPCDPoPNonceRetryTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCDPoPNonceRetryTests.swift
@@ -1,0 +1,280 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import SwiftAtproto
+
+@Suite("XRPC DPoP nonce retry")
+struct XRPCDPoPNonceRetryTests {
+  @Test("rebuilds authorization and retries once after a nonce challenge")
+  func retriesOnceWithTheServerNonce() async throws {
+    let authorizer = NonceAuthorizerState()
+    let transport = MetadataTransport(responses: [
+      challenge(nonce: "server-nonce-1"),
+      .init(statusCode: 200, body: Data()),
+    ])
+    let client = NonceRetryClient(authorizer: authorizer, transport: transport)
+
+    _ = try await client.call(NonceQuery.self, input: .init())
+
+    let requests = await transport.requests
+    #expect(requests.count == 2)
+    #expect(requests[0].headers[.dpop] == "proof-without-server-nonce")
+    #expect(requests[1].headers[.dpop] == "proof-with-server-nonce-1")
+    #expect(await authorizer.storedNonces == ["server-nonce-1"])
+  }
+
+  @Test("stops when the retry receives another nonce challenge")
+  func stopsAfterTheSecondChallenge() async {
+    let authorizer = NonceAuthorizerState()
+    let transport = MetadataTransport(responses: [
+      challenge(nonce: "server-nonce-1"),
+      challenge(nonce: "server-nonce-2"),
+    ])
+    let client = NonceRetryClient(authorizer: authorizer, transport: transport)
+
+    do {
+      _ = try await client.call(NonceQuery.self, input: .init())
+      Issue.record("Expected the second nonce challenge to be returned")
+    } catch let error as NonceCallError {
+      #expect(error.error == "use_dpop_nonce")
+    } catch {
+      Issue.record("Unexpected error: \(error)")
+    }
+
+    #expect(await transport.requests.count == 2)
+    #expect(await authorizer.storedNonces == ["server-nonce-1"])
+  }
+
+  @Test("replays the same procedure body after a rejected attempt")
+  func safelyReplaysAProcedureBody() async throws {
+    let authorizer = NonceAuthorizerState()
+    let transport = MetadataTransport(responses: [
+      challenge(nonce: "body-nonce"),
+      .init(statusCode: 200, body: Data()),
+    ])
+    let client = NonceRetryClient(authorizer: authorizer, transport: transport)
+    let input = NonceProcedureBody(value: "replay exactly")
+
+    _ = try await client.call(NonceProcedure.self, input: input)
+
+    let requests = await transport.requests
+    #expect(requests.count == 2)
+    #expect(requests[0].method == .post)
+    #expect(requests[0].body == requests[1].body)
+    #expect(
+      try JSONDecoder().decode(
+        NonceProcedureBody.self,
+        from: #require(requests[1].body)) == input)
+  }
+
+  @Test("does not retry without a complete nonce challenge")
+  func ignoresIncompleteAndUnrelatedErrors() async {
+    for response in [
+      challenge(nonce: nil),
+      errorResponse(error: "InvalidToken", nonce: "unrelated-nonce"),
+    ] {
+      let authorizer = NonceAuthorizerState()
+      let transport = MetadataTransport(responses: [response])
+      let client = NonceRetryClient(authorizer: authorizer, transport: transport)
+
+      await #expect(throws: NonceCallError.self) {
+        _ = try await client.call(NonceQuery.self, input: .init())
+      }
+      #expect(await transport.requests.count == 1)
+      #expect(await authorizer.storedNonces.isEmpty)
+    }
+  }
+
+  @Test("does not retry when the authorizer cannot store the nonce")
+  func requiresTheAuthorizerToAcceptTheNonce() async {
+    let authorizer = NonceAuthorizerState(acceptsNonce: false)
+    let transport = MetadataTransport(responses: [challenge(nonce: "unused-nonce")])
+    let client = NonceRetryClient(authorizer: authorizer, transport: transport)
+
+    await #expect(throws: NonceCallError.self) {
+      _ = try await client.call(NonceQuery.self, input: .init())
+    }
+    #expect(await transport.requests.count == 1)
+    #expect(await authorizer.storedNonces.isEmpty)
+  }
+
+  @Test("keeps the legacy data-only transport path")
+  func preservesLegacyResponseClients() async throws {
+    let transport = LegacyTransport()
+    let client = LegacyResponseClient(transport: transport)
+
+    _ = try await client.call(NonceQuery.self, input: .init())
+
+    #expect(await transport.requestCount == 1)
+  }
+
+  private func challenge(nonce: String?) -> XRPCResponseComponents {
+    errorResponse(error: "use_dpop_nonce", nonce: nonce)
+  }
+
+  private func errorResponse(
+    error: String,
+    nonce: String?
+  ) -> XRPCResponseComponents {
+    var headers = HTTPFields()
+    headers[.dpopNonce] = nonce
+    return .init(
+      statusCode: 401,
+      headers: headers,
+      body: Data(#"{"error":"\#(error)","message":"proof rejected"}"#.utf8))
+  }
+}
+
+private actor NonceAuthorizerState: XRPCRequestAuthorizer {
+  let acceptsNonce: Bool
+  private var nonce: String?
+  private(set) var storedNonces: [String] = []
+
+  init(acceptsNonce: Bool = true) {
+    self.acceptsNonce = acceptsNonce
+  }
+
+  func authorize(
+    _ requestComponents: XRPCRequestComponents,
+    serviceEndpoint _: URL
+  ) async throws -> XRPCRequestComponents {
+    var request = requestComponents
+    request.headers[.authorization] = "DPoP space-credential"
+    request.headers[.dpop] = nonce.map { "proof-with-\($0)" } ?? "proof-without-server-nonce"
+    return request
+  }
+
+  func storeDPoPNonce(
+    _ nonce: String,
+    for _: XRPCRequestComponents,
+    serviceEndpoint _: URL
+  ) async throws -> Bool {
+    guard acceptsNonce else { return false }
+    self.nonce = nonce
+    storedNonces.append(nonce)
+    return true
+  }
+}
+
+private actor MetadataTransport {
+  private var responses: [XRPCResponseComponents]
+  private(set) var requests: [XRPCRequestComponents] = []
+
+  init(responses: [XRPCResponseComponents]) {
+    self.responses = responses
+  }
+
+  func response(for request: XRPCRequestComponents) throws -> XRPCResponseComponents {
+    requests.append(request)
+    guard !responses.isEmpty else { throw NonceTestFailure.missingResponse }
+    return responses.removeFirst()
+  }
+}
+
+private struct NonceRetryClient: ATPClientProtocol {
+  let authorizer: NonceAuthorizerState
+  let transport: MetadataTransport
+  let serviceEndpoint = URL(string: "https://repo.example")!
+  let decoder = JSONDecoder()
+
+  func getProxy(nsid _: String) -> String? { nil }
+  func getAuthorization(endpoint _: String) -> String? { nil }
+  func tokenIsExpired(error _: some XRPCError) -> Bool { false }
+  func refreshSession() async -> Bool { false }
+
+  func authorize(
+    _ requestComponents: XRPCRequestComponents,
+    serviceEndpoint: URL
+  ) async throws -> XRPCRequestComponents {
+    try await authorizer.authorize(requestComponents, serviceEndpoint: serviceEndpoint)
+  }
+
+  func storeDPoPNonce(
+    _ nonce: String,
+    for requestComponents: XRPCRequestComponents,
+    serviceEndpoint: URL
+  ) async throws -> Bool {
+    try await authorizer.storeDPoPNonce(
+      nonce,
+      for: requestComponents,
+      serviceEndpoint: serviceEndpoint)
+  }
+
+  func response(_: XRPCRequestComponents) async throws -> Data {
+    throw NonceTestFailure.legacyTransportUsed
+  }
+
+  func responseWithMetadata(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCResponseComponents {
+    try await transport.response(for: requestComponents)
+  }
+}
+
+private actor LegacyTransport {
+  private(set) var requestCount = 0
+
+  func respond() -> Data {
+    requestCount += 1
+    return Data()
+  }
+}
+
+private struct LegacyResponseClient: _XRPCCallable {
+  let transport: LegacyTransport
+
+  func getProxy(nsid _: String) -> String? { nil }
+
+  func response(_: XRPCRequestComponents) async throws -> Data {
+    await transport.respond()
+  }
+}
+
+private enum NonceTestFailure: Error {
+  case legacyTransportUsed
+  case missingResponse
+}
+
+private struct NonceQuery: XRPCQuery {
+  static let id = "com.example.nonceQuery"
+  typealias Input = NonceQueryInput
+  typealias ResponseBody = EmptyResponse
+  typealias Error = NonceCallError
+}
+
+private struct NonceQueryInput: XRPCQueryInput {
+  struct Query: XRPCInputQuery {
+    var asParameters: Parameters? { nil }
+  }
+
+  let query = Query()
+}
+
+private struct NonceProcedure: XRPCProcedure {
+  static let id = "com.example.nonceProcedure"
+  static let contentType = "application/json"
+  typealias RequestBody = NonceProcedureBody
+  typealias ResponseBody = EmptyResponse
+  typealias Error = NonceCallError
+}
+
+private struct NonceProcedureBody: Codable, Sendable, Hashable {
+  let value: String
+}
+
+private enum NonceCallError: XRPCError {
+  case unexpected(error: String?, message: String?)
+
+  init(error: UnExpectedError) {
+    self = .unexpected(error: error.error, message: error.message)
+  }
+
+  var error: String? {
+    if case .unexpected(let error, _) = self { error } else { nil }
+  }
+
+  var message: String? {
+    if case .unexpected(_, let message) = self { message } else { nil }
+  }
+}


### PR DESCRIPTION
Adds response metadata and consumer-managed nonce storage so XRPC requests can rebuild DPoP proofs and retry one rejected attempt. Extends DPoP proofs with server nonces while preserving existing data-only transports.