### PR TITLE
feat: add permissioned space scopes

### DIFF
--- a/Sources/SwiftAtproto/Documentation.docc/Articles/OAuthScopes.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/OAuthScopes.md
@@ -6,8 +6,8 @@ make.
 ## Overview
 
 An AT Protocol OAuth session grants a set of scope strings. ``ScopesSet`` parses
-them into the four structured kinds — ``RpcScope``, ``RepoScope``,
-``BlobScope``, and ``IncludeScope`` — and keeps anything else, such as
+them into the five structured kinds — ``RpcScope``, ``RepoScope``,
+``BlobScope``, ``SpaceScope``, and ``IncludeScope`` — and keeps anything else, such as
 ``OAuthScope/atproto`` or ``OAuthScope/transitionGeneric``, as raw strings.
 
 ```swift
@@ -24,23 +24,33 @@ server that may know scopes this library does not.
 
 ``IncludeScope`` names a permission set by NSID rather than listing permissions.
 Constructing a ``ScopesSet`` expands each include against the
-``LexPermissionSet`` types you pass in, adding the resulting `rpc` and `repo`
+``LexPermissionSet`` types you pass in, adding the resulting `rpc`, `repo`, and `space`
 scopes to the set. An include may only grant permissions under its own
 authority: a permission naming an NSID outside the include's namespace is
 rejected.
 
 ## Checking a grant
 
-``ScopesSet`` answers the three questions a request can raise:
+``ScopesSet`` answers the four questions a request can raise:
 
 - ``ScopesSet/allowsRpc(lxm:aud:)`` — may this method be called against this
   audience?
 - ``ScopesSet/allowsRepo(collection:action:)`` — may this collection be written
   with this action?
 - ``ScopesSet/allowsBlob(mime:)`` — may a blob of this MIME type be uploaded?
+- ``ScopesSet/allowsSpace(_:grantedBy:spaceTypes:)`` — may an account read or
+  write records in a permissioned space, request a delegation token, or manage
+  the space?
 
 ``ScopesSet/hasAtprotoScope`` and ``ScopesSet/hasTransitionGeneric`` report the
-two broad grants that bypass the structured checks.
+two broad grants used by existing structured checks. `transition:generic` does
+not grant access to permissioned spaces.
+
+Space requirements are evaluated explicitly by the consumer. Pass the current
+``LexSpace`` declarations when a scope omits `collection`; this resolves the
+declaration's collection defaults at evaluation time rather than freezing them
+when the scope is parsed. A space credential is a separate credential class and
+does not pass through OAuth scope evaluation.
 
 ## Enforcement in the client
 
@@ -54,3 +64,8 @@ For a procedure input to be repo-checked it must describe its own writes by
 conforming to ``RepoWriteOperationDescribing``, returning one
 ``RepoWriteRequirement`` per collection and ``LexPermissionAction`` it performs.
 See <doc:MakingXRPCCalls>.
+
+Generated Permissioned Data methods do not declare their endpoint-specific
+authorization policy. A consumer maps generated inputs to
+``SpaceScopeRequirement`` values and decides whether OAuth or a space credential
+is appropriate before calling the generated method.

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -82,8 +82,12 @@ let posts = try await client.call(
 - ``RpcScope``
 - ``RepoScope``
 - ``BlobScope``
+- ``SpaceScope``
+- ``SpaceScopeOperation``
+- ``SpaceScopeRequirement``
 - ``IncludeScope``
 - ``LexPermission``
+- ``LexPermissionValue``
 - ``LexPermissionSet``
 - ``LexPermissionAction``
 - ``LexPermissionResource``

--- a/Sources/SwiftAtproto/LexPermission.swift
+++ b/Sources/SwiftAtproto/LexPermission.swift
@@ -1,9 +1,74 @@
 import Foundation
 
+/// An open value carried by an unrecognized field in a Lexicon permission.
+///
+/// Permission values are limited to strings, integers, booleans, and arrays of
+/// those scalar values. The representation remains open so a client can retain
+/// fields introduced by a newer permission resource.
+public enum LexPermissionValue: Codable, Hashable, Sendable {
+  /// A string value.
+  case string(String)
+  /// An integer value.
+  case integer(Int)
+  /// A boolean value.
+  case boolean(Bool)
+  /// An array whose members must all be scalar permission values.
+  case array([LexPermissionValue])
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let value = try? container.decode(Bool.self) {
+      self = .boolean(value)
+    } else if let value = try? container.decode(Int.self) {
+      self = .integer(value)
+    } else if let value = try? container.decode(String.self) {
+      self = .string(value)
+    } else if let value = try? container.decode([LexPermissionValue].self),
+      value.allSatisfy(\.isScalar)
+    {
+      self = .array(value)
+    } else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Lexicon permission values must be scalars or arrays of scalars."
+      )
+    }
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .string(let value):
+      try container.encode(value)
+    case .integer(let value):
+      try container.encode(value)
+    case .boolean(let value):
+      try container.encode(value)
+    case .array(let value):
+      guard value.allSatisfy(\.isScalar) else {
+        throw EncodingError.invalidValue(
+          value,
+          .init(
+            codingPath: encoder.codingPath,
+            debugDescription: "Lexicon permission arrays may only contain scalar values."
+          )
+        )
+      }
+      try container.encode(value)
+    }
+  }
+
+  private var isScalar: Bool {
+    if case .array = self { return false }
+    return true
+  }
+}
+
 /// One permission declared by a Lexicon permission set.
 ///
-/// Expanding an ``IncludeScope`` turns these into the `rpc` and `repo` scope
-/// strings they grant. See <doc:OAuthScopes>.
+/// Expanding an ``IncludeScope`` turns these into the structured scope strings
+/// they grant. Unrecognized fields are retained in ``additionalFields`` so
+/// permission resources introduced by newer Lexicons round-trip losslessly.
 public struct LexPermission: Codable, Hashable, Sendable {
   public let resource: LexPermissionResource
   public let aud: String?
@@ -11,14 +76,30 @@ public struct LexPermission: Codable, Hashable, Sendable {
   public let lxm: [String]?
   public let action: [LexPermissionAction]?
   public let collection: [String]?
+  /// The space type selected by a `space` permission.
+  public let spaceType: String?
+  /// The authority selected by a `space` permission.
+  public let authority: String?
+  /// The space key selected by a `space` permission.
+  public let skey: String?
+  /// The space-management operations granted by a `space` permission.
+  public let manage: [LexPermissionAction]?
+  /// Fields not understood by this version of the library.
+  public let additionalFields: [String: LexPermissionValue]
 
+  /// Creates a permission while retaining any resource-specific open fields.
   public init(
     resource: LexPermissionResource,
     aud: String? = nil,
     inheritAud: Bool? = nil,
     lxm: [String]? = nil,
     action: [LexPermissionAction]? = nil,
-    collection: [String]? = nil
+    collection: [String]? = nil,
+    spaceType: String? = nil,
+    authority: String? = nil,
+    skey: String? = nil,
+    manage: [LexPermissionAction]? = nil,
+    additionalFields: [String: LexPermissionValue] = [:]
   ) {
     self.resource = resource
     self.aud = aud
@@ -26,10 +107,65 @@ public struct LexPermission: Codable, Hashable, Sendable {
     self.lxm = lxm
     self.action = action
     self.collection = collection
+    self.spaceType = spaceType
+    self.authority = authority
+    self.skey = skey
+    self.manage = manage
+    self.additionalFields = additionalFields.filter { !Self.knownKeys.contains($0.key) }
   }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: AnyCodingKeys.self)
+    let typeKey = AnyCodingKeys(stringValue: "type")
+    guard try container.decode(String.self, forKey: typeKey) == "permission" else {
+      throw DecodingError.dataCorruptedError(
+        forKey: typeKey,
+        in: container,
+        debugDescription: "A Lexicon permission must have type 'permission'."
+      )
+    }
+    resource = try container.decode(LexPermissionResource.self, forKey: .init(stringValue: "resource"))
+    aud = try container.decodeIfPresent(String.self, forKey: .init(stringValue: "aud"))
+    inheritAud = try container.decodeIfPresent(Bool.self, forKey: .init(stringValue: "inheritAud"))
+    lxm = try container.decodeIfPresent([String].self, forKey: .init(stringValue: "lxm"))
+    action = try container.decodeIfPresent([LexPermissionAction].self, forKey: .init(stringValue: "action"))
+    collection = try container.decodeIfPresent([String].self, forKey: .init(stringValue: "collection"))
+    spaceType = try container.decodeIfPresent(String.self, forKey: .init(stringValue: "spaceType"))
+    authority = try container.decodeIfPresent(String.self, forKey: .init(stringValue: "authority"))
+    skey = try container.decodeIfPresent(String.self, forKey: .init(stringValue: "skey"))
+    manage = try container.decodeIfPresent([LexPermissionAction].self, forKey: .init(stringValue: "manage"))
+    additionalFields = try Dictionary(
+      uniqueKeysWithValues: container.allKeys.compactMap { key in
+        guard !Self.knownKeys.contains(key.stringValue) else { return nil }
+        return (key.stringValue, try container.decode(LexPermissionValue.self, forKey: key))
+      })
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: AnyCodingKeys.self)
+    try container.encode("permission", forKey: .init(stringValue: "type"))
+    try container.encode(resource, forKey: .init(stringValue: "resource"))
+    try container.encodeIfPresent(aud, forKey: .init(stringValue: "aud"))
+    try container.encodeIfPresent(inheritAud, forKey: .init(stringValue: "inheritAud"))
+    try container.encodeIfPresent(lxm, forKey: .init(stringValue: "lxm"))
+    try container.encodeIfPresent(action, forKey: .init(stringValue: "action"))
+    try container.encodeIfPresent(collection, forKey: .init(stringValue: "collection"))
+    try container.encodeIfPresent(spaceType, forKey: .init(stringValue: "spaceType"))
+    try container.encodeIfPresent(authority, forKey: .init(stringValue: "authority"))
+    try container.encodeIfPresent(skey, forKey: .init(stringValue: "skey"))
+    try container.encodeIfPresent(manage, forKey: .init(stringValue: "manage"))
+    for (key, value) in additionalFields {
+      try container.encode(value, forKey: .init(stringValue: key))
+    }
+  }
+
+  private static let knownKeys: Set<String> = [
+    "type", "resource", "aud", "inheritAud", "lxm", "action", "collection",
+    "spaceType", "authority", "skey", "manage",
+  ]
 }
 
-/// The resource kind a ``LexPermission`` applies to: `rpc`, `repo`, or `blob`.
+/// The resource kind a ``LexPermission`` applies to.
 public struct LexPermissionResource: RawRepresentable, Codable, Hashable, Sendable {
   public let rawValue: String
 
@@ -49,9 +185,11 @@ public struct LexPermissionResource: RawRepresentable, Codable, Hashable, Sendab
   public static let rpc = Self(rawValue: "rpc")
   public static let repo = Self(rawValue: "repo")
   public static let blob = Self(rawValue: "blob")
+  /// Access to records and management operations within permissioned spaces.
+  public static let space = Self(rawValue: "space")
 }
 
-/// A repository write action: `create`, `update`, or `delete`.
+/// An action granted by a structured permission resource.
 public struct LexPermissionAction: RawRepresentable, Codable, Hashable, Sendable {
   public let rawValue: String
 
@@ -68,6 +206,10 @@ public struct LexPermissionAction: RawRepresentable, Codable, Hashable, Sendable
     try container.encode(rawValue)
   }
 
+  /// Read only the granting account's repository in a space.
+  public static let readSelf = Self(rawValue: "read_self")
+  /// Read any repository in a space and request a delegation token.
+  public static let read = Self(rawValue: "read")
   public static let create = Self(rawValue: "create")
   public static let update = Self(rawValue: "update")
   public static let delete = Self(rawValue: "delete")

--- a/Sources/SwiftAtproto/OAuthScope.swift
+++ b/Sources/SwiftAtproto/OAuthScope.swift
@@ -252,6 +252,238 @@ public struct RepoScope: CustomStringConvertible, Hashable, Sendable {
   }
 }
 
+/// An operation whose authorization is evaluated against a ``SpaceScope``.
+public enum SpaceScopeOperation: Hashable, Sendable {
+  /// Read one repository in a space.
+  case read(repository: DID)
+  /// Request a delegation token for whole-space read access.
+  case delegationToken
+  /// Write a record in a collection.
+  case write(collection: NSID, action: LexPermissionAction)
+  /// Perform an implementation-defined space-management operation.
+  case manage(LexPermissionAction)
+}
+
+/// The target space and operation a consumer wants to authorize.
+public struct SpaceScopeRequirement: Hashable, Sendable {
+  /// The space being accessed or managed.
+  public let space: SpaceRef
+  /// The operation being performed.
+  public let operation: SpaceScopeOperation
+
+  /// Creates a requirement for one operation against one concrete space.
+  public init(space: SpaceRef, operation: SpaceScopeOperation) {
+    self.space = space
+    self.operation = operation
+  }
+}
+
+/// A `space` scope granting access to permissioned records and space
+/// management operations.
+///
+/// Collection defaults are intentionally not frozen into this value. Pass the
+/// current space declaration to ``ScopesSet/allowsSpace(_:grantedBy:spaceTypes:)``
+/// when evaluating a write that relies on its default collections.
+public struct SpaceScope: CustomStringConvertible, Hashable, Sendable {
+  /// The selected space-type NSID, or `*` for every type.
+  public let spaceType: String
+  /// The selected authority DID, `self`, or `*`.
+  public let authority: String
+  /// The selected space key, or `*`.
+  public let skey: String
+  /// Explicit write collections, or `nil` to use the current space declaration.
+  public let collection: [String]?
+  /// Granted record actions.
+  public let action: [LexPermissionAction]
+  /// Granted space-management operations.
+  public let manage: [LexPermissionAction]
+
+  /// The actions granted when an `action` parameter is omitted.
+  public static let defaultActions: [LexPermissionAction] = [.read, .create, .update, .delete]
+
+  /// Creates and validates a structured space grant.
+  ///
+  /// Pass `nil` for `collection` to resolve the current ``LexSpace``
+  /// declaration when a write is evaluated.
+  public init(
+    spaceType: String,
+    authority: String = "self",
+    skey: String = "*",
+    collection: [String]? = nil,
+    action: [LexPermissionAction] = Self.defaultActions,
+    manage: [LexPermissionAction] = []
+  ) throws {
+    guard spaceType == "*" || NSID.isValid(spaceType) else {
+      throw OAuthScopeError.invalidSyntax("invalid spaceType '\(spaceType)' in space scope")
+    }
+    guard authority == "self" || authority == "*" || (try? DID(string: authority)) != nil else {
+      throw OAuthScopeError.invalidSyntax("invalid authority '\(authority)' in space scope")
+    }
+    guard skey == "*" || RecordKey.isValid(skey) else {
+      throw OAuthScopeError.invalidSyntax("invalid skey '\(skey)' in space scope")
+    }
+    if let collection {
+      guard !collection.isEmpty else {
+        throw OAuthScopeError.missingRequired("collection")
+      }
+      for value in collection where value != "*" && !NSID.isValid(value) {
+        throw OAuthScopeError.invalidSyntax("invalid collection '\(value)' in space scope")
+      }
+    }
+    guard !action.isEmpty else {
+      throw OAuthScopeError.missingRequired("action")
+    }
+    for value in action where !Self.allowedActions.contains(value) {
+      throw OAuthScopeError.invalidSyntax("unknown action '\(value.rawValue)' in space scope")
+    }
+    for value in manage where !Self.allowedManage.contains(value) {
+      throw OAuthScopeError.invalidSyntax("unknown manage operation '\(value.rawValue)' in space scope")
+    }
+
+    self.spaceType = spaceType
+    self.authority = authority
+    self.skey = skey
+    self.collection = collection.map(Self.normalizeCollections)
+    self.action = Self.normalizeActions(action)
+    self.manage = Self.normalizeManage(manage)
+  }
+
+  /// Parses a `space:` scope string and applies its protocol defaults.
+  public init(string: String) throws {
+    let syntax = OAuthScopeSyntax.parse(string)
+    guard syntax.prefix == "space" else {
+      throw OAuthScopeError.invalidResource(syntax.prefix)
+    }
+    guard let spaceType = syntax.positional, !spaceType.isEmpty else {
+      throw OAuthScopeError.missingRequired("spaceType")
+    }
+
+    var authority: String?
+    var skey: String?
+    var collections: [String] = []
+    var actions: [LexPermissionAction] = []
+    var management: [LexPermissionAction] = []
+    var hasCollection = false
+    for parameter in syntax.params {
+      guard !parameter.value.isEmpty else {
+        throw OAuthScopeError.invalidSyntax("empty \(parameter.key) value in space scope")
+      }
+      switch parameter.key {
+      case "authority":
+        guard authority == nil else { throw OAuthScopeError.duplicateKey("authority") }
+        authority = parameter.value
+      case "skey":
+        guard skey == nil else { throw OAuthScopeError.duplicateKey("skey") }
+        skey = parameter.value
+      case "collection":
+        hasCollection = true
+        collections.append(parameter.value)
+      case "action":
+        actions.append(.init(rawValue: parameter.value))
+      case "manage":
+        management.append(.init(rawValue: parameter.value))
+      default:
+        throw OAuthScopeError.invalidSyntax("unknown key '\(parameter.key)' in space scope")
+      }
+    }
+
+    try self.init(
+      spaceType: spaceType,
+      authority: authority ?? "self",
+      skey: skey ?? "*",
+      collection: hasCollection ? collections : nil,
+      action: actions.isEmpty ? Self.defaultActions : actions,
+      manage: management
+    )
+  }
+
+  public var description: String {
+    var parameters: [OAuthScopeQueryParam] = []
+    if authority != "self" {
+      parameters.append(.init(key: "authority", value: authority))
+    }
+    if skey != "*" {
+      parameters.append(.init(key: "skey", value: skey))
+    }
+    if let collection {
+      parameters.append(contentsOf: collection.map { .init(key: "collection", value: $0) })
+    }
+    if action != Self.defaultActions {
+      parameters.append(contentsOf: action.map { .init(key: "action", value: $0.rawValue) })
+    }
+    parameters.append(contentsOf: manage.map { .init(key: "manage", value: $0.rawValue) })
+    return OAuthScopeSyntax(prefix: "space", positional: spaceType, params: parameters).description
+  }
+
+  fileprivate func allows(
+    _ requirement: SpaceScopeRequirement,
+    grantedBy: DID,
+    spaceTypes: [any LexSpace.Type]
+  ) -> Bool {
+    let space = requirement.space
+    guard spaceType == "*" || spaceType == space.spaceType.rawValue else { return false }
+    guard skey == "*" || skey == space.skey.rawValue else { return false }
+    switch authority {
+    case "*":
+      break
+    case "self":
+      guard space.spaceDid == grantedBy else { return false }
+    default:
+      guard authority == space.spaceDid.rawValue else { return false }
+    }
+
+    switch requirement.operation {
+    case .read(let repository):
+      return action.contains(.read) || (action.contains(.readSelf) && repository == grantedBy)
+    case .delegationToken:
+      return action.contains(.read)
+    case .write(let requiredCollection, let requiredAction):
+      guard Self.allowedManage.contains(requiredAction), action.contains(requiredAction) else {
+        return false
+      }
+      return effectiveCollections(for: space, spaceTypes: spaceTypes).contains {
+        $0 == "*" || $0 == requiredCollection.rawValue
+      }
+    case .manage(let requiredOperation):
+      return Self.allowedManage.contains(requiredOperation) && manage.contains(requiredOperation)
+    }
+  }
+
+  private func effectiveCollections(
+    for space: SpaceRef,
+    spaceTypes: [any LexSpace.Type]
+  ) -> [String] {
+    if let collection { return collection }
+    guard spaceType != "*",
+      let declaration = spaceTypes.first(where: { $0.id == space.spaceType.rawValue })
+    else {
+      return []
+    }
+    return declaration.collections.map(\.rawValue)
+  }
+
+  private static let allowedActions: [LexPermissionAction] = [
+    .readSelf, .read, .create, .update, .delete,
+  ]
+  private static let allowedManage: [LexPermissionAction] = [.create, .update, .delete]
+
+  private static func normalizeCollections(_ values: [String]) -> [String] {
+    if values.contains("*") { return ["*"] }
+    return Array(Set(values)).sorted()
+  }
+
+  private static func normalizeActions(_ values: [LexPermissionAction]) -> [LexPermissionAction] {
+    var seen = Set(values)
+    if seen.contains(.read) { seen.remove(.readSelf) }
+    return allowedActions.filter { seen.contains($0) }
+  }
+
+  private static func normalizeManage(_ values: [LexPermissionAction]) -> [LexPermissionAction] {
+    let seen = Set(values)
+    return allowedManage.filter { seen.contains($0) }
+  }
+}
+
 /// A `blob` scope: permission to upload specific MIME types.
 public struct BlobScope: CustomStringConvertible, Hashable, Sendable {
   /// The accepted MIME patterns, which may use a `*` subtype such as
@@ -379,7 +611,7 @@ public struct BlobScope: CustomStringConvertible, Hashable, Sendable {
 /// permissions.
 ///
 /// ``ScopesSet`` expands each include at construction, adding the resulting
-/// `rpc` and `repo` scopes. An include may only grant permissions under its own
+/// `rpc`, `repo`, and `space` scopes. An include may only grant permissions under its own
 /// authority. See <doc:OAuthScopes>.
 public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
   /// The NSID of the permission set being included.
@@ -486,6 +718,8 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
         scopes.append(try expandRpc(permission))
       case .repo:
         scopes.append(try expandRepo(permission))
+      case .space:
+        scopes.append(try expandSpace(permission))
       default:
         continue
       }
@@ -531,6 +765,28 @@ public struct IncludeScope: CustomStringConvertible, Hashable, Sendable {
     let actions = permission.action ?? RepoScope.defaultActions
     return try RepoScope(collection: collection, action: actions).description
   }
+
+  private func expandSpace(_ permission: LexPermission) throws -> String {
+    guard let spaceType = permission.spaceType else {
+      throw OAuthScopeError.missingRequired("spaceType in space permission")
+    }
+    guard spaceType != "*" else {
+      throw OAuthScopeError.forbiddenCombination(
+        "space permission in a permission-set cannot use spaceType=*"
+      )
+    }
+    guard isParentAuthorityOf(spaceType) else {
+      throw OAuthScopeError.nsidOutsideAuthority(parent: nsid, other: spaceType)
+    }
+    return try SpaceScope(
+      spaceType: spaceType,
+      authority: permission.authority ?? "self",
+      skey: permission.skey ?? "*",
+      collection: permission.collection,
+      action: permission.action ?? SpaceScope.defaultActions,
+      manage: permission.manage ?? []
+    ).description
+  }
 }
 
 /// The scopes granted to an OAuth session, parsed into structured resources.
@@ -544,6 +800,8 @@ public struct ScopesSet: Hashable, Sendable {
   public let repoScopes: [RepoScope]
   /// The granted `blob` scopes.
   public let blobScopes: [BlobScope]
+  /// The granted `space` scopes, including those from expanded includes.
+  public let spaceScopes: [SpaceScope]
   /// The `include` scopes as written, before expansion.
   public let includeScopes: [IncludeScope]
   /// Granted scopes that are not structured resources, such as
@@ -559,6 +817,7 @@ public struct ScopesSet: Hashable, Sendable {
     var rpc: [RpcScope] = []
     var repo: [RepoScope] = []
     var blob: [BlobScope] = []
+    var space: [SpaceScope] = []
     var include: [IncludeScope] = []
     var other: Set<String> = []
     for scope in scopes {
@@ -570,6 +829,8 @@ public struct ScopesSet: Hashable, Sendable {
         repo.append(try RepoScope(string: scope))
       case "blob":
         blob.append(try BlobScope(string: scope))
+      case "space":
+        space.append(try SpaceScope(string: scope))
       case "include":
         include.append(try IncludeScope(string: scope))
       default:
@@ -579,10 +840,12 @@ public struct ScopesSet: Hashable, Sendable {
         other.insert(scope)
       }
     }
-    try Self.expandIncludes(include, permissionSets: permissionSets, into: &rpc, repo: &repo)
+    try Self.expandIncludes(
+      include, permissionSets: permissionSets, into: &rpc, repo: &repo, space: &space)
     self.rpcScopes = rpc
     self.repoScopes = repo
     self.blobScopes = blob
+    self.spaceScopes = space
     self.includeScopes = include
     self.rawOther = other
   }
@@ -592,6 +855,7 @@ public struct ScopesSet: Hashable, Sendable {
     var rpc: [RpcScope] = []
     var repo: [RepoScope] = []
     var blob: [BlobScope] = []
+    var space: [SpaceScope] = []
     var include: [IncludeScope] = []
     var other: Set<String> = []
     for scope in scopes {
@@ -603,6 +867,8 @@ public struct ScopesSet: Hashable, Sendable {
         if let parsed = try? RepoScope(string: scope) { repo.append(parsed) }
       case "blob":
         if let parsed = try? BlobScope(string: scope) { blob.append(parsed) }
+      case "space":
+        if let parsed = try? SpaceScope(string: scope) { space.append(parsed) }
       case "include":
         if let parsed = try? IncludeScope(string: scope) { include.append(parsed) }
       default:
@@ -612,10 +878,12 @@ public struct ScopesSet: Hashable, Sendable {
         other.insert(scope)
       }
     }
-    try? Self.expandIncludes(include, permissionSets: permissionSets, into: &rpc, repo: &repo)
+    try? Self.expandIncludes(
+      include, permissionSets: permissionSets, into: &rpc, repo: &repo, space: &space)
     self.rpcScopes = rpc
     self.repoScopes = repo
     self.blobScopes = blob
+    self.spaceScopes = space
     self.includeScopes = include
     self.rawOther = other
   }
@@ -624,7 +892,8 @@ public struct ScopesSet: Hashable, Sendable {
     _ includes: [IncludeScope],
     permissionSets: [any LexPermissionSet.Type],
     into rpc: inout [RpcScope],
-    repo: inout [RepoScope]
+    repo: inout [RepoScope],
+    space: inout [SpaceScope]
   ) throws {
     guard !permissionSets.isEmpty, !includes.isEmpty else { return }
     let registry = Dictionary(
@@ -641,6 +910,8 @@ public struct ScopesSet: Hashable, Sendable {
           rpc.append(try RpcScope(string: scopeStr))
         case "repo":
           repo.append(try RepoScope(string: scopeStr))
+        case "space":
+          space.append(try SpaceScope(string: scopeStr))
         default:
           break
         }
@@ -707,6 +978,24 @@ public struct ScopesSet: Hashable, Sendable {
       return true
     }
     return false
+  }
+
+  /// Whether this session's OAuth scopes satisfy a permissioned-space
+  /// requirement.
+  ///
+  /// `grantedBy` resolves `authority=self` and identifies the repository that
+  /// a `read_self` grant may read. `spaceTypes` is consulted at evaluation time
+  /// when a scope omits `collection`, so declaration updates are not frozen
+  /// into the granted scope.
+  public func allowsSpace(
+    _ requirement: SpaceScopeRequirement,
+    grantedBy: DID,
+    spaceTypes: [any LexSpace.Type] = []
+  ) -> Bool {
+    guard hasAtprotoScope else { return false }
+    return spaceScopes.contains {
+      $0.allows(requirement, grantedBy: grantedBy, spaceTypes: spaceTypes)
+    }
   }
 }
 

--- a/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/PermissionSetTypeDefinition.swift
@@ -117,6 +117,24 @@ extension PermissionSetTypeDefinition: SwiftCodeGeneratable {
     if let collection = permission.collection {
       args.append(labeledArg(label: "collection", expression: stringArrayExpr(collection)))
     }
+    if let spaceType = permission.spaceType {
+      args.append(labeledArg(label: "spaceType", expression: StringLiteralExprSyntax(content: spaceType)))
+    }
+    if let authority = permission.authority {
+      args.append(labeledArg(label: "authority", expression: StringLiteralExprSyntax(content: authority)))
+    }
+    if let skey = permission.skey {
+      args.append(labeledArg(label: "skey", expression: StringLiteralExprSyntax(content: skey)))
+    }
+    if let manage = permission.manage {
+      args.append(labeledArg(label: "manage", expression: actionArrayExpr(manage)))
+    }
+    if !permission.additionalFields.isEmpty {
+      args.append(
+        labeledArg(
+          label: "additionalFields",
+          expression: permissionValuesExpr(permission.additionalFields)))
+    }
     for i in 0..<args.count {
       args[i].leadingTrivia = .newline
       if i < args.count - 1 {
@@ -175,12 +193,67 @@ extension PermissionSetTypeDefinition: SwiftCodeGeneratable {
     )
   }
 
+  private static func permissionValuesExpr(_ values: [String: PermissionValue]) -> ExprSyntax {
+    let sorted = values.sorted { $0.key < $1.key }
+    return ExprSyntax(
+      DictionaryExprSyntax(
+        leftSquare: .leftSquareToken(),
+        content: .elements(
+          DictionaryElementListSyntax {
+            for (index, element) in sorted.enumerated() {
+              DictionaryElementSyntax(
+                leadingTrivia: .newline,
+                key: StringLiteralExprSyntax(content: element.key),
+                value: permissionValueExpr(element.value),
+                trailingComma: index < sorted.count - 1 ? .commaToken() : nil
+              )
+            }
+          }),
+        rightSquare: .rightSquareToken(leadingTrivia: .newline)
+      )
+    )
+  }
+
+  private static func permissionValueExpr(_ value: PermissionValue) -> ExprSyntax {
+    let name: String
+    let argument: ExprSyntax
+    switch value {
+    case .string(let value):
+      name = "string"
+      argument = ExprSyntax(StringLiteralExprSyntax(content: value))
+    case .integer(let value):
+      name = "integer"
+      argument = ExprSyntax(IntegerLiteralExprSyntax(value))
+    case .boolean(let value):
+      name = "boolean"
+      argument = ExprSyntax(BooleanLiteralExprSyntax(booleanLiteral: value))
+    case .array(let values):
+      name = "array"
+      argument = ExprSyntax(
+        ArrayExprSyntax {
+          for value in values {
+            ArrayElementSyntax(expression: permissionValueExpr(value))
+          }
+        })
+    }
+    return ExprSyntax(
+      FunctionCallExprSyntax(
+        calledExpression: MemberAccessExprSyntax(name: .identifier(name)),
+        leftParen: .leftParenToken(),
+        arguments: LabeledExprListSyntax([LabeledExprSyntax(expression: argument)]),
+        rightParen: .rightParenToken()
+      )
+    )
+  }
+
   private static func resourceExpr(_ resource: PermissionResource) -> ExprSyntax {
     switch resource {
     case .rpc:
       ExprSyntax(MemberAccessExprSyntax(name: .identifier("rpc")))
     case .repo:
       ExprSyntax(MemberAccessExprSyntax(name: .identifier("repo")))
+    case .space:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("space")))
     default:
       ExprSyntax(
         FunctionCallExprSyntax(
@@ -201,6 +274,10 @@ extension PermissionSetTypeDefinition: SwiftCodeGeneratable {
 
   private static func actionExpr(_ action: PermissionAction) -> ExprSyntax {
     switch action {
+    case .readSelf:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("readSelf")))
+    case .read:
+      ExprSyntax(MemberAccessExprSyntax(name: .identifier("read")))
     case .create:
       ExprSyntax(MemberAccessExprSyntax(name: .identifier("create")))
     case .update:

--- a/Sources/SwiftAtprotoLex/Definitions/PermissionTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/PermissionTypeDefinition.swift
@@ -6,6 +6,115 @@ struct PermissionTypeDefinition: Codable {
   let lxm: [String]?
   let action: [PermissionAction]?
   let collection: [String]?
+  let spaceType: String?
+  let authority: String?
+  let skey: String?
+  let manage: [PermissionAction]?
+  let additionalFields: [String: PermissionValue]
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+    type = try container.decode(FieldType.self, forKey: .init("type"))
+    resource = try container.decode(PermissionResource.self, forKey: .init("resource"))
+    aud = try container.decodeIfPresent(String.self, forKey: .init("aud"))
+    inheritAud = try container.decodeIfPresent(Bool.self, forKey: .init("inheritAud"))
+    lxm = try container.decodeIfPresent([String].self, forKey: .init("lxm"))
+    action = try container.decodeIfPresent([PermissionAction].self, forKey: .init("action"))
+    collection = try container.decodeIfPresent([String].self, forKey: .init("collection"))
+    spaceType = try container.decodeIfPresent(String.self, forKey: .init("spaceType"))
+    authority = try container.decodeIfPresent(String.self, forKey: .init("authority"))
+    skey = try container.decodeIfPresent(String.self, forKey: .init("skey"))
+    manage = try container.decodeIfPresent([PermissionAction].self, forKey: .init("manage"))
+    additionalFields = try Dictionary(
+      uniqueKeysWithValues: container.allKeys.compactMap { key in
+        guard !Self.knownKeys.contains(key.stringValue) else { return nil }
+        return (key.stringValue, try container.decode(PermissionValue.self, forKey: key))
+      })
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: DynamicCodingKey.self)
+    try container.encode(type, forKey: .init("type"))
+    try container.encode(resource, forKey: .init("resource"))
+    try container.encodeIfPresent(aud, forKey: .init("aud"))
+    try container.encodeIfPresent(inheritAud, forKey: .init("inheritAud"))
+    try container.encodeIfPresent(lxm, forKey: .init("lxm"))
+    try container.encodeIfPresent(action, forKey: .init("action"))
+    try container.encodeIfPresent(collection, forKey: .init("collection"))
+    try container.encodeIfPresent(spaceType, forKey: .init("spaceType"))
+    try container.encodeIfPresent(authority, forKey: .init("authority"))
+    try container.encodeIfPresent(skey, forKey: .init("skey"))
+    try container.encodeIfPresent(manage, forKey: .init("manage"))
+    for (key, value) in additionalFields {
+      try container.encode(value, forKey: .init(key))
+    }
+  }
+
+  private static let knownKeys: Set<String> = [
+    "type", "resource", "aud", "inheritAud", "lxm", "action", "collection",
+    "spaceType", "authority", "skey", "manage",
+  ]
+}
+
+enum PermissionValue: Codable, Hashable, Sendable {
+  case string(String)
+  case integer(Int)
+  case boolean(Bool)
+  case array([PermissionValue])
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    if let value = try? container.decode(Bool.self) {
+      self = .boolean(value)
+    } else if let value = try? container.decode(Int.self) {
+      self = .integer(value)
+    } else if let value = try? container.decode(String.self) {
+      self = .string(value)
+    } else if let value = try? container.decode([PermissionValue].self),
+      value.allSatisfy(\.isScalar)
+    {
+      self = .array(value)
+    } else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Permission values must be scalars or arrays of scalars."
+      )
+    }
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .string(let value): try container.encode(value)
+    case .integer(let value): try container.encode(value)
+    case .boolean(let value): try container.encode(value)
+    case .array(let value): try container.encode(value)
+    }
+  }
+
+  private var isScalar: Bool {
+    if case .array = self { return false }
+    return true
+  }
+}
+
+private struct DynamicCodingKey: CodingKey {
+  let stringValue: String
+  let intValue: Int?
+
+  init(_ stringValue: String) {
+    self.stringValue = stringValue
+    intValue = nil
+  }
+
+  init(stringValue: String) {
+    self.init(stringValue)
+  }
+
+  init(intValue: Int) {
+    stringValue = String(intValue)
+    self.intValue = intValue
+  }
 }
 
 struct PermissionResource: RawRepresentable, Codable, Hashable, Sendable {
@@ -26,6 +135,7 @@ struct PermissionResource: RawRepresentable, Codable, Hashable, Sendable {
 
   static let rpc = Self(rawValue: "rpc")
   static let repo = Self(rawValue: "repo")
+  static let space = Self(rawValue: "space")
 }
 
 struct PermissionAction: RawRepresentable, Codable, Hashable, Sendable {
@@ -44,6 +154,8 @@ struct PermissionAction: RawRepresentable, Codable, Hashable, Sendable {
     try container.encode(rawValue)
   }
 
+  static let readSelf = Self(rawValue: "read_self")
+  static let read = Self(rawValue: "read")
   static let create = Self(rawValue: "create")
   static let update = Self(rawValue: "update")
   static let delete = Self(rawValue: "delete")

--- a/Tests/SwiftAtprotoLexTests/PermissionGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/PermissionGenerationTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Open permission generation")
+struct PermissionGenerationTests {
+  @Test("space permissions generate without consumer-specific request policy")
+  func generatesSpacePermissionValues() async throws {
+    let source = try await generateClient(fixture: Self.spacePermissionSet)
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains("public enum AuthForums: LexPermissionSet"))
+    #expect(source.contains("resource: .space"))
+    #expect(source.contains(#"spaceType: "com.example.forum""#))
+    #expect(source.contains(#"authority: "*""#))
+    #expect(source.contains("action: [.read, .create]"))
+    #expect(source.contains("manage: [.update]"))
+    #expect(source.contains(#""futureFlag": .boolean(true)"#))
+    #expect(
+      source.contains(
+        #""futureValues": .array([.string("one"), .integer(2), .boolean(false)])"#))
+    #expect(!source.contains("SpaceScopeRequirement"))
+  }
+
+  private func generateClient(fixture: String) async throws -> String {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-permission-generation-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let input = root.appending(path: "input", directoryHint: .isDirectory)
+    let output = root.appending(path: "output", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+    try fixture.write(
+      to: input.appending(path: "authForums.json"), atomically: true, encoding: .utf8)
+
+    try await SwiftAtprotoLex.main(
+      outdir: output, path: input.path, generate: .client, pluginSource: .command)
+    return try String(
+      contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+  }
+
+  static let spacePermissionSet = #"""
+    {
+      "lexicon": 1,
+      "id": "com.example.authForums",
+      "defs": {
+        "main": {
+          "type": "permission-set",
+          "title": "Example Forums",
+          "detail": "Read and post in example forums",
+          "permissions": [
+            {
+              "type": "permission",
+              "resource": "space",
+              "spaceType": "com.example.forum",
+              "authority": "*",
+              "collection": ["net.external.thread"],
+              "action": ["read", "create"],
+              "manage": ["update"],
+              "futureFlag": true,
+              "futureValues": ["one", 2, false]
+            }
+          ]
+        }
+      }
+    }
+    """#
+}

--- a/Tests/SwiftAtprotoTests/LexPermissionTests.swift
+++ b/Tests/SwiftAtprotoTests/LexPermissionTests.swift
@@ -29,7 +29,7 @@ struct LexPermissionTests {
   @Test func actionKnownConstantsRoundTrip() throws {
     let encoder = JSONEncoder()
     let decoder = JSONDecoder()
-    for value in [LexPermissionAction.create, .update, .delete] {
+    for value in [LexPermissionAction.readSelf, .read, .create, .update, .delete] {
       let data = try encoder.encode(value)
       #expect(String(data: data, encoding: .utf8) == "\"\(value.rawValue)\"")
       let decoded = try decoder.decode(LexPermissionAction.self, from: data)
@@ -63,6 +63,35 @@ struct LexPermissionTests {
     let data = try JSONEncoder().encode(original)
     let decoded = try JSONDecoder().decode(LexPermission.self, from: data)
     #expect(decoded == original)
+  }
+
+  @Test func spacePermissionRoundTripPreservesOpenFields() throws {
+    let json = Data(
+      #"{"type":"permission","resource":"space","spaceType":"com.example.forum","authority":"*","skey":"default","collection":["net.external.thread"],"action":["read","create"],"manage":["update"],"futureFlag":true,"futureValues":["one",2,false]}"#.utf8
+    )
+
+    let permission = try JSONDecoder().decode(LexPermission.self, from: json)
+    #expect(permission.resource == .space)
+    #expect(permission.spaceType == "com.example.forum")
+    #expect(permission.authority == "*")
+    #expect(permission.skey == "default")
+    #expect(permission.manage == [.update])
+    #expect(permission.additionalFields["futureFlag"] == .boolean(true))
+    #expect(
+      permission.additionalFields["futureValues"]
+        == .array([.string("one"), .integer(2), .boolean(false)]))
+
+    let roundTrip = try JSONEncoder().encode(permission)
+    let decoded = try JSONDecoder().decode(LexPermission.self, from: roundTrip)
+    #expect(decoded == permission)
+  }
+
+  @Test func permissionRejectsNestedOpenArrays() {
+    let json = Data(
+      #"{"type":"permission","resource":"space","futureValues":[["nested"]]}"#.utf8)
+    #expect(throws: (any Error).self) {
+      try JSONDecoder().decode(LexPermission.self, from: json)
+    }
   }
 
   @Test func conformingTypeSatisfiesProtocol() {

--- a/Tests/SwiftAtprotoTests/SpaceOAuthScopeTests.swift
+++ b/Tests/SwiftAtprotoTests/SpaceOAuthScopeTests.swift
@@ -1,0 +1,212 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+@Suite("Permissioned space OAuth scopes")
+struct SpaceOAuthScopeTests {
+  private let grantor = try! DID(string: "did:plc:alice")
+  private let otherAuthority = try! DID(string: "did:plc:forum")
+  private let ownSpace = try! SpaceRef(
+    string: "at://did:plc:alice/space/com.example.forum/default")
+  private let sharedSpace = try! SpaceRef(
+    string: "at://did:plc:forum/space/com.example.forum/default")
+
+  @Test("bare scope applies proposal defaults")
+  func parsesDefaults() throws {
+    let scope = try SpaceScope(string: "space:com.example.forum")
+
+    #expect(scope.spaceType == "com.example.forum")
+    #expect(scope.authority == "self")
+    #expect(scope.skey == "*")
+    #expect(scope.collection == nil)
+    #expect(scope.action == [.read, .create, .update, .delete])
+    #expect(scope.manage.isEmpty)
+    #expect(scope.description == "space:com.example.forum")
+  }
+
+  @Test(
+    "proposal examples round-trip canonically",
+    arguments: [
+      "space:com.example.bookmarks",
+      "space:com.atmoboards.forum?authority=*",
+      "space:com.atmoboards.forum?authority=*&action=read",
+      "space:com.atmoboards.forum?authority=*&action=read_self",
+      "space:com.atmoboards.forum?authority=*&collection=*",
+      "space:com.atmoboards.forum?authority=did:plc:abc123&skey=default&collection=com.atmoboards.thread&action=create&action=update",
+      "space:com.atmoboards.forum?authority=*&action=read_self&manage=update&manage=delete",
+      "space:com.atmoboards.forum?authority=*&manage=update&manage=delete",
+      "space:*?authority=did:plc:abc123",
+    ])
+  func proposalExamplesRoundTrip(_ example: String) throws {
+    #expect(try SpaceScope(string: example).description == example)
+  }
+
+  @Test("scope parameters normalize in a stable order")
+  func normalizesParameters() throws {
+    let scope = try SpaceScope(
+      string:
+        "space:com.example.forum?manage=delete&authority=*&action=update&collection=com.example.reply&action=read_self&collection=com.example.thread&action=read&manage=update"
+    )
+
+    #expect(scope.action == [.read, .update])
+    #expect(scope.manage == [.update, .delete])
+    #expect(scope.collection == ["com.example.reply", "com.example.thread"])
+    #expect(
+      scope.description
+        == "space:com.example.forum?authority=*&collection=com.example.reply&collection=com.example.thread&action=read&action=update&manage=update&manage=delete"
+    )
+  }
+
+  @Test("invalid selectors and operations are rejected")
+  func rejectsInvalidScopes() {
+    #expect(throws: OAuthScopeError.self) { try SpaceScope(string: "space:") }
+    #expect(throws: OAuthScopeError.self) {
+      try SpaceScope(string: "space:com.example.forum?authority=example.com")
+    }
+    #expect(throws: OAuthScopeError.self) {
+      try SpaceScope(string: "space:com.example.forum?action=publish")
+    }
+    #expect(throws: OAuthScopeError.duplicateKey("authority")) {
+      try SpaceScope(
+        string: "space:com.example.forum?authority=self&authority=did:plc:forum")
+    }
+  }
+
+  @Test("self and wildcard selectors match the intended spaces")
+  func matchesSpaceSelectors() throws {
+    let ownScopes = try ScopesSet(["atproto", "space:com.example.forum"])
+    let readOwn = SpaceScopeRequirement(space: ownSpace, operation: .read(repository: grantor))
+    let readShared = SpaceScopeRequirement(space: sharedSpace, operation: .read(repository: grantor))
+
+    #expect(ownScopes.allowsSpace(readOwn, grantedBy: grantor))
+    #expect(!ownScopes.allowsSpace(readShared, grantedBy: grantor))
+
+    let wildcard = try ScopesSet([
+      "atproto", "space:*?authority=did:plc:forum&action=read",
+    ])
+    #expect(wildcard.allowsSpace(readShared, grantedBy: grantor))
+
+    let exactKey = try ScopesSet([
+      "atproto", "space:com.example.forum?authority=*&skey=other&action=read",
+    ])
+    #expect(!exactKey.allowsSpace(readShared, grantedBy: grantor))
+  }
+
+  @Test("read_self is limited to the grantor and cannot mint delegation tokens")
+  func enforcesReadSelf() throws {
+    let scopes = try ScopesSet([
+      "atproto", "space:com.example.forum?authority=*&action=read_self",
+    ])
+    let ownRead = SpaceScopeRequirement(space: sharedSpace, operation: .read(repository: grantor))
+    let otherRead = SpaceScopeRequirement(
+      space: sharedSpace, operation: .read(repository: otherAuthority))
+    let delegation = SpaceScopeRequirement(space: sharedSpace, operation: .delegationToken)
+
+    #expect(scopes.allowsSpace(ownRead, grantedBy: grantor))
+    #expect(!scopes.allowsSpace(otherRead, grantedBy: grantor))
+    #expect(!scopes.allowsSpace(delegation, grantedBy: grantor))
+
+    let read = try ScopesSet([
+      "atproto", "space:com.example.forum?authority=*&action=read",
+    ])
+    #expect(read.allowsSpace(otherRead, grantedBy: grantor))
+    #expect(read.allowsSpace(delegation, grantedBy: grantor))
+  }
+
+  @Test("omitted collections resolve from the current declaration")
+  func resolvesDynamicCollectionDefaults() throws {
+    let scopes = try ScopesSet(["atproto", "space:com.example.forum"])
+    let thread = try NSID(string: "com.external.thread")
+    let write = SpaceScopeRequirement(
+      space: ownSpace, operation: .write(collection: thread, action: .create))
+
+    #expect(!scopes.allowsSpace(write, grantedBy: grantor))
+    #expect(
+      scopes.allowsSpace(write, grantedBy: grantor, spaceTypes: [ForumSpace.self]))
+
+    let wildcardType = try ScopesSet(["atproto", "space:*?authority=*"])
+    #expect(
+      !wildcardType.allowsSpace(
+        write, grantedBy: grantor, spaceTypes: [ForumSpace.self]))
+  }
+
+  @Test("explicit collections and management grants remain independent")
+  func separatesWritesAndManagement() throws {
+    let collection = try NSID(string: "net.external.thread")
+    let scopes = try ScopesSet([
+      "atproto",
+      "space:com.example.forum?collection=net.external.thread&action=create&manage=delete",
+    ])
+    let write = SpaceScopeRequirement(
+      space: ownSpace, operation: .write(collection: collection, action: .create))
+    let updateSpace = SpaceScopeRequirement(space: ownSpace, operation: .manage(.update))
+    let deleteSpace = SpaceScopeRequirement(space: ownSpace, operation: .manage(.delete))
+
+    #expect(scopes.allowsSpace(write, grantedBy: grantor))
+    #expect(!scopes.allowsSpace(updateSpace, grantedBy: grantor))
+    #expect(scopes.allowsSpace(deleteSpace, grantedBy: grantor))
+  }
+
+  @Test("transition generic does not grant permissioned space access")
+  func doesNotExtendTransitionGeneric() throws {
+    let requirement = SpaceScopeRequirement(
+      space: ownSpace, operation: .read(repository: grantor))
+    let scopes = try ScopesSet(["transition:generic"])
+
+    #expect(!scopes.allowsSpace(requirement, grantedBy: grantor))
+    #expect(
+      !ScopesSet(rawScopes: ["space:com.example.forum"])
+        .allowsSpace(requirement, grantedBy: grantor))
+  }
+
+  @Test("space permissions expand with namespace authority checks")
+  func expandsPermissionSets() throws {
+    let include = try IncludeScope(nsid: "com.example.authForums")
+    let permission = LexPermission(
+      resource: .space,
+      action: [.read, .create],
+      collection: ["net.external.thread"],
+      spaceType: "com.example.forum",
+      authority: "*"
+    )
+
+    #expect(
+      try include.expand([permission]) == [
+        "space:com.example.forum?authority=*&collection=net.external.thread&action=read&action=create"
+      ])
+    #expect(throws: OAuthScopeError.self) {
+      try include.expand([
+        LexPermission(resource: .space, spaceType: "net.external.forum")
+      ])
+    }
+    #expect(throws: OAuthScopeError.self) {
+      try include.expand([LexPermission(resource: .space, spaceType: "*")])
+    }
+
+    let scopes = try ScopesSet(
+      ["atproto", "include:com.example.authForums"],
+      permissionSets: [ForumPermissions.self])
+    #expect(scopes.spaceScopes.count == 1)
+  }
+}
+
+private enum ForumSpace: LexSpace {
+  static let id = "com.example.forum"
+  static let key: LexRecordKeyType = .any
+  static let name = "Forum"
+  static let nameLang: [String: String]? = nil
+  static let collections: [FormatString<NSID>] = [
+    .init(rawValue: "com.external.thread")
+  ]
+  static let description: String? = nil
+}
+
+private enum ForumPermissions: LexPermissionSet {
+  static let id = "com.example.authForums"
+  static let title: String? = nil
+  static let detail: String? = nil
+  static let permissions: [LexPermission] = [
+    .init(resource: .space, action: [.read], spaceType: "com.example.forum")
+  ]
+}


### PR DESCRIPTION
Adds typed permissioned space OAuth scope parsing, permission-set expansion, and generic authorization matching for record, read, and management operations. Preserves open permission fields while keeping generated Permissioned Data APIs consumer-owned.