### PR TITLE
feat: verify permissioned repository commits

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -12,4 +12,5 @@ builder:
     - documentation_targets:
         - SwiftAtproto
         - ATProtoCrypto
+        - ATProtoSync
         - swift-atproto

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "90808b5ae57f3266cc96552b7c9fd873ae4d3bd01f52ba73823fc2fa473929bc",
+  "originHash" : "78749e575dcd57ff9392823a5744b412485cf934a209e0b89eb58a37789f38d7",
   "pins" : [
+    {
+      "identity" : "blake3",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nnabeyang/BLAKE3.git",
+      "state" : {
+        "revision" : "18742b2d7a8fc32a78275d58e82f12d7792da129",
+        "version" : "1.8.7-swift.1"
+      }
+    },
     {
       "identity" : "cryptoswift",
       "kind" : "remoteSourceControl",

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,9 @@ let package = Package(
       name: "ATProtoCrypto",
       targets: ["ATProtoCrypto"]),
     .library(
+      name: "ATProtoSync",
+      targets: ["ATProtoSync"]),
+    .library(
       name: "ATProtoMacro",
       targets: ["ATProtoMacro"]),
     .executable(
@@ -36,6 +39,7 @@ let package = Package(
     ),
   ],
   dependencies: [
+    .package(url: "https://github.com/nnabeyang/BLAKE3.git", exact: "1.8.7-swift.1"),
     .package(url: "https://github.com/nnabeyang/swift-cbor.git", exact: "0.1.0"),
     .package(url: "https://github.com/swift-libp2p/swift-cid", exact: "0.2.2"),
     .package(url: "https://github.com/swift-libp2p/swift-multibase.git", exact: "0.2.3"),
@@ -61,6 +65,16 @@ let package = Package(
         .product(name: "P256K", package: "swift-secp256k1"),
         .product(name: "libsecp256k1", package: "swift-secp256k1"),
         .product(name: "Multibase", package: "swift-multibase"),
+      ]
+    ),
+    .target(
+      name: "ATProtoSync",
+      dependencies: [
+        "ATProtoCrypto",
+        "SwiftAtproto",
+        .product(name: "CBLAKE3", package: "BLAKE3"),
+        .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "SwiftCbor", package: "swift-cbor"),
       ]
     ),
     .target(
@@ -127,6 +141,16 @@ let package = Package(
     .testTarget(
       name: "ATProtoCryptoTests",
       dependencies: ["ATProtoCrypto"]
+    ),
+    .testTarget(
+      name: "ATProtoSyncTests",
+      dependencies: [
+        "ATProtoCrypto",
+        "ATProtoSync",
+        "SwiftAtproto",
+        .product(name: "Crypto", package: "swift-crypto"),
+        .product(name: "SwiftCbor", package: "swift-cbor"),
+      ]
     ),
     .testTarget(
       name: "SourceControlTests",

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Package Index:
   representations, and the Lexicon string formats.
 - [ATProtoCrypto](https://swiftpackageindex.com/nnabeyang/swift-atproto/main/documentation/atprotocrypto)
   — signing keys, their `did:key` encodings, and DID documents.
+- [ATProtoSync](https://swiftpackageindex.com/nnabeyang/swift-atproto/main/documentation/atprotosync)
+  — signed Permissioned Data repository commit and LtHash verification.
 - [swift-atproto](https://swiftpackageindex.com/nnabeyang/swift-atproto/main/documentation/swift_atproto)
   — the code generation executable the package plugins invoke.
 
@@ -152,6 +154,10 @@ from `.spi.yml`:
 
 The generated documentation is not committed; the Swift Package Index rebuilds
 it from source.
+
+Third-party source notices, including the Apache License 2.0 terms for the
+BLAKE3 C implementation used by `ATProtoSync`, are listed in
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md).
 
 ## Apps Using
 

--- a/Sources/ATProtoSync/BLAKE3.swift
+++ b/Sources/ATProtoSync/BLAKE3.swift
@@ -1,0 +1,24 @@
+import CBLAKE3
+import Foundation
+
+enum BLAKE3 {
+  static func hash(_ input: Data, outputByteCount: Int) -> Data {
+    precondition(outputByteCount >= 0)
+
+    var hasher = blake3_hasher()
+    blake3_hasher_init(&hasher)
+    input.withUnsafeBytes { bytes in
+      blake3_hasher_update(&hasher, bytes.baseAddress, bytes.count)
+    }
+
+    var output = [UInt8](repeating: 0, count: outputByteCount)
+    output.withUnsafeMutableBytes { bytes in
+      blake3_hasher_finalize(
+        &hasher,
+        bytes.baseAddress?.assumingMemoryBound(to: UInt8.self),
+        bytes.count
+      )
+    }
+    return Data(output)
+  }
+}

--- a/Sources/ATProtoSync/Documentation.docc/ATProtoSync.md
+++ b/Sources/ATProtoSync/Documentation.docc/ATProtoSync.md
@@ -1,0 +1,51 @@
+# ``ATProtoSync``
+
+Verify Permissioned Data repository states without owning consumer persistence.
+
+## Overview
+
+`ATProtoSync` authenticates a Permissioned Data signed commit and compares its
+hash claim with an ``LtHash`` accumulated from complete records, a DRISL index,
+or incremental operations. It does not fetch repositories, parse CAR framing,
+or decide how a consumer stores checkpoints.
+
+Generated `com.atproto.space.defs#signedCommit` and
+`com.atproto.space.listRepoOps#opEntry` values expose the fields this module
+needs, so a consumer can pass generated values directly to ``RepoCommit`` and
+``SignedRepoCommitVerifier``.
+
+```swift
+var repository = RepoCommit()
+for operation in response.ops {
+  try repository.apply(operation)
+}
+
+if let commit = response.commit {
+  try repository.verify(
+    commit,
+    context: RepoCommitContext(space: space, author: author, revision: revision),
+    publicKey: authorKey
+  )
+}
+```
+
+The internal BLAKE3 implementation is upstream BLAKE3 1.8.7, distributed
+under Apache License 2.0. Applications distributing binaries containing this
+target need to reproduce that license as part of their third-party notices;
+see `THIRD_PARTY_NOTICES.md` in the package repository.
+
+## Topics
+
+### Repository state
+
+- ``LtHash``
+- ``RepoCommit``
+- ``RepoRecord``
+- ``RepoOperation``
+
+### Signed commits
+
+- ``RepoCommitContext``
+- ``SignedRepoCommitVerifier``
+- ``RepoVerificationLimits``
+- ``RepoVerificationError``

--- a/Sources/ATProtoSync/LtHash.swift
+++ b/Sources/ATProtoSync/LtHash.swift
@@ -1,0 +1,75 @@
+import Crypto
+import Foundation
+
+/// A homomorphic set hash used by Permissioned Data repositories.
+///
+/// Each UTF-8 element expands through BLAKE3 XOF into 1024 little-endian
+/// `UInt16` lanes. Adding and removing elements uses wrapping arithmetic, so
+/// the resulting state depends on the current multiset rather than operation
+/// order.
+public struct LtHash: Hashable, Sendable {
+  /// The serialized size of an LtHash state.
+  public static let stateByteCount = 2048
+
+  private static let laneCount = stateByteCount / MemoryLayout<UInt16>.size
+  private var lanes: [UInt16]
+
+  /// Creates an empty LtHash state.
+  public init() {
+    lanes = [UInt16](repeating: 0, count: Self.laneCount)
+  }
+
+  /// Restores a previously serialized LtHash state.
+  ///
+  /// - Throws: ``RepoVerificationError/invalidLtHashStateLength(actual:)``
+  ///   unless `state` contains exactly 2048 bytes.
+  public init(state: Data) throws {
+    guard state.count == Self.stateByteCount else {
+      throw RepoVerificationError.invalidLtHashStateLength(actual: state.count)
+    }
+    lanes = stride(from: 0, to: state.count, by: 2).map { offset in
+      UInt16(state[offset]) | (UInt16(state[offset + 1]) << 8)
+    }
+  }
+
+  /// The complete 2048-byte little-endian state for persistence.
+  public var state: Data {
+    var bytes = [UInt8]()
+    bytes.reserveCapacity(Self.stateByteCount)
+    for lane in lanes {
+      bytes.append(UInt8(truncatingIfNeeded: lane))
+      bytes.append(UInt8(truncatingIfNeeded: lane >> 8))
+    }
+    return Data(bytes)
+  }
+
+  /// The SHA-256 digest compared with a signed commit's `hash` field.
+  public var digest: Data {
+    Data(SHA256.hash(data: state))
+  }
+
+  /// Whether every lane is zero.
+  public var isEmpty: Bool {
+    lanes.allSatisfy { $0 == 0 }
+  }
+
+  /// Adds one UTF-8 element to the multiset.
+  public mutating func add(_ element: String) {
+    combine(element, adding: true)
+  }
+
+  /// Removes one UTF-8 element from the multiset.
+  public mutating func remove(_ element: String) {
+    combine(element, adding: false)
+  }
+
+  private mutating func combine(_ element: String, adding: Bool) {
+    let expanded = BLAKE3.hash(
+      Data(element.utf8), outputByteCount: Self.stateByteCount)
+    for laneIndex in lanes.indices {
+      let offset = laneIndex * 2
+      let value = UInt16(expanded[offset]) | (UInt16(expanded[offset + 1]) << 8)
+      lanes[laneIndex] = adding ? lanes[laneIndex] &+ value : lanes[laneIndex] &- value
+    }
+  }
+}

--- a/Sources/ATProtoSync/RepoCommit.swift
+++ b/Sources/ATProtoSync/RepoCommit.swift
@@ -1,0 +1,216 @@
+import ATProtoCrypto
+import Foundation
+import SwiftAtproto
+
+/// A record path and CID folded into a Permissioned Data repository state.
+public struct RepoRecord: Hashable, Sendable {
+  /// The record's collection.
+  public let collection: NSID
+
+  /// The record key within ``collection``.
+  public let recordKey: RecordKey
+
+  /// The CID of the record value.
+  public let cid: LexLink
+
+  /// Creates a repository record reference.
+  public init(collection: NSID, recordKey: RecordKey, cid: LexLink) {
+    self.collection = collection
+    self.recordKey = recordKey
+    self.cid = cid
+  }
+}
+
+/// A create, update, or delete applied to a Permissioned Data repository state.
+public struct RepoOperation: Hashable, Sendable {
+  /// The affected record's collection.
+  public let collection: NSID
+
+  /// The affected record's key.
+  public let recordKey: RecordKey
+
+  /// The record CID after the operation, or `nil` for a deletion.
+  public let cid: LexLink?
+
+  /// The record CID before the operation, or `nil` for a creation.
+  public let previousCID: LexLink?
+
+  /// Creates an operation with at least one current or previous CID.
+  ///
+  /// - Throws: ``RepoVerificationError/malformedOperation`` when both CIDs are
+  ///   absent.
+  public init(
+    collection: NSID,
+    recordKey: RecordKey,
+    cid: LexLink?,
+    previousCID: LexLink?
+  ) throws {
+    guard cid != nil || previousCID != nil else {
+      throw RepoVerificationError.malformedOperation
+    }
+    self.collection = collection
+    self.recordKey = recordKey
+    self.cid = cid
+    self.previousCID = previousCID
+  }
+}
+
+/// The running LtHash state for a Permissioned Data repository.
+public struct RepoCommit: Hashable, Sendable {
+  /// The repository's homomorphic set hash.
+  public private(set) var setHash: LtHash
+
+  /// Creates an empty repository state.
+  public init() {
+    setHash = LtHash()
+  }
+
+  /// Restores a repository from a persisted LtHash state.
+  public init(state: Data) throws {
+    setHash = try LtHash(state: state)
+  }
+
+  /// Builds a repository state from complete record references.
+  public init<Records: Sequence>(records: Records) where Records.Element == RepoRecord {
+    self.init()
+    for record in records {
+      add(record)
+    }
+  }
+
+  /// Builds a repository state from a canonical DRISL index block.
+  ///
+  /// Index keys use `collection/rkey`; values are CID links. The input limits
+  /// bound both encoded allocation and the number of records folded into the
+  /// state.
+  public init(
+    drislIndex data: Data,
+    limits: RepoVerificationLimits = .init()
+  ) throws {
+    guard data.count <= limits.maximumIndexBytes else {
+      throw RepoVerificationError.inputTooLarge(
+        limit: limits.maximumIndexBytes, actual: data.count)
+    }
+
+    let index: [String: LexLink]
+    do {
+      index = try drislDecoder(
+        maximumNestingDepth: limits.maximumNestingDepth,
+        maximumContainerElements: limits.maximumIndexEntries,
+        maximumStringBytes: 1024
+      ).decode([String: LexLink].self, from: data)
+    } catch {
+      throw RepoVerificationError.malformedRepositoryIndex
+    }
+
+    self.init()
+    for (path, cid) in index {
+      add(try Self.record(path: path, cid: cid))
+    }
+  }
+
+  /// Adds a complete record reference to the state.
+  public mutating func add(_ record: RepoRecord) {
+    setHash.add(Self.element(for: record))
+  }
+
+  /// Removes a complete record reference from the state.
+  public mutating func remove(_ record: RepoRecord) {
+    setHash.remove(Self.element(for: record))
+  }
+
+  /// Applies a typed create, update, or delete operation.
+  public mutating func apply(_ operation: RepoOperation) {
+    if let previousCID = operation.previousCID {
+      remove(
+        RepoRecord(
+          collection: operation.collection,
+          recordKey: operation.recordKey,
+          cid: previousCID))
+    }
+    if let cid = operation.cid {
+      add(
+        RepoRecord(
+          collection: operation.collection,
+          recordKey: operation.recordKey,
+          cid: cid))
+    }
+  }
+
+  /// Validates and applies an operation produced from a Permissioned Data lexicon.
+  public mutating func apply(_ operation: any PermissionedRepoOperationDescribing) throws {
+    guard
+      let collection = operation.permissionedRepoOperationCollection.typed,
+      let recordKey = operation.permissionedRepoOperationRecordKey.typed
+    else {
+      throw RepoVerificationError.malformedOperation
+    }
+    let cid = try Self.validatedLink(operation.permissionedRepoOperationCID)
+    let previousCID = try Self.validatedLink(
+      operation.permissionedRepoOperationPreviousCID)
+    apply(
+      try RepoOperation(
+        collection: collection,
+        recordKey: recordKey,
+        cid: cid,
+        previousCID: previousCID))
+  }
+
+  /// Applies a sequence of generated Permissioned Data operations.
+  public mutating func apply<Operations: Sequence>(_ operations: Operations) throws
+  where Operations.Element: PermissionedRepoOperationDescribing {
+    for operation in operations {
+      try apply(operation)
+    }
+  }
+
+  /// Whether the local LtHash digest equals a signed commit's claimed hash.
+  ///
+  /// This comparison alone does not authenticate the claim. Prefer
+  /// ``verify(_:context:publicKey:limits:)`` when the author key is available.
+  public func matches(_ commit: any PermissionedRepoSignedCommitDescribing) -> Bool {
+    setHash.digest == commit.permissionedRepoCommitHash
+  }
+
+  /// Authenticates a signed commit and compares it with this repository state.
+  public func verify(
+    _ commit: any PermissionedRepoSignedCommitDescribing,
+    context: RepoCommitContext,
+    publicKey: ATProtoCrypto.PublicKey,
+    limits: RepoVerificationLimits = .init()
+  ) throws {
+    try SignedRepoCommitVerifier.verify(
+      commit, context: context, publicKey: publicKey, limits: limits)
+    guard matches(commit) else {
+      throw RepoVerificationError.setHashMismatch
+    }
+  }
+
+  private static func validatedLink(_ value: FormatString<LexLink>?) throws -> LexLink? {
+    guard let value else { return nil }
+    guard let link = value.typed else {
+      throw RepoVerificationError.malformedOperation
+    }
+    return link
+  }
+
+  private static func record(path: String, cid: LexLink) throws -> RepoRecord {
+    guard let separator = path.firstIndex(of: "/") else {
+      throw RepoVerificationError.malformedRecordPath(path)
+    }
+    let collectionRaw = String(path[..<separator])
+    let recordKeyRaw = String(path[path.index(after: separator)...])
+    do {
+      return RepoRecord(
+        collection: try NSID(string: collectionRaw),
+        recordKey: try RecordKey(string: recordKeyRaw),
+        cid: cid)
+    } catch {
+      throw RepoVerificationError.malformedRecordPath(path)
+    }
+  }
+
+  private static func element(for record: RepoRecord) -> String {
+    "\(record.collection.rawValue)/\(record.recordKey.rawValue)/\(record.cid.toBaseEncodedString)"
+  }
+}

--- a/Sources/ATProtoSync/RepoVerification.swift
+++ b/Sources/ATProtoSync/RepoVerification.swift
@@ -1,0 +1,242 @@
+import ATProtoCrypto
+import Crypto
+import Foundation
+import SwiftAtproto
+import SwiftCbor
+
+/// Resource limits applied while decoding and verifying Permissioned Data repositories.
+public struct RepoVerificationLimits: Hashable, Sendable {
+  /// The largest encoded signed commit accepted by the DRISL decoder.
+  public var maximumCommitBytes: Int
+
+  /// The largest encoded repository index accepted by the DRISL decoder.
+  public var maximumIndexBytes: Int
+
+  /// The largest number of entries accepted in a repository index.
+  public var maximumIndexEntries: Int
+
+  /// The largest nesting depth accepted from DRISL input.
+  public var maximumNestingDepth: Int
+
+  /// The largest signature accepted before public-key verification.
+  public var maximumSignatureBytes: Int
+
+  /// Creates verification limits suitable for client-side repository sync.
+  public init(
+    maximumCommitBytes: Int = 64 * 1024,
+    maximumIndexBytes: Int = 64 * 1024 * 1024,
+    maximumIndexEntries: Int = 100_000,
+    maximumNestingDepth: Int = 16,
+    maximumSignatureBytes: Int = 256
+  ) {
+    self.maximumCommitBytes = maximumCommitBytes
+    self.maximumIndexBytes = maximumIndexBytes
+    self.maximumIndexEntries = maximumIndexEntries
+    self.maximumNestingDepth = maximumNestingDepth
+    self.maximumSignatureBytes = maximumSignatureBytes
+  }
+}
+
+/// A failure to decode or verify a Permissioned Data repository state.
+public enum RepoVerificationError: Error, Hashable, Sendable {
+  /// An encoded input exceeded its configured byte limit.
+  case inputTooLarge(limit: Int, actual: Int)
+
+  /// A persisted LtHash state had a size other than 2048 bytes.
+  case invalidLtHashStateLength(actual: Int)
+
+  /// A signed commit could not be decoded as canonical DRISL.
+  case malformedSignedCommit
+
+  /// A repository index could not be decoded as canonical DRISL.
+  case malformedRepositoryIndex
+
+  /// A repository index path was not a valid collection and record-key pair.
+  case malformedRecordPath(String)
+
+  /// A generated incremental operation contained invalid fields.
+  case malformedOperation
+
+  /// The signed commit format version is not supported.
+  case unsupportedCommitVersion(Int)
+
+  /// A fixed-size signed commit field had the wrong byte length.
+  case invalidCommitFieldLength(field: String, expected: Int, actual: Int)
+
+  /// A variable-size signed commit field was empty or exceeded its limit.
+  case invalidCommitField(field: String)
+
+  /// A context field cannot be represented by its uint16 length prefix.
+  case contextFieldTooLong
+
+  /// The signed commit revision did not match the supplied context.
+  case revisionMismatch
+
+  /// The hash-binding MAC did not authenticate the claimed repository hash.
+  case macMismatch
+
+  /// The author key did not verify the commit context signature.
+  case signatureMismatch
+
+  /// The local LtHash digest did not match the authenticated commit hash.
+  case setHashMismatch
+}
+
+/// The identity and revision bound into a Permissioned Data signed commit.
+public struct RepoCommitContext: Hashable, Sendable {
+  /// The permissioned space being synchronized.
+  public let space: SpaceRef
+
+  /// The DID of the repository author.
+  public let author: SwiftAtproto.DID
+
+  /// The repository revision claimed by the signed commit.
+  public let revision: TID
+
+  /// Creates a signed commit context.
+  public init(space: SpaceRef, author: SwiftAtproto.DID, revision: TID) {
+    self.space = space
+    self.author = author
+    self.revision = revision
+  }
+
+  /// Encodes the domain-separated context signed by a repository author.
+  ///
+  /// Each field is prefixed by its big-endian uint16 byte length. This is
+  /// deliberately independent from LtHash's little-endian lane encoding.
+  public func encoded(inputKeyMaterial: Data) throws -> Data {
+    let fields = [
+      Data(space.rawValue.utf8),
+      Data(author.rawValue.utf8),
+      Data(revision.rawValue.utf8),
+      inputKeyMaterial,
+    ]
+    guard fields.allSatisfy({ $0.count <= Int(UInt16.max) }) else {
+      throw RepoVerificationError.contextFieldTooLong
+    }
+
+    var output = Data("atproto-space-v1".utf8)
+    for field in fields {
+      let length = UInt16(field.count)
+      output.append(UInt8(length >> 8))
+      output.append(UInt8(length & 0xff))
+      output.append(field)
+    }
+    return output
+  }
+}
+
+/// Decodes and authenticates Permissioned Data signed commits.
+public enum SignedRepoCommitVerifier {
+  /// Decodes a generated signed commit type from canonical DRISL bytes.
+  ///
+  /// - Throws: ``RepoVerificationError/malformedSignedCommit`` when decoding
+  ///   fails, or ``RepoVerificationError/inputTooLarge(limit:actual:)`` before
+  ///   decoding an oversized block.
+  public static func decode<Commit>(
+    _ type: Commit.Type,
+    fromDRISL data: Data,
+    limits: RepoVerificationLimits = .init()
+  ) throws -> Commit where Commit: Decodable & PermissionedRepoSignedCommitDescribing {
+    guard data.count <= limits.maximumCommitBytes else {
+      throw RepoVerificationError.inputTooLarge(
+        limit: limits.maximumCommitBytes, actual: data.count)
+    }
+    do {
+      return try drislDecoder(
+        maximumNestingDepth: limits.maximumNestingDepth,
+        maximumContainerElements: 64,
+        maximumStringBytes: limits.maximumCommitBytes
+      ).decode(type, from: data)
+    } catch {
+      throw RepoVerificationError.malformedSignedCommit
+    }
+  }
+
+  /// Verifies a signed commit's context, hash-binding MAC, and author signature.
+  ///
+  /// This authenticates the commit's hash claim but does not compare it with a
+  /// local repository state. Use ``RepoCommit/verify(_:context:publicKey:limits:)``
+  /// when a local state is available.
+  public static func verify(
+    _ commit: any PermissionedRepoSignedCommitDescribing,
+    context: RepoCommitContext,
+    publicKey: PublicKey,
+    limits: RepoVerificationLimits = .init()
+  ) throws {
+    guard commit.permissionedRepoCommitVersion == 1 else {
+      throw RepoVerificationError.unsupportedCommitVersion(
+        commit.permissionedRepoCommitVersion)
+    }
+    try requireLength(commit.permissionedRepoCommitHash, field: "hash", expected: 32)
+    try requireLength(
+      commit.permissionedRepoCommitInputKeyMaterial, field: "ikm", expected: 32)
+    try requireLength(commit.permissionedRepoCommitMAC, field: "mac", expected: 32)
+
+    let signature = commit.permissionedRepoCommitSignature
+    guard !signature.isEmpty, signature.count <= limits.maximumSignatureBytes else {
+      throw RepoVerificationError.invalidCommitField(field: "sig")
+    }
+    guard commit.permissionedRepoCommitRevision.typed != nil else {
+      throw RepoVerificationError.invalidCommitField(field: "rev")
+    }
+    guard commit.permissionedRepoCommitRevision.rawValue == context.revision.rawValue else {
+      throw RepoVerificationError.revisionMismatch
+    }
+
+    let contextBytes = try context.encoded(
+      inputKeyMaterial: commit.permissionedRepoCommitInputKeyMaterial)
+    let macKey = HKDF<SHA256>.expand(
+      pseudoRandomKey: SymmetricKey(
+        data: commit.permissionedRepoCommitInputKeyMaterial),
+      info: contextBytes,
+      outputByteCount: 32
+    )
+    guard
+      HMAC<SHA256>.isValidAuthenticationCode(
+        commit.permissionedRepoCommitMAC,
+        authenticating: commit.permissionedRepoCommitHash,
+        using: macKey)
+    else {
+      throw RepoVerificationError.macMismatch
+    }
+    guard
+      publicKey.isValidSignature(
+        signature: signature,
+        for: contextBytes)
+    else {
+      throw RepoVerificationError.signatureMismatch
+    }
+  }
+
+  private static func requireLength(_ data: Data, field: String, expected: Int) throws {
+    guard data.count == expected else {
+      throw RepoVerificationError.invalidCommitFieldLength(
+        field: field, expected: expected, actual: data.count)
+    }
+  }
+}
+
+func drislDecoder(
+  maximumNestingDepth: Int,
+  maximumContainerElements: Int,
+  maximumStringBytes: Int
+) -> CborDecoder {
+  CborDecoder(
+    options: [
+      .minimalArgumentEncoding,
+      .definiteLengthItems,
+      .lexicographicallySortedMapKeys,
+      .stringMapKeysOnly,
+      .basicSimpleValuesOnly,
+      .validUTF8Only,
+      .singleTopLevelItem,
+      .floatingPointValuesDisallowed,
+    ],
+    allowedTags: [42],
+    limits: .init(
+      maximumNestingDepth: maximumNestingDepth,
+      maximumContainerElements: maximumContainerElements,
+      maximumStringBytes: maximumStringBytes)
+  )
+}

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -99,6 +99,11 @@ let posts = try await client.call(
 - ``LexSpace``
 - ``LexRecordKeyType``
 
+### Permissioned repository sync descriptors
+
+- ``PermissionedRepoSignedCommitDescribing``
+- ``PermissionedRepoOperationDescribing``
+
 ### Space credentials
 
 - <doc:SpaceCredentials>

--- a/Sources/SwiftAtproto/PermissionedRepoSync.swift
+++ b/Sources/SwiftAtproto/PermissionedRepoSync.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Exposes the wire fields needed to verify a Permissioned Data repository commit.
+///
+/// The lexicon generator adds this conformance to
+/// `com.atproto.space.defs#signedCommit` when that definition is present and has
+/// the expected shape. Verification is provided by the `ATProtoSync` product.
+public protocol PermissionedRepoSignedCommitDescribing: Sendable {
+  /// The signed commit format version.
+  var permissionedRepoCommitVersion: Int { get }
+
+  /// The SHA-256 digest claimed for the repository's LtHash state.
+  var permissionedRepoCommitHash: Data { get }
+
+  /// Per-commit input keying material used for the hash-binding MAC.
+  var permissionedRepoCommitInputKeyMaterial: Data { get }
+
+  /// The author's signature over the encoded commit context.
+  var permissionedRepoCommitSignature: Data { get }
+
+  /// The HMAC-SHA256 value binding the repository hash to the context.
+  var permissionedRepoCommitMAC: Data { get }
+
+  /// The revision encoded in the signed commit.
+  var permissionedRepoCommitRevision: FormatString<TID> { get }
+}
+
+/// Exposes one Permissioned Data repository operation to a sync verifier.
+///
+/// The lexicon generator adds this conformance to
+/// `com.atproto.space.listRepoOps#opEntry` when that definition is present and
+/// has the expected shape.
+public protocol PermissionedRepoOperationDescribing: Sendable {
+  /// The collection containing the affected record.
+  var permissionedRepoOperationCollection: FormatString<NSID> { get }
+
+  /// The record key within ``permissionedRepoOperationCollection``.
+  var permissionedRepoOperationRecordKey: FormatString<RecordKey> { get }
+
+  /// The record CID after the operation, or `nil` for a deletion.
+  var permissionedRepoOperationCID: FormatString<LexLink>? { get }
+
+  /// The record CID before the operation, or `nil` for a creation.
+  var permissionedRepoOperationPreviousCID: FormatString<LexLink>? { get }
+}

--- a/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ObjectTypeDefinition.swift
@@ -64,11 +64,20 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     let repoWriteActions = Self.repoWriteActions(nsid: ts.id, inputName: name)
     let isRepoApplyWritesInput =
       ts.id == "com.atproto.repo.applyWrites" && name.hasSuffix("_Input")
+    let permissionedRepoDescriptor = permissionedRepoDescriptor(ts: ts)
     let inheritedNames: [String] = {
       if ts.isRecord { return ["ATProtoRecord"] }
       var names = ["Codable", "Hashable", "Sendable"]
       if repoWriteActions != nil || isRepoApplyWritesInput {
         names.append("RepoWriteOperationDescribing")
+      }
+      switch permissionedRepoDescriptor {
+      case .signedCommit:
+        names.append("PermissionedRepoSignedCommitDescribing")
+      case .operation:
+        names.append("PermissionedRepoOperationDescribing")
+      case nil:
+        break
       }
       return names
     }()
@@ -168,6 +177,50 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
       } else if isRepoApplyWritesInput {
         Self.applyWritesRequirementsAccessor()
           .with(\.leadingTrivia, .newlines(2))
+      }
+      if case .signedCommit? = permissionedRepoDescriptor {
+        Self.forwardingAccessor(
+          name: "permissionedRepoCommitVersion", type: Lex.typeSyntax("Swift.Int"),
+          source: "ver"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoCommitHash", type: Lex.typeSyntax("Foundation.Data"),
+          source: "hash"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoCommitInputKeyMaterial",
+          type: Lex.typeSyntax("Foundation.Data"), source: "ikm"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoCommitSignature", type: Lex.typeSyntax("Foundation.Data"),
+          source: "sig"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoCommitMAC", type: Lex.typeSyntax("Foundation.Data"),
+          source: "mac"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoCommitRevision", type: Self.formatStringType("TID"),
+          source: "rev"
+        ).with(\.leadingTrivia, .newlines(2))
+      }
+      if case .operation? = permissionedRepoDescriptor {
+        Self.forwardingAccessor(
+          name: "permissionedRepoOperationCollection", type: Self.formatStringType("NSID"),
+          source: "collection"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoOperationRecordKey",
+          type: Self.formatStringType("RecordKey"), source: "rkey"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoOperationCID",
+          type: Self.formatStringType("LexLink", optional: true), source: "cid"
+        ).with(\.leadingTrivia, .newlines(2))
+        Self.forwardingAccessor(
+          name: "permissionedRepoOperationPreviousCID",
+          type: Self.formatStringType("LexLink", optional: true), source: "prev"
+        ).with(\.leadingTrivia, .newlines(2))
       }
       if !enumCaseIsEmpty {
         EnumDeclSyntax(
@@ -936,6 +989,79 @@ struct ObjectTypeDefinition: Encodable, DecodableWithConfiguration, SwiftCodeGen
     case "com.atproto.repo.deleteRecord": return ["delete"]
     default: return nil
     }
+  }
+
+  private enum PermissionedRepoDescriptor {
+    case signedCommit
+    case operation
+  }
+
+  private func permissionedRepoDescriptor(ts: TypeSchema) -> PermissionedRepoDescriptor? {
+    let required = Set(required ?? [])
+    if ts.id == "com.atproto.space.defs", ts.defName == "signedCommit",
+      required.isSuperset(of: ["ver", "hash", "ikm", "sig", "mac", "rev"]),
+      isInteger("ver"), isBytes("hash"), isBytes("ikm"), isBytes("sig"),
+      isBytes("mac"), isString("rev", format: "tid")
+    {
+      return .signedCommit
+    }
+    let nullable = Set(nullable ?? [])
+    if ts.id == "com.atproto.space.listRepoOps", ts.defName == "opEntry",
+      required.isSuperset(of: ["collection", "rkey", "cid", "prev"]),
+      nullable.isSuperset(of: ["cid", "prev"]),
+      isString("collection", format: "nsid"),
+      isString("rkey", format: "record-key"),
+      isString("cid", format: "cid"), isString("prev", format: "cid")
+    {
+      return .operation
+    }
+    return nil
+  }
+
+  private func isInteger(_ property: String) -> Bool {
+    guard case .integer = properties[property] else { return false }
+    return true
+  }
+
+  private func isBytes(_ property: String) -> Bool {
+    guard case .bytes = properties[property] else { return false }
+    return true
+  }
+
+  private func isString(_ property: String, format: String) -> Bool {
+    guard case .string(let definition) = properties[property] else { return false }
+    return definition.format?.rawValue == format
+  }
+
+  private static func formatStringType(_ wrappedName: String, optional: Bool = false)
+    -> TypeSyntax
+  {
+    let type = TypeSyntax(
+      IdentifierTypeSyntax(
+        name: .identifier("FormatString"),
+        genericArgumentClause: GenericArgumentClauseSyntax {
+          GenericArgumentSyntax.create(
+            argument: IdentifierTypeSyntax(name: .identifier(wrappedName)))
+        }))
+    return optional ? TypeSyntax(OptionalTypeSyntax(wrappedType: type)) : type
+  }
+
+  private static func forwardingAccessor(
+    name: String, type: TypeSyntax, source: String
+  ) -> VariableDeclSyntax {
+    VariableDeclSyntax(
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      bindingSpecifier: .keyword(.var),
+      bindings: [
+        PatternBindingSyntax(
+          pattern: IdentifierPatternSyntax(identifier: .identifier(name)),
+          typeAnnotation: TypeAnnotationSyntax(type: type),
+          accessorBlock: AccessorBlockSyntax(
+            accessors: .getter(
+              CodeBlockItemListSyntax {
+                DeclReferenceExprSyntax(baseName: .identifier(source))
+              })))
+      ])
   }
 
   private static func repoWriteRequirementsAccessor(actionRaws: [String]) -> VariableDeclSyntax {

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,11 @@
+# Third-party notices
+
+## BLAKE3
+
+`ATProtoSync` depends on the portable C implementation from BLAKE3 1.8.7,
+packaged for SwiftPM as version `1.8.7-swift.1`:
+
+- Source: https://github.com/BLAKE3-team/BLAKE3/tree/1.8.7/c
+- Swift package: https://github.com/nnabeyang/BLAKE3/tree/1.8.7-swift.1
+- License: Apache License 2.0
+- License text: https://github.com/nnabeyang/BLAKE3/blob/1.8.7-swift.1/LICENSE_A2

--- a/Tests/ATProtoSyncTests/LtHashTests.swift
+++ b/Tests/ATProtoSyncTests/LtHashTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import Testing
+
+@testable import ATProtoSync
+
+@Suite("Permissioned repository LtHash")
+struct LtHashTests {
+  @Test func matchesTheProposalSnapshot() {
+    var hash = LtHash()
+    hash.add("one")
+    hash.add("two")
+
+    #expect(
+      hash.digest.hex == "ae05cb6d224379d9710c290c8529945c5b0e0fde9ead30b9699057ce701c63e7")
+  }
+
+  @Test func emptyStateMatchesSHA256Vector() {
+    let hash = LtHash()
+    #expect(hash.state.count == 2048)
+    #expect(hash.isEmpty)
+    #expect(
+      hash.digest.hex == "e5a00aa9991ac8a5ee3109844d84a55583bd20572ad3ffcd42792f3c36b183ad")
+  }
+
+  @Test func additionIsOrderIndependentAndRemovalRestoresState() {
+    var forward = LtHash()
+    forward.add("a")
+    forward.add("b")
+
+    var reverse = LtHash()
+    reverse.add("b")
+    reverse.add("a")
+    #expect(forward == reverse)
+
+    forward.remove("a")
+    forward.remove("b")
+    #expect(forward.isEmpty)
+  }
+
+  @Test func persistedStateDoesNotAliasItsSource() throws {
+    var original = LtHash()
+    original.add("a")
+    let state = original.state
+    var restored = try LtHash(state: state)
+    restored.add("b")
+
+    #expect(restored != original)
+    #expect(try LtHash(state: state) == original)
+  }
+
+  @Test func rejectsWrongStateLength() {
+    #expect(throws: RepoVerificationError.invalidLtHashStateLength(actual: 32)) {
+      try LtHash(state: Data(repeating: 0, count: 32))
+    }
+  }
+}

--- a/Tests/ATProtoSyncTests/RepoCommitTests.swift
+++ b/Tests/ATProtoSyncTests/RepoCommitTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import SwiftAtproto
+import SwiftCbor
+import Testing
+
+@testable import ATProtoSync
+
+@Suite("Permissioned repository state")
+struct RepoCommitTests {
+  private let first = RepoRecord(
+    collection: try! NSID(string: "com.example.post"),
+    recordKey: try! RecordKey(string: "first"),
+    cid: try! LexLink("bafyreidefdycgbfy3oglcb6ism3eqhyp5llsrpzxjsuac2gsy4mtrtx244"))
+  private let second = RepoRecord(
+    collection: try! NSID(string: "com.example.post"),
+    recordKey: try! RecordKey(string: "second"),
+    cid: try! LexLink("bafyreidpw4cbv6gr4ukh33z23pvvrpr3wi4gnpmi4doamlsl3sa4rgri2a"))
+
+  @Test func recordsIndexAndOperationsConverge() throws {
+    let records = RepoCommit(records: [first, second])
+
+    let index = [
+      "com.example.post/first": first.cid,
+      "com.example.post/second": second.cid,
+    ]
+    let encodedIndex = try CborEncoder(
+      options: .lexicographicallySortedMapKeys,
+      allowedTags: [42]
+    ).encode(index)
+    let fromIndex = try RepoCommit(drislIndex: encodedIndex)
+
+    var fromOperations = RepoCommit()
+    try fromOperations.apply([
+      StubOperation(record: first, previousCID: nil),
+      StubOperation(record: second, previousCID: nil),
+    ])
+
+    #expect(records == fromIndex)
+    #expect(records == fromOperations)
+  }
+
+  @Test func recordElementMatchesTheNodeReferenceVector() {
+    let commit = RepoCommit(records: [first])
+    #expect(
+      commit.setHash.digest.hex == "fcc551a3fdab795be0e7640d11759201fc90a193295c11bb383245d6be16747f")
+  }
+
+  @Test func updateAndDeleteReplaceBothSidesOfAnOperation() throws {
+    var commit = RepoCommit(records: [first])
+    let replacement = try LexLink(
+      "bafyreidpw4cbv6gr4ukh33z23pvvrpr3wi4gnpmi4doamlsl3sa4rgri2a")
+    commit.apply(
+      try RepoOperation(
+        collection: first.collection,
+        recordKey: first.recordKey,
+        cid: replacement,
+        previousCID: first.cid))
+    #expect(
+      commit
+        == RepoCommit(
+          records: [
+            RepoRecord(
+              collection: first.collection, recordKey: first.recordKey, cid: replacement)
+          ]))
+
+    commit.apply(
+      try RepoOperation(
+        collection: first.collection,
+        recordKey: first.recordKey,
+        cid: nil,
+        previousCID: replacement))
+    #expect(commit.setHash.isEmpty)
+  }
+
+  @Test func rejectsMalformedGeneratedOperation() {
+    let malformed = StubOperation(
+      collection: "not an nsid", recordKey: "first", cid: nil, previousCID: nil)
+    var commit = RepoCommit()
+    #expect(throws: RepoVerificationError.malformedOperation) {
+      try commit.apply(malformed)
+    }
+  }
+
+  @Test func rejectsMalformedAndOversizedIndexes() throws {
+    let malformedPath = ["missing-separator": first.cid]
+    let encoded = try CborEncoder(
+      options: .lexicographicallySortedMapKeys,
+      allowedTags: [42]
+    ).encode(malformedPath)
+    #expect(throws: RepoVerificationError.malformedRecordPath("missing-separator")) {
+      try RepoCommit(drislIndex: encoded)
+    }
+    #expect(
+      throws: RepoVerificationError.inputTooLarge(limit: encoded.count - 1, actual: encoded.count)
+    ) {
+      try RepoCommit(
+        drislIndex: encoded,
+        limits: RepoVerificationLimits(maximumIndexBytes: encoded.count - 1))
+    }
+
+    let twoEntries = [
+      "com.example.post/first": first.cid,
+      "com.example.post/second": second.cid,
+    ]
+    let encodedTwoEntries = try CborEncoder(
+      options: .lexicographicallySortedMapKeys,
+      allowedTags: [42]
+    ).encode(twoEntries)
+    #expect(throws: RepoVerificationError.malformedRepositoryIndex) {
+      try RepoCommit(
+        drislIndex: encodedTwoEntries,
+        limits: RepoVerificationLimits(maximumIndexEntries: 1))
+    }
+  }
+}
+
+private struct StubOperation: PermissionedRepoOperationDescribing {
+  let permissionedRepoOperationCollection: FormatString<NSID>
+  let permissionedRepoOperationRecordKey: FormatString<RecordKey>
+  let permissionedRepoOperationCID: FormatString<LexLink>?
+  let permissionedRepoOperationPreviousCID: FormatString<LexLink>?
+
+  init(record: RepoRecord, previousCID: LexLink?) {
+    self.init(
+      collection: record.collection.rawValue,
+      recordKey: record.recordKey.rawValue,
+      cid: record.cid.toBaseEncodedString,
+      previousCID: previousCID?.toBaseEncodedString)
+  }
+
+  init(collection: String, recordKey: String, cid: String?, previousCID: String?) {
+    permissionedRepoOperationCollection = .init(rawValue: collection)
+    permissionedRepoOperationRecordKey = .init(rawValue: recordKey)
+    permissionedRepoOperationCID = cid.map(FormatString<LexLink>.init(rawValue:))
+    permissionedRepoOperationPreviousCID = previousCID.map(
+      FormatString<LexLink>.init(rawValue:))
+  }
+}

