### PR TITLE
fix: guard applyWrites with repo scopes

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -61,11 +61,11 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
       required[key] = false
     }
     let hasConstraints = sortedProperties.contains { $0.1.hasConstraints }
-    let repoWriteAction = Self.repoWriteAction(nsid: ts.id, inputName: name)
+    let repoWriteKind = Self.repoWriteKind(nsid: ts.id, inputName: name)
     let inheritedNames: [String] = {
       if ts.isRecord { return ["ATProtoRecord"] }
       var names = ["Codable", "Hashable", "Sendable"]
-      if repoWriteAction != nil {
+      if repoWriteKind != nil {
         names.append("RepoWriteOperationDescribing")
       }
       return names
@@ -160,9 +160,15 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
         staticMakeDecl(ts: ts, name: name, defMap: defMap, required: required)
           .with(\.leadingTrivia, .newlines(2))
       }
-      if let actionRaw = repoWriteAction {
-        Self.repoWriteRequirementsAccessor(actionRaw: actionRaw)
-          .with(\.leadingTrivia, .newlines(2))
+      if let repoWriteKind {
+        switch repoWriteKind {
+        case .single(let actionRaw):
+          Self.repoWriteRequirementsAccessor(actionRaw: actionRaw)
+            .with(\.leadingTrivia, .newlines(2))
+        case .applyWrites:
+          Self.applyWritesRequirementsAccessor()
+            .with(\.leadingTrivia, .newlines(2))
+        }
       }
       if !enumCaseIsEmpty {
         EnumDeclSyntax(
@@ -923,14 +929,43 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     }
   }
 
-  private static func repoWriteAction(nsid: String, inputName: String) -> String? {
+  private enum RepoWriteKind {
+    case single(actionRaw: String)
+    case applyWrites
+  }
+
+  private static func repoWriteKind(nsid: String, inputName: String) -> RepoWriteKind? {
     guard inputName.hasSuffix("_Input") else { return nil }
     switch nsid {
-    case "com.atproto.repo.createRecord": return "create"
-    case "com.atproto.repo.putRecord": return "update"
-    case "com.atproto.repo.deleteRecord": return "delete"
+    case "com.atproto.repo.createRecord": return .single(actionRaw: "create")
+    case "com.atproto.repo.putRecord": return .single(actionRaw: "update")
+    case "com.atproto.repo.deleteRecord": return .single(actionRaw: "delete")
+    case "com.atproto.repo.applyWrites": return .applyWrites
     default: return nil
     }
+  }
+
+  private static func applyWritesRequirementsAccessor() -> DeclSyntax {
+    DeclSyntax(
+      stringLiteral: """
+        public var repoWriteRequirements: [RepoWriteRequirement] {
+          writes.map { write in
+            switch write {
+            case .repoApplyWritesCreate(let value):
+              RepoWriteRequirement(collection: value.collection.rawValue, action: .create)
+            case .repoApplyWritesUpdate(let value):
+              RepoWriteRequirement(collection: value.collection.rawValue, action: .update)
+            case .repoApplyWritesDelete(let value):
+              RepoWriteRequirement(collection: value.collection.rawValue, action: .delete)
+            case ._other(let value):
+              RepoWriteRequirement(
+                collection: value.type,
+                action: LexPermissionAction(rawValue: "unsupported")
+              )
+            }
+          }
+        }
+        """)
   }
 
   private static func repoWriteRequirementsAccessor(actionRaw: String) -> VariableDeclSyntax {

--- a/Tests/SwiftAtprotoLexTests/RepoWriteGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/RepoWriteGenerationTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Repository write generation")
+struct RepoWriteGenerationTests {
+  @Test("applyWrites describes every repository write")
+  func applyWritesDescribesEveryRepositoryWrite() async throws {
+    let source = try await generateClient(nsid: "com.atproto.repo.applyWrites")
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(
+      source.contains(
+        "public struct RepoApplyWrites_Input: Codable, Hashable, Sendable, RepoWriteOperationDescribing"
+      ))
+    #expect(source.contains("public var repoWriteRequirements: [RepoWriteRequirement]"))
+    #expect(source.contains("case .repoApplyWritesCreate(let value):"))
+    #expect(
+      source.contains(
+        "RepoWriteRequirement(collection: value.collection.rawValue, action: .create)"))
+    #expect(source.contains("case .repoApplyWritesUpdate(let value):"))
+    #expect(
+      source.contains(
+        "RepoWriteRequirement(collection: value.collection.rawValue, action: .update)"))
+    #expect(source.contains("case .repoApplyWritesDelete(let value):"))
+    #expect(
+      source.contains(
+        "RepoWriteRequirement(collection: value.collection.rawValue, action: .delete)"))
+    #expect(source.contains("case ._other(let value):"))
+    #expect(source.contains("action: LexPermissionAction(rawValue: \"unsupported\")"))
+  }
+
+  @Test("similarly named procedures do not receive repository write guards")
+  func similarlyNamedProceduresDoNotReceiveRepositoryWriteGuards() async throws {
+    let source = try await generateClient(nsid: "com.atproto.space.applyWrites")
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(!source.contains("RepoWriteOperationDescribing"))
+    #expect(!source.contains("repoWriteRequirements"))
+  }
+
+  private func generateClient(nsid: String) async throws -> String {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-repo-write-generation-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let input = root.appending(path: "input", directoryHint: .isDirectory)
+    let output = root.appending(path: "output", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+    try fixture(nsid: nsid).write(
+      to: input.appending(path: "applyWrites.json"), atomically: true, encoding: .utf8)
+
+    try await SwiftAtprotoLex.main(
+      outdir: output, path: input.path, generate: .client, pluginSource: .command)
+    return try String(
+      contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+  }
+
+  private func fixture(nsid: String) -> String {
+    """
+    {
+      "lexicon": 1,
+      "id": "\(nsid)",
+      "defs": {
+        "main": {
+          "type": "procedure",
+          "input": {
+            "encoding": "application/json",
+            "schema": {
+              "type": "object",
+              "required": ["repo", "writes"],
+              "properties": {
+                "repo": {"type": "string", "format": "at-identifier"},
+                "writes": {
+                  "type": "array",
+                  "items": {
+                    "type": "union",
+                    "refs": ["#create", "#update", "#delete"],
+                    "closed": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "create": {
+          "type": "object",
+          "required": ["collection", "value"],
+          "properties": {
+            "collection": {"type": "string", "format": "nsid"},
+            "value": {"type": "unknown"}
+          }
+        },
+        "update": {
+          "type": "object",
+          "required": ["collection", "rkey", "value"],
+          "properties": {
+            "collection": {"type": "string", "format": "nsid"},
+            "rkey": {"type": "string", "format": "record-key"},
+            "value": {"type": "unknown"}
+          }
+        },
+        "delete": {
+          "type": "object",
+          "required": ["collection", "rkey"],
+          "properties": {
+            "collection": {"type": "string", "format": "nsid"},
+            "rkey": {"type": "string", "format": "record-key"}
+          }
+        }
+      }
+    }
+    """
+  }
+}

--- a/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCScopeGuardTests.swift
@@ -550,24 +550,45 @@ struct RepoScopeGuardEnforcementTests {
   }
 
   @Test func multipleRequirementsAllChecked() async throws {
+    let recorder = RequestRecorder()
     let session = try sampleSession(scopes: [
       "atproto",
       "repo:com.example.post?action=create",
     ])
-    let client = MockClient(session: session)
+    let client = OAuthOnlyCallable(session: session, recorder: recorder)
     await #expect(
       throws: OAuthScopeError.insufficientRepoScope(
         collection: "com.example.other",
-        action: .create
+        action: .update
       )
     ) {
       _ = try await client.call(
         StubRepoBatchProcedure.self,
         input: StubRepoBatchInput(items: [
           .init(collection: "com.example.post", action: "create"),
-          .init(collection: "com.example.other", action: "create"),
+          .init(collection: "com.example.other", action: "update"),
         ]))
     }
+    #expect(recorder.lastRequest == nil)
+  }
+
+  @Test func multipleRequirementsAllAllowed() async throws {
+    let recorder = RequestRecorder()
+    let session = try sampleSession(scopes: [
+      "atproto",
+      "repo:com.example.post?action=create",
+      "repo:com.example.other?action=update",
+    ])
+    let client = OAuthOnlyCallable(session: session, recorder: recorder)
+
+    _ = try await client.call(
+      StubRepoBatchProcedure.self,
+      input: StubRepoBatchInput(items: [
+        .init(collection: "com.example.post", action: "create"),
+        .init(collection: "com.example.other", action: "update"),
+      ]))
+
+    #expect(recorder.lastRequest != nil)
   }
 }
 


### PR DESCRIPTION
Generate repository scope requirements for every create, update, and delete in com.atproto.repo.applyWrites so unauthorized batches fail before transport.