### PR TITLE
feat: stream binary XRPC responses

### DIFF
--- a/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
+++ b/Sources/SwiftAtproto/Documentation.docc/Articles/MakingXRPCCalls.md
@@ -54,6 +54,31 @@ transport that wants the runtime to inspect a failure overrides
 `responseWithMetadata(_:)` and returns ``XRPCResponseComponents`` for success
 and failure responses alike. Network and transport failures still throw.
 
+## Stream binary responses
+
+CAR, CBOR, MP4, and other uninterpreted binary Lexicon outputs can be consumed
+without first buffering the complete response. A transport opts in by conforming
+to ``XRPCStreamingCallable`` and implementing
+``XRPCStreamingCallable/responseStreamWithMetadata(_:)``. Generated binary
+methods then include a `Streaming` variant that returns
+``XRPCStreamingResponseComponents``:
+
+```swift
+let response = try await client.GetRepoStreaming(did: memberDID)
+for try await chunk in response.body {
+  try await importer.write(chunk)
+}
+```
+
+``XRPCBody`` is a single-pass, pull-driven sequence of byte chunks, so the
+transport only produces the next chunk when its consumer advances. Call
+``XRPCBody/cancel()`` when abandoning a response early. Existing generated
+methods remain source-compatible and collect the same stream into `Data`.
+
+Successful responses remain unbuffered. Error responses are bounded while the
+runtime decodes their XRPC error payload and handles a possible DPoP nonce
+retry.
+
 ## Authorize the complete request
 
 ``XRPCRequestAuthorizer`` receives the complete request after any

