### PR TITLE
feat: generate repository write scope requirements

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -62,10 +62,12 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     }
     let hasConstraints = sortedProperties.contains { $0.1.hasConstraints }
     let repoWriteAction = Self.repoWriteAction(nsid: ts.id, inputName: name)
+    let isRepoApplyWritesInput =
+      ts.id == "com.atproto.repo.applyWrites" && name.hasSuffix("_Input")
     let inheritedNames: [String] = {
       if ts.isRecord { return ["ATProtoRecord"] }
       var names = ["Codable", "Hashable", "Sendable"]
-      if repoWriteAction != nil {
+      if repoWriteAction != nil || isRepoApplyWritesInput {
         names.append("RepoWriteOperationDescribing")
       }
       return names
@@ -162,6 +164,9 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
       }
       if let actionRaw = repoWriteAction {
         Self.repoWriteRequirementsAccessor(actionRaw: actionRaw)
+          .with(\.leadingTrivia, .newlines(2))
+      } else if isRepoApplyWritesInput {
+        Self.applyWritesRequirementsAccessor()
           .with(\.leadingTrivia, .newlines(2))
       }
       if !enumCaseIsEmpty {
@@ -934,6 +939,119 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
   }
 
   private static func repoWriteRequirementsAccessor(actionRaw: String) -> VariableDeclSyntax {
+    repoWriteRequirementsAccessor(
+      ArrayExprSyntax {
+        ArrayElementSyntax(expression: repoWriteRequirement(actionRaw: actionRaw))
+      })
+  }
+
+  private static func applyWritesRequirementsAccessor() -> VariableDeclSyntax {
+    repoWriteRequirementsAccessor(
+      FunctionCallExprSyntax(
+        callee: MemberAccessExprSyntax(
+          base: DeclReferenceExprSyntax(baseName: .identifier("writes")),
+          name: .identifier("map")
+        ),
+        trailingClosure: ClosureExprSyntax(signaturesBuilder: {
+          ClosureShorthandParameterSyntax(name: .identifier("write"))
+        }) {
+          SwitchExprSyntax(subject: DeclReferenceExprSyntax(baseName: .identifier("write"))) {
+            applyWritesCase(name: "repoApplyWritesCreate", actionRaw: "create")
+            applyWritesCase(name: "repoApplyWritesUpdate", actionRaw: "update")
+            applyWritesCase(name: "repoApplyWritesDelete", actionRaw: "delete")
+            SwitchCaseSyntax(
+              label: .case(
+                .init(caseItems: [
+                  .init(
+                    pattern: ExpressionPatternSyntax(
+                      expression: FunctionCallExprSyntax(
+                        callee: MemberAccessExprSyntax(name: .identifier("_other"))
+                      ) {
+                        LabeledExprSyntax(
+                          expression: PatternExprSyntax(
+                            pattern: WildcardPatternSyntax(wildcard: .wildcardToken())
+                          ))
+                      }
+                    ))
+                ])
+              )
+            ) {
+              FunctionCallExprSyntax(callee: DeclReferenceExprSyntax(baseName: .identifier("RepoWriteRequirement"))) {
+                LabeledExprSyntax(
+                  label: .identifier("collection"), colon: .colonToken(),
+                  expression: StringLiteralExprSyntax(content: "unsupported"),
+                  trailingComma: .commaToken())
+                LabeledExprSyntax(
+                  label: .identifier("action"), colon: .colonToken(),
+                  expression: FunctionCallExprSyntax(
+                    callee: DeclReferenceExprSyntax(baseName: .identifier("LexPermissionAction"))
+                  ) {
+                    LabeledExprSyntax(
+                      label: .identifier("rawValue"), colon: .colonToken(),
+                      expression: StringLiteralExprSyntax(content: "unsupported"))
+                  })
+              }
+            }
+          }
+        }
+      ))
+  }
+
+  private static func applyWritesCase(name: String, actionRaw: String) -> SwitchCaseSyntax {
+    SwitchCaseSyntax(
+      label: .case(
+        .init(caseItems: [
+          .init(
+            pattern: ExpressionPatternSyntax(
+              expression: FunctionCallExprSyntax(
+                callee: MemberAccessExprSyntax(name: .identifier(name))
+              ) {
+                LabeledExprSyntax(
+                  expression: PatternExprSyntax(
+                    pattern: ValueBindingPatternSyntax(
+                      bindingSpecifier: .keyword(.let),
+                      pattern: IdentifierPatternSyntax(identifier: .identifier("value"))
+                    )))
+              }
+            ))
+        ])
+      )
+    ) {
+      repoWriteRequirement(actionRaw: actionRaw, collectionBase: "value")
+    }
+  }
+
+  private static func repoWriteRequirement(
+    actionRaw: String, collectionBase: String? = nil
+  ) -> FunctionCallExprSyntax {
+    let collectionBaseExpr: ExprSyntax =
+      if let collectionBase {
+        ExprSyntax(
+          MemberAccessExprSyntax(
+            base: DeclReferenceExprSyntax(baseName: .identifier(collectionBase)),
+            name: .identifier("collection")))
+      } else {
+        ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("collection")))
+      }
+    let collection = MemberAccessExprSyntax(
+      base: collectionBaseExpr,
+      name: .identifier("rawValue")
+    )
+    return FunctionCallExprSyntax(
+      callee: DeclReferenceExprSyntax(baseName: .identifier("RepoWriteRequirement"))
+    ) {
+      LabeledExprSyntax(
+        label: .identifier("collection"), colon: .colonToken(),
+        expression: collection, trailingComma: .commaToken())
+      LabeledExprSyntax(
+        label: .identifier("action"), colon: .colonToken(),
+        expression: MemberAccessExprSyntax(name: .identifier(actionRaw)))
+    }
+  }
+
+  private static func repoWriteRequirementsAccessor(
+    _ expression: some ExprSyntaxProtocol
+  ) -> VariableDeclSyntax {
     VariableDeclSyntax(
       modifiers: [DeclModifierSyntax(name: .keyword(.public))],
       bindingSpecifier: .keyword(.var),
@@ -942,55 +1060,13 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
           pattern: IdentifierPatternSyntax(identifier: .identifier("repoWriteRequirements")),
           typeAnnotation: TypeAnnotationSyntax(
             type: ArrayTypeSyntax(
-              element: IdentifierTypeSyntax(name: .identifier("RepoWriteRequirement"))
-            )
-          ),
+              element: IdentifierTypeSyntax(name: .identifier("RepoWriteRequirement")))),
           accessorBlock: AccessorBlockSyntax(
-            leftBrace: .leftBraceToken(),
-            accessors: AccessorBlockSyntax.Accessors([
-              CodeBlockItemSyntax(
-                item: CodeBlockItemSyntax.Item(
-                  ArrayExprSyntax(
-                    leftSquare: .leftSquareToken(),
-                    elements: ArrayElementListSyntax([
-                      ArrayElementSyntax(
-                        expression: FunctionCallExprSyntax(
-                          calledExpression: DeclReferenceExprSyntax(
-                            baseName: .identifier("RepoWriteRequirement")),
-                          leftParen: .leftParenToken(),
-                          arguments: LabeledExprListSyntax([
-                            LabeledExprSyntax(
-                              label: .identifier("collection"),
-                              colon: .colonToken(),
-                              expression: MemberAccessExprSyntax(
-                                base: DeclReferenceExprSyntax(baseName: .identifier("collection")),
-                                period: .periodToken(),
-                                declName: DeclReferenceExprSyntax(baseName: .identifier("rawValue"))
-                              ),
-                              trailingComma: .commaToken()
-                            ),
-                            LabeledExprSyntax(
-                              label: .identifier("action"),
-                              colon: .colonToken(),
-                              expression: MemberAccessExprSyntax(
-                                period: .periodToken(),
-                                name: .identifier(actionRaw)
-                              )
-                            ),
-                          ]),
-                          rightParen: .rightParenToken()
-                        )
-                      )
-                    ]),
-                    rightSquare: .rightSquareToken()
-                  )
-                )
-              )
-            ]),
-            rightBrace: .rightBraceToken()
-          )
-        )
-      ]
-    )
+            accessors: .getter(
+              CodeBlockItemListSyntax {
+                expression
+              })))
+      ])
   }
