### PR TITLE
feat: support generated API access modifiers

### DIFF
--- a/CommandLineTool/Lexgen.swift
+++ b/CommandLineTool/Lexgen.swift
@@ -45,6 +45,7 @@ struct Lexgen: AsyncParsableCommand {
         outdir: outdirURL,
         path: SourceControl.lexiconsDirectoryURL(packageRootURL: rootURL).path(),
         generate: config.generate,
+        accessModifier: config.accessModifier,
         pluginSource: pluginSource
       )
     #endif

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ swift package plugin \
 ```
 
 
-Sample configuration file is as follows. You can specify whether to generate client code, server code, or both using the `generate` field (defaults to `["client"]`).
+Sample configuration file is as follows. You can specify whether to generate client code, server code, or both using the `generate` field (defaults to `["client"]`). Use `accessModifier` to generate `internal`, `package`, or `public` declarations; it defaults to `public`.
 
 The same `.atproto.json` schema serves both the `ATProtoGenerator` build tool plugin and the `Generate Source Code` command plugin, but the `module` field behaves differently:
 

--- a/Sources/SourceControl/LexiconConfig.swift
+++ b/Sources/SourceControl/LexiconConfig.swift
@@ -43,15 +43,23 @@ public struct GenerateOption: OptionSet, Codable, Sendable {
   public static let server = Self(rawValue: 1 << 1)
 }
 
+public enum AccessModifier: String, Codable, Sendable {
+  case `internal`
+  case package
+  case `public`
+}
+
 public struct LexiconConfig: Encodable, DecodableWithConfiguration, Sendable {
   public let dependencies: [LexiconDependency]
   public let module: String
   public let generate: GenerateOption
+  public let accessModifier: AccessModifier
 
   enum CodingKeys: String, CodingKey {
     case dependencies
     case module
     case generate
+    case accessModifier
   }
 
   public init(from decoder: Decoder, configuration outdir: String?) throws {
@@ -59,6 +67,7 @@ public struct LexiconConfig: Encodable, DecodableWithConfiguration, Sendable {
     dependencies = try container.decode([LexiconDependency].self, forKey: .dependencies)
     module = try outdir ?? container.decodeIfPresent(String.self, forKey: .module) ?? Self.defaultModule
     generate = try container.decodeIfPresent(GenerateOption.self, forKey: .generate) ?? .client
+    accessModifier = try container.decodeIfPresent(AccessModifier.self, forKey: .accessModifier) ?? .public
   }
 
   private static let defaultModule = "."

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -3,8 +3,16 @@ import SwiftBasicFormat
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+#if os(macOS) || os(Linux)
+  import SourceControl
+#endif
+
 extension Lex {
-  static func genXRPCAPIProtocolFile(for schemasMap: [String: [Schema]], defMap: ExtDefMap) -> String {
+  static func genXRPCAPIProtocolFile(
+    for schemasMap: [String: [Schema]],
+    defMap: ExtDefMap,
+    accessModifier: AccessModifier = .public
+  ) -> String {
     var methodTypes = [(key: String, prefix: String, value: TypeSchema, def: any HTTPAPITypeDefinition)]()
     for schemas in schemasMap {
       for schema in schemas.value {
@@ -54,15 +62,16 @@ extension Lex {
         genUnversalServerExtension(leadingTrivia: .newlines(2), for: methodTypes, defMap: defMap)
       },
       trailingTrivia: .newline)
-    return src.formatted(using: BasicFormat(indentationWidth: .spaces(2))).description
+    return renderSourceFile(applyingAccessModifier(to: src, accessModifier: accessModifier))
   }
 
-  private static func genXRPCAPIProtocol(leadingTrivia _: Trivia? = nil, for methodTypes: [(key: String, prefix: String, value: TypeSchema, def: any HTTPAPITypeDefinition)]) -> ProtocolDeclSyntax {
+  private static func genXRPCAPIProtocol(
+    leadingTrivia _: Trivia? = nil,
+    for methodTypes: [(key: String, prefix: String, value: TypeSchema, def: any HTTPAPITypeDefinition)]
+  ) -> ProtocolDeclSyntax {
     ProtocolDeclSyntax(
       leadingTrivia: nil,
-      modifiers: [
-        DeclModifierSyntax(name: .keyword(.public))
-      ],
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
       name: .identifier("XRPCAPIProtocol"),
       inheritanceClause: InheritanceClauseSyntax(typeNames: ["Sendable"])
     ) {

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -7,13 +7,25 @@ import SwiftSyntaxBuilder
   import SourceControl
 #endif
 
-public func main(outdir outdirBaseURL: URL, path: String, generate: GenerateOption, pluginSource: PluginSource = .command) async throws {
+public func main(
+  outdir outdirBaseURL: URL,
+  path: String,
+  generate: GenerateOption,
+  accessModifier: AccessModifier = .public,
+  pluginSource: PluginSource = .command
+) async throws {
   let url = URL(filePath: path)
 
   let fileURLs = collectJSONFileURLs(at: url)
   let schemasMap = try await decodeSchemasByPrefix(from: fileURLs)
   let defMap = Lex.buildExtDefMap(schemasMap: schemasMap)
-  try await writeSchemaCode(for: schemasMap, with: defMap, to: outdirBaseURL, generate: generate, pluginSource: pluginSource)
+  try await writeSchemaCode(
+    for: schemasMap,
+    with: defMap,
+    to: outdirBaseURL,
+    generate: generate,
+    accessModifier: accessModifier,
+    pluginSource: pluginSource)
 }
 
 func collectJSONFileURLs(at baseURL: URL) -> [URL] {
@@ -116,17 +128,21 @@ func writeSchemaCode(
   with defMap: ExtDefMap,
   to baseURL: URL,
   generate: GenerateOption,
+  accessModifier: AccessModifier = .public,
   pluginSource: PluginSource
 ) async throws {
   let schemasArray = schemasMap.sorted { $0.key < $1.key }
   let (blocks, methods, requirements) = try await withThrowingTaskGroup(of: (DeclSyntax, MemberBlockItemListSyntax, MemberBlockItemListSyntax, Int).self) { group in
-    let src = Lex.genUnknownRecord(for: schemasMap)
+    let src = Lex.genUnknownRecord(for: schemasMap, accessModifier: accessModifier)
     let recordURL = baseURL.appending(path: "UnknownATPValue.swift")
     try src.write(to: recordURL, atomically: true, encoding: .utf8)
     let serverURL = baseURL.appending(path: "XRPCAPIProtocol.swift")
     switch (generate.contains(.server), pluginSource) {
     case (true, _):
-      let serverSrc = Lex.genXRPCAPIProtocolFile(for: schemasMap, defMap: defMap)
+      let serverSrc = Lex.genXRPCAPIProtocolFile(
+        for: schemasMap,
+        defMap: defMap,
+        accessModifier: accessModifier)
       try serverSrc.write(to: serverURL, atomically: true, encoding: .utf8)
     case (false, .build):
       // The build plugin pre-declares this file as an output at plan time, so
@@ -256,9 +272,7 @@ func writeSchemaCode(
     if !methods.isEmpty {
       ProtocolDeclSyntax(
         leadingTrivia: .newlines(2),
-        modifiers: [
-          DeclModifierSyntax(name: .keyword(.public))
-        ],
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
         name: .identifier("XRPCCallable"),
         inheritanceClause: InheritanceClauseSyntax(
           typeNames: ["_XRPCCallable"])
@@ -270,7 +284,8 @@ func writeSchemaCode(
       }
     }
   }
-  let clientSrc: String = Lex.renderSourceFile(clientTree)
+  let clientSrc: String = Lex.renderSourceFile(
+    Lex.applyingAccessModifier(to: clientTree, accessModifier: accessModifier))
   let clientURL = baseURL.appending(path: "XRPCAPIClient.swift")
   try clientSrc.write(to: clientURL, atomically: true, encoding: .utf8)
 }
@@ -289,13 +304,11 @@ class EnumDeclSyntaxNode {
     let lt: Trivia? = depth > 0 ? .newline : leadingTrivia
     return EnumDeclSyntax(
       leadingTrivia: lt,
-      modifiers: [
-        DeclModifierSyntax(name: .keyword(.public))
-      ],
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
       name: .lexIdentifier(name)
     ) {
       for childKey in children.keys.sorted() {
-        children[childKey]!.generateEnums()
+        children[childKey]!.generateEnums(depth: depth + 1)
       }
     }
   }
@@ -366,6 +379,16 @@ enum Lex {
       .description
   }
 
+  static func applyingAccessModifier(
+    to source: SourceFileSyntax,
+    accessModifier: AccessModifier
+  ) -> SourceFileSyntax {
+    guard accessModifier != .public else { return source }
+    return AccessModifierRewriter(accessModifier: accessModifier)
+      .rewrite(source)
+      .cast(SourceFileSyntax.self)
+  }
+
   static var fileHeader: Trivia {
     Trivia(pieces: [
       .lineComment("//"),
@@ -423,7 +446,10 @@ enum Lex {
     }
   }
 
-  static func genUnknownRecord(for schemasMap: [String: [Schema]]) -> String {
+  static func genUnknownRecord(
+    for schemasMap: [String: [Schema]],
+    accessModifier: AccessModifier = .public
+  ) -> String {
     var recordTypes = [(key: String, value: TypeSchema)]()
     for schemas in schemasMap {
       for schema in schemas.value {
@@ -437,9 +463,7 @@ enum Lex {
         trailingTrivia: .newlines(2)
       )
       EnumDeclSyntax(
-        modifiers: [
-          DeclModifierSyntax(name: .keyword(.public))
-        ],
+        modifiers: [DeclModifierSyntax(name: .keyword(.public))],
         name: .identifier("UnknownATPValue"),
         inheritanceClause: InheritanceClauseSyntax(typeNames: ["UnknownATPValueProtocol"])
       ) {
@@ -726,7 +750,7 @@ enum Lex {
       }
     }
     .with(\.trailingTrivia, .newline)
-    return src.formatted(using: BasicFormat(indentationWidth: .spaces(2))).description
+    return renderSourceFile(applyingAccessModifier(to: src, accessModifier: accessModifier))
   }
 
   static func buildExtDefMap(schemasMap: [String: [Schema]]) -> ExtDefMap {
@@ -769,6 +793,35 @@ enum Lex {
     id.trim(prefix: "\(prefix).").components(separatedBy: CharacterSet(charactersIn: ".#")).enumerated().map {
       $0 == 0 ? $1 : $1.titleCased()
     }.joined()
+  }
+}
+
+private final class AccessModifierRewriter: SyntaxRewriter {
+  let accessModifier: AccessModifier
+
+  init(accessModifier: AccessModifier) {
+    self.accessModifier = accessModifier
+  }
+
+  override func visit(_ node: DeclModifierListSyntax) -> DeclModifierListSyntax {
+    switch accessModifier {
+    case .internal:
+      node.filter { $0.name.tokenKind != .keyword(.public) }
+    case .package:
+      DeclModifierListSyntax {
+        for modifier in node {
+          if modifier.name.tokenKind == .keyword(.public) {
+            modifier.with(
+              \.name,
+              .keyword(.package, trailingTrivia: modifier.name.trailingTrivia))
+          } else {
+            modifier
+          }
+        }
+      }
+    case .public:
+      node
+    }
   }
 }
 

--- a/Tests/SourceControlTests/LexiconConfigTests.swift
+++ b/Tests/SourceControlTests/LexiconConfigTests.swift
@@ -1,0 +1,40 @@
+#if os(macOS) || os(Linux)
+
+  import Foundation
+  import Testing
+
+  @testable import SourceControl
+
+  @Suite("Lexicon configuration")
+  struct LexiconConfigTests {
+    @Test("accessModifier defaults to public")
+    func accessModifierDefaultsToPublic() throws {
+      let config = try decodeConfig(
+        """
+        {"dependencies": []}
+        """)
+
+      #expect(config.accessModifier == .public)
+    }
+
+    @Test(
+      "accessModifier accepts Swift access levels",
+      arguments: [AccessModifier.internal, .package, .public])
+    func accessModifierAcceptsSwiftAccessLevels(accessModifier: AccessModifier) throws {
+      let config = try decodeConfig(
+        """
+        {"dependencies": [], "accessModifier": "\(accessModifier.rawValue)"}
+        """)
+
+      #expect(config.accessModifier == accessModifier)
+    }
+
+    private func decodeConfig(_ source: String) throws -> LexiconConfig {
+      try JSONDecoder().decode(
+        LexiconConfig.self,
+        from: Data(source.utf8),
+        configuration: nil)
+    }
+  }
+
+#endif

--- a/Tests/SwiftAtprotoLexTests/ConstraintDecodingGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/ConstraintDecodingGenerationTests.swift
@@ -44,4 +44,66 @@ struct ConstraintDecodingGenerationTests {
     #expect(source.contains("self = Self.init(value: value)"))
     #expect(source.contains("self = try Self.make(value: value)"))
   }
+
+  @Test("internal API generation removes public access modifiers")
+  func internalAPIRemovesPublicAccessModifiers() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-non-public-api-\(UUID().uuidString)", directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: root) }
+
+    let input = root.appending(path: "input", directoryHint: .isDirectory)
+    let output = root.appending(path: "output", directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    let fixture = """
+      {
+        "lexicon": 1,
+        "id": "com.example.internal",
+        "defs": {
+          "main": {
+            "type": "object",
+            "required": ["value"],
+            "properties": {"value": {"type": "string"}}
+          }
+        }
+      }
+      """
+    try fixture.write(
+      to: input.appending(path: "internal.json"), atomically: true, encoding: .utf8)
+
+    try await SwiftAtprotoLex.main(
+      outdir: output,
+      path: input.path,
+      generate: [.client, .server],
+      accessModifier: .internal,
+      pluginSource: .command)
+
+    let client = try String(
+      contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+    let unknown = try String(
+      contentsOf: output.appending(path: "UnknownATPValue.swift"), encoding: .utf8)
+    let server = try String(
+      contentsOf: output.appending(path: "XRPCAPIProtocol.swift"), encoding: .utf8)
+
+    #expect(!client.contains("public "))
+    #expect(!unknown.contains("public "))
+    #expect(!server.contains("public "))
+    #expect(!Parser.parse(source: client).hasError)
+    #expect(!Parser.parse(source: unknown).hasError)
+    #expect(!Parser.parse(source: server).hasError)
+
+    try await SwiftAtprotoLex.main(
+      outdir: output,
+      path: input.path,
+      generate: .client,
+      accessModifier: .package,
+      pluginSource: .command)
+    let packageClient = try String(
+      contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+
+    #expect(packageClient.contains("package enum Com"))
+    #expect(!packageClient.contains("public "))
+    #expect(!Parser.parse(source: packageClient).hasError)
+  }
 }


### PR DESCRIPTION
Add an accessModifier configuration option for generating internal, package, or public API declarations while preserving public as the default. Apply the selected visibility consistently across generated client, server, and unknown-value types.