--- a/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
+++ b/Sources/SwiftAtproto/Documentation.docc/SwiftAtproto.md
@@ -42,6 +42,10 @@ let posts = try await client.call(
 - ``XRPCProcedure``
 - ``XRPCRequestComponents``
 - ``XRPCResponseComponents``
+- ``XRPCStreamingResponseComponents``
+- ``XRPCBody``
+- ``XRPCStreamingCallable``
+- ``XRPCBinaryResponseRequest``
 - ``XRPCRequestDestination``
 - ``XRPCRequestAuthorizer``
 - ``XRPCCredential``

--- a/Sources/SwiftAtproto/XRPCBody.swift
+++ b/Sources/SwiftAtproto/XRPCBody.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+/// A single-pass, pull-driven XRPC response body.
+///
+/// The underlying transport is asked for another byte chunk only when the
+/// consumer advances the async iterator. Call ``cancel()`` when abandoning a
+/// body before reaching its end.
+public final class XRPCBody: AsyncSequence, @unchecked Sendable {
+  /// A byte chunk produced by the transport.
+  public typealias Element = ArraySlice<UInt8>
+
+  /// The total body length reported by the transport.
+  public enum Length: Hashable, Sendable {
+    case unknown
+    case known(Int64)
+  }
+
+  /// The total body length, if known before iteration begins.
+  public let length: Length
+
+  private let makeIteratorClosure: @Sendable () -> Iterator
+  private let state: State
+
+  /// Wraps a transport-provided async sequence of byte chunks.
+  ///
+  /// - Parameters:
+  ///   - chunks: A pull-driven sequence supplied by the transport.
+  ///   - length: The response length, if known.
+  ///   - onCancel: Called at most once when iteration is cancelled or the
+  ///     consumer explicitly cancels the body.
+  public init<Chunks: AsyncSequence & Sendable>(
+    _ chunks: Chunks,
+    length: Length = .unknown,
+    onCancel: @escaping @Sendable () -> Void = {}
+  ) where Chunks.Element == Element {
+    let state = State(onCancel: onCancel)
+    self.length = length
+    self.state = state
+    self.makeIteratorClosure = {
+      var iterator = chunks.makeAsyncIterator()
+      return Iterator(
+        next: { try await iterator.next() },
+        state: state)
+    }
+  }
+
+  /// Creates a body containing one in-memory byte chunk.
+  public convenience init(_ data: Data) {
+    let chunks = AsyncStream(Element.self) { continuation in
+      continuation.yield(ArraySlice(data))
+      continuation.finish()
+    }
+    self.init(
+      chunks,
+      length: .known(Int64(data.count)))
+  }
+
+  /// Creates the body's single iterator.
+  ///
+  /// A second call returns an iterator that throws
+  /// ``XRPCBodyError/alreadyConsumed`` when advanced.
+  public func makeAsyncIterator() -> Iterator {
+    guard state.beginIteration() else {
+      return Iterator(throwing: XRPCBodyError.alreadyConsumed)
+    }
+    return makeIteratorClosure()
+  }
+
+  /// Cancels the transport operation backing this body.
+  public func cancel() {
+    state.cancel()
+  }
+
+  /// Collects the body into memory, rejecting bodies larger than `limit`.
+  public func collect(upTo limit: Int) async throws -> Data {
+    precondition(limit >= 0, "The collection limit must not be negative")
+    var result = Data()
+    if case .known(let length) = length, length > Int64(limit) {
+      cancel()
+      throw XRPCBodyError.tooManyBytes(limit: limit)
+    }
+    do {
+      for try await chunk in self {
+        guard chunk.count <= limit - result.count else {
+          cancel()
+          throw XRPCBodyError.tooManyBytes(limit: limit)
+        }
+        result.append(contentsOf: chunk)
+      }
+      return result
+    } catch {
+      cancel()
+      throw error
+    }
+  }
+
+  /// The single-pass iterator used to pull chunks from the transport.
+  public struct Iterator: AsyncIteratorProtocol {
+    private let produceNext: () async throws -> Element?
+    private let state: State
+
+    fileprivate init(
+      next: @escaping () async throws -> Element?,
+      state: State
+    ) {
+      produceNext = next
+      self.state = state
+    }
+
+    fileprivate init(throwing error: any Error) {
+      let state = State(onCancel: {})
+      state.complete()
+      self.state = state
+      produceNext = { throw error }
+    }
+
+    /// Returns the next response byte chunk, or `nil` after the body ends.
+    ///
+    /// Cancelling the calling task cancels the transport operation.
+    public mutating func next() async throws -> Element? {
+      let state = self.state
+      return try await withTaskCancellationHandler {
+        let element = try await produceNext()
+        if element == nil {
+          state.complete()
+        }
+        return element
+      } onCancel: {
+        state.cancel()
+      }
+    }
+  }
+
+  fileprivate final class State: @unchecked Sendable {
+    private let lock = NSLock()
+    private let onCancel: @Sendable () -> Void
+    private var iterationStarted = false
+    private var isComplete = false
+    private var isCancelled = false
+
+    init(onCancel: @escaping @Sendable () -> Void) {
+      self.onCancel = onCancel
+    }
+
+    func beginIteration() -> Bool {
+      lock.withLock {
+        guard !iterationStarted else { return false }
+        iterationStarted = true
+        return true
+      }
+    }
+
+    func complete() {
+      lock.withLock { isComplete = true }
+    }
+
+    func cancel() {
+      let shouldCancel = lock.withLock {
+        guard !isComplete, !isCancelled else { return false }
+        isCancelled = true
+        return true
+      }
+      if shouldCancel {
+        onCancel()
+      }
+    }
+  }
+}
+
+/// Failures raised while consuming an ``XRPCBody``.
+public enum XRPCBodyError: Error, Hashable, Sendable {
+  /// The single-pass body has already produced an iterator.
+  case alreadyConsumed
+  /// Collecting the body would exceed the caller's memory limit.
+  case tooManyBytes(limit: Int)
+}

--- a/Sources/SwiftAtproto/XRPCStreamingResponseComponents.swift
+++ b/Sources/SwiftAtproto/XRPCStreamingResponseComponents.swift
@@ -1,0 +1,58 @@
+import Foundation
+import HTTPTypes
+
+/// An XRPC response whose body can be consumed incrementally.
+public struct XRPCStreamingResponseComponents: Sendable {
+  /// The HTTP status code returned by the service.
+  public var statusCode: Int
+  /// The HTTP response headers.
+  public var headers: HTTPFields
+  /// The pull-driven response body.
+  public var body: XRPCBody
+
+  /// Creates an incremental response with its HTTP metadata.
+  public init(
+    statusCode: Int,
+    headers: HTTPFields = .init(),
+    body: XRPCBody
+  ) {
+    self.statusCode = statusCode
+    self.headers = headers
+    self.body = body
+  }
+}
+
+/// A method whose Lexicon output is an uninterpreted binary payload.
+public protocol XRPCBinaryResponseRequest: XRPCRequest where ResponseBody == Data {}
+
+/// An XRPC client transport capable of returning an incremental response body.
+///
+/// Implement ``responseStreamWithMetadata(_:)``. The compatibility methods
+/// required by `_XRPCCallable` collect the stream for existing `Data` APIs.
+public protocol XRPCStreamingCallable: _XRPCCallable {
+  /// Sends a prepared request and returns its response without buffering its
+  /// body.
+  func responseStreamWithMetadata(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCStreamingResponseComponents
+}
+
+extension XRPCStreamingCallable {
+  /// Sends a prepared request and collects its successful body into memory.
+  public func response(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> Data {
+    try await responseWithMetadata(requestComponents).body
+  }
+
+  /// Sends a prepared request and collects its body while retaining metadata.
+  public func responseWithMetadata(
+    _ requestComponents: XRPCRequestComponents
+  ) async throws -> XRPCResponseComponents {
+    let response = try await responseStreamWithMetadata(requestComponents)
+    return try await XRPCResponseComponents(
+      statusCode: response.statusCode,
+      headers: response.headers,
+      body: response.body.collect(upTo: .max))
+  }
+}

--- a/Sources/SwiftAtproto/_XRPCCallable.swift
+++ b/Sources/SwiftAtproto/_XRPCCallable.swift
@@ -91,6 +91,132 @@ extension _XRPCCallable {
   }
 }
 
+extension _XRPCCallable where Self: XRPCStreamingCallable {
+  /// Calls a binary query without buffering its successful response body.
+  public func callStreaming<X: XRPCQuery>(
+    _ query: X.Type,
+    input: X.Input.Query
+  ) async throws -> XRPCStreamingResponseComponents where X: XRPCBinaryResponseRequest {
+    try await callStreaming(query, input: input, destination: nil)
+  }
+
+  /// Calls a binary query at an explicitly resolved destination without
+  /// buffering its successful response body.
+  public func callStreaming<X: XRPCQuery>(
+    _ query: X.Type,
+    input: X.Input.Query,
+    destination: XRPCRequestDestination
+  ) async throws -> XRPCStreamingResponseComponents where X: XRPCBinaryResponseRequest {
+    try await callStreaming(query, input: input, destination: Optional(destination))
+  }
+
+  private func callStreaming<X: XRPCQuery>(
+    _ query: X.Type,
+    input: X.Input.Query,
+    destination: XRPCRequestDestination?
+  ) async throws -> XRPCStreamingResponseComponents where X: XRPCBinaryResponseRequest {
+    let proxy = getProxy(nsid: X.id)
+    try enforceRpcScopeGuard(X.self, proxy: proxy)
+    var request = try constructRequest(query, input: input, destination: destination)
+    if let proxy {
+      request.headers[.atprotoProxy] = proxy
+    }
+    return try await sendStreaming(query, for: request)
+  }
+
+  /// Calls a binary procedure without buffering its successful response body.
+  public func callStreaming<X: XRPCProcedure>(
+    _ procedure: X.Type,
+    input: X.RequestBody?
+  ) async throws -> XRPCStreamingResponseComponents where X: XRPCBinaryResponseRequest {
+    try await callStreaming(procedure, input: input, destination: nil)
+  }
+
+  /// Calls a binary procedure at an explicitly resolved destination without
+  /// buffering its successful response body.
+  public func callStreaming<X: XRPCProcedure>(
+    _ procedure: X.Type,
+    input: X.RequestBody?,
+    destination: XRPCRequestDestination
+  ) async throws -> XRPCStreamingResponseComponents where X: XRPCBinaryResponseRequest {
+    try await callStreaming(procedure, input: input, destination: Optional(destination))
+  }
+
+  private func callStreaming<X: XRPCProcedure>(
+    _ procedure: X.Type,
+    input: X.RequestBody?,
+    destination: XRPCRequestDestination?
+  ) async throws -> XRPCStreamingResponseComponents where X: XRPCBinaryResponseRequest {
+    let proxy = getProxy(nsid: X.id)
+    try enforceRpcScopeGuard(X.self, proxy: proxy)
+    try enforceRepoScopeGuard(input as? any RepoWriteOperationDescribing)
+    try enforceBlobScopeGuard(input as? XRPCBlobUpload)
+    var request = try constructRequest(procedure, input: input, destination: destination)
+    if let proxy {
+      request.headers[.atprotoProxy] = proxy
+    }
+    return try await sendStreaming(procedure, for: request)
+  }
+
+  private func sendStreaming<X: XRPCRequest>(
+    _: X.Type,
+    for request: XRPCRequestComponents
+  ) async throws -> XRPCStreamingResponseComponents where X: XRPCBinaryResponseRequest {
+    do {
+      let firstResponse = try await performStreaming(request)
+      if (200...299).contains(firstResponse.statusCode) {
+        return firstResponse
+      }
+
+      let firstBuffered = try await bufferErrorResponse(firstResponse)
+      if let nonce = dpopNonceChallenge(in: firstBuffered),
+        try await storeDPoPNonce(nonce, for: request)
+      {
+        return try await validateStreamingResponse(
+          try await performStreaming(request))
+      }
+      try throwResponseError(firstBuffered)
+    } catch let error as UnExpectedError {
+      throw X.Error(error: error)
+    }
+  }
+
+  private func performStreaming(
+    _ request: XRPCRequestComponents
+  ) async throws -> XRPCStreamingResponseComponents {
+    let authorizedRequest = try await authorize(request)
+    return try await responseStreamWithMetadata(authorizedRequest)
+  }
+
+  private func validateStreamingResponse(
+    _ response: XRPCStreamingResponseComponents
+  ) async throws -> XRPCStreamingResponseComponents {
+    guard !(200...299).contains(response.statusCode) else { return response }
+    try throwResponseError(try await bufferErrorResponse(response))
+  }
+
+  private func bufferErrorResponse(
+    _ response: XRPCStreamingResponseComponents
+  ) async throws -> XRPCResponseComponents {
+    let maximumErrorBodyBytes = 1_048_576
+    return try await XRPCResponseComponents(
+      statusCode: response.statusCode,
+      headers: response.headers,
+      body: response.body.collect(upTo: maximumErrorBodyBytes))
+  }
+
+  private func throwResponseError(
+    _ response: XRPCResponseComponents
+  ) throws -> Never {
+    if let error = try? JSONDecoder().decode(UnExpectedError.self, from: response.body) {
+      throw error
+    }
+    throw UnExpectedError(
+      error: nil,
+      message: "HTTP request failed with status code \(response.statusCode).")
+  }
+}
+
 extension _XRPCCallable {
   public func call<X: XRPCQuery>(_ query: X.Type, input: X.Input.Query) async throws -> X.ResponseBody {
     try await call(query, input: input, destination: nil)

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -220,6 +220,9 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       name: .lexIdentifier(ts.typeName),
       inheritanceClause: InheritanceClauseSyntax {
         InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCProcedure")))
+        if output?.isBinary == true {
+          InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCBinaryResponseRequest")))
+        }
       }
     ) {
       staticLetDecl(leadingTrivia: .newline, ident: "id", value: StringLiteralExprSyntax(content: type))

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -211,6 +211,9 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
       name: .lexIdentifier(ts.typeName),
       inheritanceClause: InheritanceClauseSyntax {
         InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCQuery")))
+        if output?.isBinary == true {
+          InheritedTypeSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCBinaryResponseRequest")))
+        }
       }
     ) {
       VariableDeclSyntax(

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex.swift
@@ -431,6 +431,14 @@ enum Lex {
           prefix: structNameFor(prefix: prefix),
           protocolRequirement: protocolRequirement
         )
+        if !protocolRequirement, method.value.hasBinaryOutput {
+          writeStreamingMethod(
+            typeName: Self.nameFromId(id: method.value.id, prefix: method.value.prefix),
+            typeSchema: method.value,
+            defMap: defMap,
+            prefix: structNameFor(prefix: prefix)
+          )
+        }
       }
     }
   }
@@ -441,6 +449,17 @@ enum Lex {
       ts.writeProcedure(leadingTrivia: nil, def: def, typeName: typeName, defMap: defMap, prefix: prefix, protocolRequirement: protocolRequirement)
     case .query(let def):
       ts.writeQuery(leadingTrivia: nil, def: def, typeName: typeName, defMap: defMap, prefix: prefix, protocolRequirement: protocolRequirement)
+    default:
+      fatalError()
+    }
+  }
+
+  static func writeStreamingMethod(typeName: String, typeSchema ts: TypeSchema, defMap: ExtDefMap, prefix: String) -> DeclSyntaxProtocol {
+    switch ts.type {
+    case .procedure(let def):
+      ts.writeStreamingProcedure(def: def, typeName: typeName, defMap: defMap, prefix: prefix)
+    case .query(let def):
+      ts.writeStreamingQuery(def: def, typeName: typeName, defMap: defMap, prefix: prefix)
     default:
       fatalError()
     }

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -407,6 +407,16 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
         })
   }
 