+
 }

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -61,13 +61,13 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
       required[key] = false
     }
     let hasConstraints = sortedProperties.contains { $0.1.hasConstraints }
-    let repoWriteAction = Self.repoWriteAction(nsid: ts.id, inputName: name)
+    let repoWriteActions = Self.repoWriteActions(nsid: ts.id, inputName: name)
     let isRepoApplyWritesInput =
       ts.id == "com.atproto.repo.applyWrites" && name.hasSuffix("_Input")
     let inheritedNames: [String] = {
       if ts.isRecord { return ["ATProtoRecord"] }
       var names = ["Codable", "Hashable", "Sendable"]
-      if repoWriteAction != nil || isRepoApplyWritesInput {
+      if repoWriteActions != nil || isRepoApplyWritesInput {
         names.append("RepoWriteOperationDescribing")
       }
       return names
@@ -162,8 +162,8 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
         staticMakeDecl(ts: ts, name: name, defMap: defMap, required: required)
           .with(\.leadingTrivia, .newlines(2))
       }
-      if let actionRaw = repoWriteAction {
-        Self.repoWriteRequirementsAccessor(actionRaw: actionRaw)
+      if let actionRaws = repoWriteActions {
+        Self.repoWriteRequirementsAccessor(actionRaws: actionRaws)
           .with(\.leadingTrivia, .newlines(2))
       } else if isRepoApplyWritesInput {
         Self.applyWritesRequirementsAccessor()
@@ -928,20 +928,22 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     }
   }
 
-  private static func repoWriteAction(nsid: String, inputName: String) -> String? {
+  private static func repoWriteActions(nsid: String, inputName: String) -> [String]? {
     guard inputName.hasSuffix("_Input") else { return nil }
     switch nsid {
-    case "com.atproto.repo.createRecord": return "create"
-    case "com.atproto.repo.putRecord": return "update"
-    case "com.atproto.repo.deleteRecord": return "delete"
+    case "com.atproto.repo.createRecord": return ["create"]
+    case "com.atproto.repo.putRecord": return ["create", "update"]
+    case "com.atproto.repo.deleteRecord": return ["delete"]
     default: return nil
     }
   }
 
-  private static func repoWriteRequirementsAccessor(actionRaw: String) -> VariableDeclSyntax {
+  private static func repoWriteRequirementsAccessor(actionRaws: [String]) -> VariableDeclSyntax {
     repoWriteRequirementsAccessor(
       ArrayExprSyntax {
-        ArrayElementSyntax(expression: repoWriteRequirement(actionRaw: actionRaw))
+        for actionRaw in actionRaws {
+          ArrayElementSyntax(expression: repoWriteRequirement(actionRaw: actionRaw))
+        }
       })
   }
 

--- a/Tests/SwiftAtprotoLexTests/RepoWriteGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/RepoWriteGenerationTests.swift
@@ -6,6 +6,58 @@ import Testing
 
 @Suite("Repository write generation")
 struct RepoWriteGenerationTests {
+  @Test("putRecord requires create and update scopes")
+  func putRecordRequiresCreateAndUpdateScopes() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-put-record-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let input = root.appending(path: "input")
+    let output = root.appending(path: "output")
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    let fixture = """
+      {
+        "lexicon": 1,
+        "id": "com.atproto.repo.putRecord",
+        "defs": {
+          "main": {
+            "type": "procedure",
+            "input": {
+              "encoding": "application/json",
+              "schema": {
+                "type": "object",
+                "required": ["repo", "collection", "rkey", "record"],
+                "properties": {
+                  "repo": { "type": "string", "format": "at-identifier" },
+                  "collection": { "type": "string", "format": "nsid" },
+                  "rkey": { "type": "string", "format": "record-key" },
+                  "record": { "type": "unknown" }
+                }
+              }
+            }
+          }
+        }
+      }
+      """
+    try Data(fixture.utf8).write(to: input.appending(path: "putRecord.json"))
+
+    try await SwiftAtprotoLex.main(
+      outdir: output, path: input.path, generate: .client, pluginSource: .command)
+
+    let source = try String(
+      contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(
+      source.contains(
+        "RepoWriteRequirement(collection: collection.rawValue, action: .create)"
+      ))
+    #expect(
+      source.contains(
+        "RepoWriteRequirement(collection: collection.rawValue, action: .update)"
+      ))
+  }
+
   @Test("applyWrites describes every generated write variant")
   func applyWritesDescribesEveryGeneratedWriteVariant() async throws {
     let root = FileManager.default.temporaryDirectory

--- a/Tests/SwiftAtprotoLexTests/RepoWriteGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/RepoWriteGenerationTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Repository write generation")
+struct RepoWriteGenerationTests {
+  @Test("applyWrites describes every generated write variant")
+  func applyWritesDescribesEveryGeneratedWriteVariant() async throws {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-repo-writes-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let input = root.appending(path: "input")
+    let output = root.appending(path: "output")
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+
+    let fixture = """
+      {
+        "lexicon": 1,
+        "id": "com.atproto.repo.applyWrites",
+        "defs": {
+          "main": {
+            "type": "procedure",
+            "input": {
+              "encoding": "application/json",
+              "schema": {
+                "type": "object",
+                "required": ["repo", "writes"],
+                "properties": {
+                  "repo": { "type": "string", "format": "at-identifier" },
+                  "writes": {
+                    "type": "array",
+                    "items": {
+                      "type": "union",
+                      "refs": ["#create", "#update", "#delete"],
+                      "closed": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "create": {
+            "type": "object",
+            "required": ["collection", "value"],
+            "properties": {
+              "collection": { "type": "string", "format": "nsid" },
+              "value": { "type": "unknown" }
+            }
+          },
+          "update": {
+            "type": "object",
+            "required": ["collection", "rkey", "value"],
+            "properties": {
+              "collection": { "type": "string", "format": "nsid" },
+              "rkey": { "type": "string", "format": "record-key" },
+              "value": { "type": "unknown" }
+            }
+          },
+          "delete": {
+            "type": "object",
+            "required": ["collection", "rkey"],
+            "properties": {
+              "collection": { "type": "string", "format": "nsid" },
+              "rkey": { "type": "string", "format": "record-key" }
+            }
+          }
+        }
+      }
+      """
+    try Data(fixture.utf8).write(to: input.appending(path: "applyWrites.json"))
+
+    try await SwiftAtprotoLex.main(
+      outdir: output, path: input.path, generate: .client, pluginSource: .command)
+
+    let source = try String(
+      contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(
+      source.contains(
+        "public struct RepoApplyWrites_Input: Codable, Hashable, Sendable, RepoWriteOperationDescribing"
+      ))
+    #expect(source.contains("case .repoApplyWritesCreate(let value):"))
+    #expect(source.contains("case .repoApplyWritesUpdate(let value):"))
+    #expect(source.contains("case .repoApplyWritesDelete(let value):"))
+    #expect(source.contains("action: .create"))
+    #expect(source.contains("action: .update"))
+    #expect(source.contains("action: .delete"))
+  }
+}


### PR DESCRIPTION
Generate OAuth repository write scope requirements for every applyWrites variant and require both create and update scopes for putRecord.