--- a/Tests/ATProtoSyncTests/SignedRepoCommitTests.swift
+++ b/Tests/ATProtoSyncTests/SignedRepoCommitTests.swift
@@ -1,0 +1,211 @@
+import ATProtoCrypto
+import Crypto
+import Foundation
+import SwiftAtproto
+import SwiftCbor
+import Testing
+
+@testable import ATProtoSync
+
+@Suite("Permissioned repository signed commits")
+struct SignedRepoCommitTests {
+  private let context = RepoCommitContext(
+    space: try! SpaceRef(
+      string:
+        "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/space/com.example.forum/test"),
+    author: try! SwiftAtproto.DID(string: "did:plc:ewvi7nxzyoun6zhxrhs64oiz"),
+    revision: try! TID(string: "3kbgyjzqfeq2e"))
+  private let key = try! PrivateKey(
+    type: .ed25519, rawValue: Data(repeating: 7, count: 32))
+
+  @Test func contextAndMACMatchTheNodeReferenceVector() throws {
+    let ikm = Data((0..<32).map(UInt8.init))
+    let hash = Data(
+      hex: "ae05cb6d224379d9710c290c8529945c5b0e0fde9ead30b9699057ce701c63e7")
+    let contextBytes = try context.encoded(inputKeyMaterial: ikm)
+    #expect(
+      contextBytes.hex == "617470726f746f2d73706163652d7631004261743a2f2f6469643a706c633a65777669376e787a796f756e367a687872687336346f697a2f73706163652f636f6d2e6578616d706c652e666f72756d2f7465737400206469643a706c633a65777669376e787a796f756e367a687872687336346f697a000d336b6267796a7a7166657132650020000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f")
+
+    let commit = try signedCommit(hash: hash, ikm: ikm)
+    #expect(commit.mac.hex == "a3229b8c8e136ad0886d7bc9cbf75ac73a7f90b9c487dab5bcb879fd5a203160")
+    try SignedRepoCommitVerifier.verify(
+      commit, context: context, publicKey: key.publicKey)
+  }
+
+  @Test func decodesCanonicalDRISLAndRejectsTrailingData() throws {
+    let commit = try signedCommit(hash: Data(repeating: 5, count: 32))
+    let encoded = try CborEncoder(options: .lexicographicallySortedMapKeys).encode(commit)
+    let decoded = try SignedRepoCommitVerifier.decode(
+      TestSignedCommit.self, fromDRISL: encoded)
+    #expect(decoded == commit)
+
+    var trailing = encoded
+    trailing.append(0)
+    #expect(throws: RepoVerificationError.malformedSignedCommit) {
+      try SignedRepoCommitVerifier.decode(TestSignedCommit.self, fromDRISL: trailing)
+    }
+    #expect(
+      throws: RepoVerificationError.inputTooLarge(
+        limit: encoded.count - 1, actual: encoded.count)
+    ) {
+      try SignedRepoCommitVerifier.decode(
+        TestSignedCommit.self,
+        fromDRISL: encoded,
+        limits: RepoVerificationLimits(maximumCommitBytes: encoded.count - 1))
+    }
+
+    #expect(throws: RepoVerificationError.malformedSignedCommit) {
+      try SignedRepoCommitVerifier.decode(
+        TestSignedCommit.self, fromDRISL: Data([0xbf, 0xff]))
+    }
+    #expect(throws: RepoVerificationError.malformedSignedCommit) {
+      try SignedRepoCommitVerifier.decode(
+        TestSignedCommit.self,
+        fromDRISL: Data([0xa1, 0x63, 0x76, 0x65, 0x72, 0x18, 0x01]))
+    }
+  }
+
+  @Test func rejectsAnOversizedContextField() {
+    #expect(throws: RepoVerificationError.contextFieldTooLong) {
+      try context.encoded(inputKeyMaterial: Data(repeating: 0, count: 65_536))
+    }
+  }
+
+  @Test func repositoryVerificationAcceptsTheMatchingState() throws {
+    var repository = LtHash()
+    repository.add("one")
+    repository.add("two")
+    let commit = try signedCommit(hash: repository.digest)
+
+    try RepoCommit(state: repository.state).verify(
+      commit, context: context, publicKey: key.publicKey)
+  }
+
+  @Test func rejectsUnsupportedVersionAndMalformedFields() throws {
+    let valid = try signedCommit(hash: Data(repeating: 5, count: 32))
+    var unsupported = valid
+    unsupported.ver = 2
+    #expect(throws: RepoVerificationError.unsupportedCommitVersion(2)) {
+      try SignedRepoCommitVerifier.verify(
+        unsupported, context: context, publicKey: key.publicKey)
+    }
+
+    var shortHash = valid
+    shortHash.hash = Data(repeating: 0, count: 31)
+    #expect(
+      throws: RepoVerificationError.invalidCommitFieldLength(
+        field: "hash", expected: 32, actual: 31)
+    ) {
+      try SignedRepoCommitVerifier.verify(
+        shortHash, context: context, publicKey: key.publicKey)
+    }
+
+    var oversizedSignature = valid
+    oversizedSignature.sig = Data(repeating: 0, count: 257)
+    #expect(throws: RepoVerificationError.invalidCommitField(field: "sig")) {
+      try SignedRepoCommitVerifier.verify(
+        oversizedSignature, context: context, publicKey: key.publicKey)
+    }
+  }
+
+  @Test func rejectsRevisionContextHashMACSignatureAndStateChanges() throws {
+    let valid = try signedCommit(hash: Data(repeating: 5, count: 32))
+
+    var revision = valid
+    revision.rev = .init(rawValue: "3kbgyjzqfeq2f")
+    #expect(throws: RepoVerificationError.revisionMismatch) {
+      try SignedRepoCommitVerifier.verify(
+        revision, context: context, publicKey: key.publicKey)
+    }
+
+    let otherContext = RepoCommitContext(
+      space: try SpaceRef(
+        string:
+          "at://did:plc:ewvi7nxzyoun6zhxrhs64oiz/space/com.example.forum/other"),
+      author: context.author,
+      revision: context.revision)
+    #expect(throws: RepoVerificationError.macMismatch) {
+      try SignedRepoCommitVerifier.verify(
+        valid, context: otherContext, publicKey: key.publicKey)
+    }
+
+    let otherAuthor = RepoCommitContext(
+      space: context.space,
+      author: try SwiftAtproto.DID(string: "did:plc:ragtjsm2j2vknwkz3zp4oxrd"),
+      revision: context.revision)
+    #expect(throws: RepoVerificationError.macMismatch) {
+      try SignedRepoCommitVerifier.verify(
+        valid, context: otherAuthor, publicKey: key.publicKey)
+    }
+
+    var ikm = valid
+    ikm.ikm[0] ^= 0xff
+    #expect(throws: RepoVerificationError.macMismatch) {
+      try SignedRepoCommitVerifier.verify(ikm, context: context, publicKey: key.publicKey)
+    }
+
+    var hash = valid
+    hash.hash[0] ^= 0xff
+    #expect(throws: RepoVerificationError.macMismatch) {
+      try SignedRepoCommitVerifier.verify(hash, context: context, publicKey: key.publicKey)
+    }
+
+    var mac = valid
+    mac.mac[0] ^= 0xff
+    #expect(throws: RepoVerificationError.macMismatch) {
+      try SignedRepoCommitVerifier.verify(mac, context: context, publicKey: key.publicKey)
+    }
+
+    var signature = valid
+    signature.sig[0] ^= 0xff
+    #expect(throws: RepoVerificationError.signatureMismatch) {
+      try SignedRepoCommitVerifier.verify(
+        signature, context: context, publicKey: key.publicKey)
+    }
+
+    var malformedRevision = valid
+    malformedRevision.rev = .init(rawValue: "not-a-tid")
+    #expect(throws: RepoVerificationError.invalidCommitField(field: "rev")) {
+      try SignedRepoCommitVerifier.verify(
+        malformedRevision, context: context, publicKey: key.publicKey)
+    }
+
+    #expect(throws: RepoVerificationError.setHashMismatch) {
+      try RepoCommit().verify(valid, context: context, publicKey: key.publicKey)
+    }
+  }
+
+  private func signedCommit(
+    hash: Data,
+    ikm: Data = Data((0..<32).map(UInt8.init))
+  ) throws -> TestSignedCommit {
+    let contextBytes = try context.encoded(inputKeyMaterial: ikm)
+    let macKey = HKDF<SHA256>.expand(
+      pseudoRandomKey: SymmetricKey(data: ikm),
+      info: contextBytes,
+      outputByteCount: 32)
+    return TestSignedCommit(
+      ver: 1,
+      hash: hash,
+      ikm: ikm,
+      sig: try key.sign(contextBytes),
+      mac: Data(HMAC<SHA256>.authenticationCode(for: hash, using: macKey)),
+      rev: .init(rawValue: context.revision.rawValue))
+  }
+}
+
+private struct TestSignedCommit: Codable, Hashable, PermissionedRepoSignedCommitDescribing {
+  var ver: Int
+  var hash: Data
+  var ikm: Data
+  var sig: Data
+  var mac: Data
+  var rev: FormatString<TID>
+
+  var permissionedRepoCommitVersion: Int { ver }
+  var permissionedRepoCommitHash: Data { hash }
+  var permissionedRepoCommitInputKeyMaterial: Data { ikm }
+  var permissionedRepoCommitSignature: Data { sig }
+  var permissionedRepoCommitMAC: Data { mac }
+  var permissionedRepoCommitRevision: FormatString<TID> { rev }
+}