+  func writeStreamingProcedure(def: ProcedureTypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String) -> DeclSyntaxProtocol {
+    streamingFunction(
+      def: def,
+      typeName: typeName,
+      defMap: defMap,
+      prefix: prefix,
+      input: def.input == nil ? ExprSyntax(NilLiteralExprSyntax()) : ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("input")))
+    )
+  }
+
   func writeQuery(leadingTrivia: Trivia? = nil, def: QueryTypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String, protocolRequirement: Bool) -> DeclSyntaxProtocol {
     let prefixIdentifiers = Lex.enumIdentifiersFor(prefix: prefix)
     let docTrivia: Trivia? = def.description.map { Trivia(pieces: [.docLineComment("/// \($0)"), .newlines(1)]) }
@@ -484,6 +494,83 @@ final class TypeSchema: Encodable, DecodableWithConfiguration, Sendable {
           )
         }
     )
+  }
+
+  func writeStreamingQuery(def: QueryTypeDefinition, typeName: String, defMap: ExtDefMap, prefix: String) -> DeclSyntaxProtocol {
+    let prefixIdentifiers = Lex.enumIdentifiersFor(prefix: prefix)
+    let callee: ExprSyntax =
+      def.paramsHaveConstraints
+      ? ExprSyntax(MemberAccessExprSyntax(parts: prefixIdentifiers + [.identifier(typeName), .identifier("Input"), .identifier("Query"), .identifier("make")]))
+      : ExprSyntax(MemberAccessExprSyntax(period: .periodToken(), declName: DeclReferenceExprSyntax(baseName: .keyword(.`init`))))
+    let call = FunctionCallExprSyntax(callee: callee) {
+      if let properties = def.parameters?.sortedProperties {
+        for (name, _) in properties {
+          LabeledExprSyntax(label: .lexIdentifier(name), colon: .colonToken(), expression: DeclReferenceExprSyntax(baseName: .lexIdentifier(name)))
+        }
+      }
+    }
+    return streamingFunction(
+      def: def,
+      typeName: typeName,
+      defMap: defMap,
+      prefix: prefix,
+      input: def.paramsHaveConstraints ? ExprSyntax(TryExprSyntax(expression: call)) : ExprSyntax(call)
+    )
+  }
+
+  private func streamingFunction(
+    def: any HTTPAPITypeDefinition,
+    typeName: String,
+    defMap: ExtDefMap,
+    prefix: String,
+    input: ExprSyntax
+  ) -> FunctionDeclSyntax {
+    let prefixIdentifiers = Lex.enumIdentifiersFor(prefix: prefix)
+    return FunctionDeclSyntax(
+      leadingTrivia: .newlines(2),
+      modifiers: [DeclModifierSyntax(name: .keyword(.public))],
+      name: .identifier("\(typeName)Streaming"),
+      signature: FunctionSignatureSyntax(
+        parameterClause: FunctionParameterClauseSyntax {
+          def.rpcArguments(ts: self, fname: typeName, defMap: defMap, prefix: prefix, protocolRequirement: false)
+        },
+        effectSpecifiers: FunctionEffectSpecifiersSyntax(
+          asyncSpecifier: .keyword(.async),
+          throwsClause: ThrowsClauseSyntax(throwsSpecifier: .keyword(.throws))
+        ),
+        returnClause: ReturnClauseSyntax(type: IdentifierTypeSyntax(name: .identifier("XRPCStreamingResponseComponents")))
+      ),
+      genericWhereClause: GenericWhereClauseSyntax(
+        requirements: GenericRequirementListSyntax([
+          GenericRequirementSyntax(
+            requirement: .conformanceRequirement(
+              ConformanceRequirementSyntax(
+                leftType: IdentifierTypeSyntax(name: .keyword(.Self)),
+                colon: .colonToken(),
+                rightType: IdentifierTypeSyntax(name: .identifier("XRPCStreamingCallable"))
+              )))
+        ])
+      )
+    ) {
+      TryExprSyntax(
+        leadingTrivia: .newline,
+        expression: AwaitExprSyntax(
+          awaitKeyword: .keyword(.await),
+          expression: FunctionCallExprSyntax(callee: DeclReferenceExprSyntax(baseName: .identifier("callStreaming"))) {
+            LabeledExprSyntax(expression: MemberAccessExprSyntax(parts: prefixIdentifiers + [.identifier(typeName), .keyword(.self)]))
+            LabeledExprSyntax(label: .identifier("input"), colon: .colonToken(), expression: input)
+          }
+        )
+      )
+    }
+  }
+
+  var hasBinaryOutput: Bool {
+    switch type {
+    case .procedure(let def): def.output?.isBinary == true
+    case .query(let def): def.output?.isBinary == true
+    default: false
+    }
   }
 
   func typeIdentifier(name: String, property: FieldTypeDefinition, defMap: ExtDefMap, key: String, isRequired: Bool, dropPrefix: Bool = true) -> TypeSyntax {

--- a/Tests/SwiftAtprotoLexTests/BinaryResponseStreamingGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/BinaryResponseStreamingGenerationTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import SwiftParser
+import Testing
+
+@testable import SwiftAtprotoLex
+
+@Suite("Binary response streaming generation")
+struct BinaryResponseStreamingGenerationTests {
+  @Test("generates streaming overloads only for binary outputs")
+  func generatesBinaryStreamingMethods() async throws {
+    let source = try await generate([
+      "getArchive.json": Self.getArchive,
+      "exportVideo.json": Self.exportVideo,
+      "getMetadata.json": Self.getMetadata,
+    ])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains("XRPCQuery, XRPCBinaryResponseRequest"))
+    #expect(source.contains("XRPCProcedure, XRPCBinaryResponseRequest"))
+    #expect(source.contains("func GetArchiveStreaming("))
+    #expect(source.contains("func ExportVideoStreaming("))
+    #expect(source.contains("where Self: XRPCStreamingCallable"))
+    #expect(!source.contains("func GetMetadataStreaming("))
+  }
+
+  private func generate(_ fixtures: [String: String]) async throws -> String {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-streaming-generation-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let input = root.appending(path: "input")
+    let output = root.appending(path: "output")
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+    for (name, fixture) in fixtures {
+      try Data(fixture.utf8).write(to: input.appending(path: name))
+    }
+    try await SwiftAtprotoLex.main(
+      outdir: output, path: input.path, generate: .client, pluginSource: .command)
+    return try String(contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+  }
+
+  private static let getArchive = """
+    {
+      "lexicon": 1,
+      "id": "app.example.getArchive",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": { "type": "params", "properties": {} },
+          "output": { "encoding": "application/vnd.ipld.car" }
+        }
+      }
+    }
+    """
+
+  private static let exportVideo = """
+    {
+      "lexicon": 1,
+      "id": "app.example.exportVideo",
+      "defs": {
+        "main": {
+          "type": "procedure",
+          "output": { "encoding": "video/mp4" }
+        }
+      }
+    }
+    """
+
+  private static let getMetadata = """
+    {
+      "lexicon": 1,
+      "id": "app.example.getMetadata",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": { "type": "params", "properties": {} },
+          "output": {
+            "encoding": "application/json",
+            "schema": { "type": "object", "properties": {} }
+          }
+        }
+      }
+    }
+    """
+}

--- a/Tests/SwiftAtprotoTests/XRPCBodyTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCBodyTests.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Testing
+
+@testable import SwiftAtproto
+
+@Suite("XRPC streaming body")
+struct XRPCBodyTests {
+  @Test("collects transport chunks without changing their order")
+  func collectsChunks() async throws {
+    let chunks = AsyncStream<ArraySlice<UInt8>> { continuation in
+      continuation.yield([1, 2])
+      continuation.yield([3, 4])
+      continuation.finish()
+    }
+    let body = XRPCBody(chunks, length: .known(4))
+
+    #expect(try await body.collect(upTo: 4) == Data([1, 2, 3, 4]))
+  }
+
+  @Test("rejects a known body larger than the collection limit")
+  func enforcesKnownLengthLimit() async {
+    let body = XRPCBody(Data([1, 2, 3]))
+
+    await #expect(throws: XRPCBodyError.tooManyBytes(limit: 2)) {
+      _ = try await body.collect(upTo: 2)
+    }
+  }
+
+  @Test("allows only one iterator")
+  func isSinglePass() async throws {
+    let body = XRPCBody(Data([1]))
+    var first = body.makeAsyncIterator()
+    #expect(try await first.next() == [1])
+    var second = body.makeAsyncIterator()
+
+    await #expect(throws: XRPCBodyError.alreadyConsumed) {
+      _ = try await second.next()
+    }
+  }
+}

--- a/Tests/SwiftAtprotoTests/XRPCStreamingCallTests.swift
+++ b/Tests/SwiftAtprotoTests/XRPCStreamingCallTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import HTTPTypes
+import Testing
+
+@testable import SwiftAtproto
+
+@Suite("XRPC streaming calls")
+struct XRPCStreamingCallTests {
+  @Test("returns successful metadata before consuming the body")
+  func returnsStreamingResponse() async throws {
+    var headers = HTTPFields()
+    headers[.contentType] = "application/vnd.ipld.car"
+    let client = StreamingTestClient(
+      response: .init(
+        statusCode: 206,
+        headers: headers,
+        body: XRPCBody(Data([1, 2, 3]))))
+
+    let response = try await client.callStreaming(
+      StreamingTestQuery.self,
+      input: .init())
+
+    #expect(response.statusCode == 206)
+    #expect(response.headers[.contentType] == "application/vnd.ipld.car")
+    #expect(try await response.body.collect(upTo: 3) == Data([1, 2, 3]))
+  }
+
+  @Test("keeps the existing Data call compatible")
+  func collectsForLegacyCall() async throws {
+    let client = StreamingTestClient(
+      response: .init(statusCode: 200, body: XRPCBody(Data([4, 5]))))
+
+    let body = try await client.call(StreamingTestQuery.self, input: .init())
+
+    #expect(body == Data([4, 5]))
+  }
+}
+
+private struct StreamingTestClient: XRPCStreamingCallable {
+  let streamedResponse: XRPCStreamingResponseComponents
+
+  init(response: XRPCStreamingResponseComponents) {
+    streamedResponse = response
+  }
+
+  func getProxy(nsid _: String) -> String? { nil }
+
+  func responseStreamWithMetadata(
+    _: XRPCRequestComponents
+  ) async throws -> XRPCStreamingResponseComponents {
+    streamedResponse
+  }
+}
+
+private struct StreamingTestQuery: XRPCQuery, XRPCBinaryResponseRequest {
+  static let id = "com.example.stream"
+  typealias Input = StreamingTestInput
+  typealias ResponseBody = Data
+  typealias Error = StreamingTestError
+}
+
+private struct StreamingTestInput: XRPCQueryInput {
+  struct Query: XRPCInputQuery {
+    var asParameters: Parameters? { nil }
+  }
+
+  let query = Query()
+}
+
+private enum StreamingTestError: XRPCError {
+  case unexpected(error: String?, message: String?)
+
+  init(error: UnExpectedError) {
+    self = .unexpected(error: error.error, message: error.message)
+  }
+
+  var error: String? {
+    if case .unexpected(let error, _) = self { return error }
+    return nil
+  }
+
+  var message: String? {
+    if case .unexpected(_, let message) = self { return message }
+    return nil
+  }
+}


### PR DESCRIPTION
Add a pull-driven streaming response transport with status metadata, cancellation, bounded error handling, and compatibility with existing Data-based calls. Generate streaming methods for CAR, CBOR, MP4, and other binary Lexicon outputs.