--- a/Tests/ATProtoSyncTests/TestSupport.swift
+++ b/Tests/ATProtoSyncTests/TestSupport.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+extension Data {
+  init(hex: String) {
+    precondition(hex.count.isMultiple(of: 2))
+    self.init(
+      stride(from: 0, to: hex.count, by: 2).map { offset in
+        let start = hex.index(hex.startIndex, offsetBy: offset)
+        let end = hex.index(start, offsetBy: 2)
+        return UInt8(hex[start..<end], radix: 16)!
+      })
+  }
+
+  var hex: String {
+    map { String(format: "%02x", $0) }.joined()
+  }
+}

--- a/Tests/SwiftAtprotoLexTests/PermissionedRepoSyncGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/PermissionedRepoSyncGenerationTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Permissioned repository sync generation")
+struct PermissionedRepoSyncGenerationTests {
+  @Test("signed commits and operations expose sync descriptors")
+  func generatesSyncDescriptors() async throws {
+    let source = try await generate([
+      "defs.json": Self.signedCommit,
+      "listRepoOps.json": Self.listRepoOps,
+    ])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(
+      source.contains(
+        "public struct SpaceDefs_SignedCommit: Codable, Hashable, Sendable, PermissionedRepoSignedCommitDescribing"
+      ))
+    #expect(source.contains("public var permissionedRepoCommitInputKeyMaterial: Foundation.Data"))
+    #expect(
+      source.contains(
+        "public struct SpaceListRepoOps_OpEntry: Codable, Hashable, Sendable, PermissionedRepoOperationDescribing"
+      ))
+    #expect(source.contains("public var permissionedRepoOperationPreviousCID: FormatString<LexLink>?"))
+  }
+
+  @Test("a similarly named but incompatible definition gets no conformance")
+  func rejectsAnIncompatibleShape() async throws {
+    let source = try await generate(["defs.json": Self.incompatibleSignedCommit])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(!source.contains("PermissionedRepoSignedCommitDescribing"))
+    #expect(!source.contains("permissionedRepoCommitVersion"))
+  }
+
+  private func generate(_ files: [String: String]) async throws -> String {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-permissioned-sync-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let input = root.appending(path: "input")
+    let output = root.appending(path: "output")
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+    for (name, source) in files {
+      try Data(source.utf8).write(to: input.appending(path: name))
+    }
+
+    try await SwiftAtprotoLex.main(
+      outdir: output, path: input.path, generate: .client, pluginSource: .command)
+    return try String(
+      contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+  }
+
+  private static let signedCommit = """
+    {
+      "lexicon": 1,
+      "id": "com.atproto.space.defs",
+      "defs": {
+        "signedCommit": {
+          "type": "object",
+          "required": ["ver", "hash", "mac", "ikm", "sig", "rev"],
+          "properties": {
+            "ver": { "type": "integer" },
+            "hash": { "type": "bytes" },
+            "ikm": { "type": "bytes" },
+            "sig": { "type": "bytes" },
+            "mac": { "type": "bytes" },
+            "rev": { "type": "string", "format": "tid" }
+          }
+        }
+      }
+    }
+    """
+
+  private static let incompatibleSignedCommit = """
+    {
+      "lexicon": 1,
+      "id": "com.atproto.space.defs",
+      "defs": {
+        "signedCommit": {
+          "type": "object",
+          "required": ["ver", "hash", "mac", "ikm", "sig", "rev"],
+          "properties": {
+            "ver": { "type": "integer" },
+            "hash": { "type": "bytes" },
+            "ikm": { "type": "bytes" },
+            "sig": { "type": "bytes" },
+            "mac": { "type": "bytes" },
+            "rev": { "type": "string" }
+          }
+        }
+      }
+    }
+    """
+
+  private static let listRepoOps = """
+    {
+      "lexicon": 1,
+      "id": "com.atproto.space.listRepoOps",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": { "type": "params", "properties": {} },
+          "output": {
+            "encoding": "application/json",
+            "schema": { "type": "object", "properties": {} }
+          }
+        },
+        "opEntry": {
+          "type": "object",
+          "required": ["rev", "collection", "rkey", "cid", "prev"],
+          "nullable": ["cid", "prev"],
+          "properties": {
+            "rev": { "type": "string", "format": "tid" },
+            "collection": { "type": "string", "format": "nsid" },
+            "rkey": { "type": "string", "format": "record-key" },
+            "cid": { "type": "string", "format": "cid" },
+            "prev": { "type": "string", "format": "cid" }
+          }
+        }
+      }
+    }
+    """
+}


### PR DESCRIPTION
Add an ATProtoSync library for signed permissioned repository commit verification and LtHash state tracking, using BLAKE3 1.8.7 through an exact SwiftPM dependency. Generated permissioned-data commit and operation types conform to sync descriptors so CAR indexes and incremental operations share the same verification path.