### PR TITLE
feat: parse permissioned repository CAR streams

### DIFF
--- a/Sources/ATProtoSync/Documentation.docc/ATProtoSync.md
+++ b/Sources/ATProtoSync/Documentation.docc/ATProtoSync.md
@@ -6,8 +6,9 @@ Verify Permissioned Data repository states without owning consumer persistence.
 
 `ATProtoSync` authenticates a Permissioned Data signed commit and compares its
 hash claim with an ``LtHash`` accumulated from complete records, a DRISL index,
-or incremental operations. It does not fetch repositories, parse CAR framing,
-or decide how a consumer stores checkpoints.
+or incremental operations. It also verifies the two roots and blocks in a
+streaming Permissioned Data repository CAR. It does not fetch repositories or
+decide how a consumer maps records and stores checkpoints.
 
 Generated `com.atproto.space.defs#signedCommit` and
 `com.atproto.space.listRepoOps#opEntry` values expose the fields this module
@@ -29,6 +30,36 @@ if let commit = response.commit {
 }
 ```
 
+For full-state recovery, pass the body returned by a generated streaming
+`com.atproto.space.getRepo` call directly to ``PermissionedRepoCAR``. The
+signed commit and repository index are available immediately; record blocks
+remain pull-driven and are checked against their CIDs as they are consumed.
+
+```swift
+let response = try await client.SpaceGetRepoStreaming(repo: repo, space: space)
+let car = try await PermissionedRepoCAR.read(from: response.body)
+
+let commit = try SignedRepoCommitVerifier.decode(
+  Com.Atproto.SpaceDefs_SignedCommit.self,
+  fromDRISL: car.signedCommitBlock.bytes
+)
+let repository = try RepoCommit(drislIndex: car.repositoryIndexBlock.bytes)
+let context = RepoCommitContext(
+  space: expectedSpace,
+  author: repositoryAuthor,
+  revision: try TID(string: commit.permissionedRepoCommitRevision.rawValue)
+)
+try repository.verify(
+  commit,
+  context: context,
+  publicKey: authorPublicKey
+)
+
+for try await record in car.recordBlocks {
+  // Map the index-verified path and CID-verified value into consumer-owned storage.
+}
+```
+
 The internal BLAKE3 implementation is upstream BLAKE3 1.8.7, distributed
 under Apache License 2.0. Applications distributing binaries containing this
 target need to reproduce that license as part of their third-party notices;
@@ -42,6 +73,12 @@ see `THIRD_PARTY_NOTICES.md` in the package repository.
 - ``RepoCommit``
 - ``RepoRecord``
 - ``RepoOperation``
+
+### Full-state recovery
+
+- ``PermissionedRepoCAR``
+- ``PermissionedRepoCARBlock``
+- ``PermissionedRepoCARRecord``
 
 ### Signed commits
 

--- a/Sources/ATProtoSync/PermissionedRepoCAR.swift
+++ b/Sources/ATProtoSync/PermissionedRepoCAR.swift
@@ -1,0 +1,376 @@
+import Crypto
+import Foundation
+import SwiftAtproto
+
+/// A verified block read from a Permissioned Data repository CAR.
+public struct PermissionedRepoCARBlock: Hashable, Sendable {
+  /// The DAG-CBOR CID that identifies ``bytes``.
+  public let cid: LexLink
+
+  /// The encoded DAG-CBOR block payload.
+  public let bytes: Data
+
+  init(cid: LexLink, bytes: Data) {
+    self.cid = cid
+    self.bytes = bytes
+  }
+}
+
+/// A CID-verified record value paired with its repository-index path.
+public struct PermissionedRepoCARRecord: Hashable, Sendable {
+  /// The collection containing the record.
+  public let collection: NSID
+
+  /// The record key within ``collection``.
+  public let recordKey: RecordKey
+
+  /// The CID declared by the repository index.
+  public let cid: LexLink
+
+  /// The encoded DAG-CBOR record value.
+  public let bytes: Data
+}
+
+/// The structurally verified, streaming contents of a Permissioned Data repository CAR.
+///
+/// Permissioned repository archives declare exactly two roots. The signed
+/// commit and repository index blocks are read and checked eagerly, while
+/// record blocks remain pull-driven through ``recordBlocks``.
+public struct PermissionedRepoCAR: Sendable {
+  /// Whether the CAR is expected to contain record value blocks.
+  public enum RecordValues: Hashable, Sendable {
+    /// A normal `getRepo` response containing one block per index entry.
+    case included
+
+    /// An `excludeValues: true` response containing only commit and index blocks.
+    case excluded
+  }
+
+  /// The block matching the CAR's first, signed-commit root.
+  public let signedCommitBlock: PermissionedRepoCARBlock
+
+  /// The block matching the CAR's second, repository-index root.
+  public let repositoryIndexBlock: PermissionedRepoCARBlock
+
+  /// The remaining CID-verified record blocks.
+  public let recordBlocks: RecordBlocks
+
+  /// Reads the CAR header and its two root blocks from an XRPC response body.
+  ///
+  /// Record blocks are not pulled until ``recordBlocks`` is consumed. Call
+  /// ``RecordBlocks/cancel()`` when abandoning the archive before reaching its
+  /// end.
+  public static func read(
+    from body: XRPCBody,
+    recordValues: RecordValues = .included,
+    limits: RepoVerificationLimits = .init()
+  ) async throws -> Self {
+    let reader = PermissionedRepoCARReader(body: body)
+    do {
+      let roots = try await reader.readRoots(limits: limits)
+      let signedCommit = try await reader.requiredBlock(
+        maximumPayloadBytes: limits.maximumCommitBytes)
+      guard signedCommit.cid == roots[0] else {
+        throw RepoVerificationError.unexpectedCARRootBlock(
+          expected: roots[0], actual: signedCommit.cid)
+      }
+
+      let repositoryIndex = try await reader.requiredBlock(
+        maximumPayloadBytes: limits.maximumIndexBytes)
+      guard repositoryIndex.cid == roots[1] else {
+        throw RepoVerificationError.unexpectedCARRootBlock(
+          expected: roots[1], actual: repositoryIndex.cid)
+      }
+      let index = try PermissionedRepoIndex(
+        drisl: repositoryIndex.bytes,
+        limits: limits)
+
+      return Self(
+        signedCommitBlock: signedCommit,
+        repositoryIndexBlock: repositoryIndex,
+        recordBlocks: RecordBlocks(
+          reader: reader,
+          records: index.records,
+          recordValues: recordValues,
+          maximumPayloadBytes: limits.maximumCARBlockBytes))
+    } catch {
+      body.cancel()
+      throw error
+    }
+  }
+
+  /// A single-pass, pull-driven sequence of index-matched record blocks.
+  ///
+  /// Consume the sequence through its `nil` terminator to verify that the CAR
+  /// contains neither missing nor extra record blocks.
+  public final class RecordBlocks: AsyncSequence, @unchecked Sendable {
+    public typealias Element = PermissionedRepoCARRecord
+
+    private let reader: PermissionedRepoCARReader
+    private let records: [RepoRecord]
+    private let recordValues: RecordValues
+    private let maximumPayloadBytes: Int
+    private let state = ConsumptionState()
+
+    fileprivate init(
+      reader: PermissionedRepoCARReader,
+      records: [RepoRecord],
+      recordValues: RecordValues,
+      maximumPayloadBytes: Int
+    ) {
+      self.reader = reader
+      self.records = records
+      self.recordValues = recordValues
+      self.maximumPayloadBytes = maximumPayloadBytes
+    }
+
+    /// Creates the sequence's single iterator.
+    public func makeAsyncIterator() -> Iterator {
+      guard state.beginIteration() else {
+        return Iterator(throwing: RepoVerificationError.carRecordBlocksAlreadyConsumed)
+      }
+      return Iterator(
+        reader: reader,
+        records: records,
+        recordValues: recordValues,
+        maximumPayloadBytes: maximumPayloadBytes)
+    }
+
+    /// Cancels the transport operation backing the CAR body.
+    public func cancel() {
+      reader.cancel()
+    }
+
+    /// The iterator that verifies one record block per pull.
+    public struct Iterator: AsyncIteratorProtocol {
+      private let reader: PermissionedRepoCARReader?
+      private let records: [RepoRecord]
+      private let recordValues: RecordValues
+      private let maximumPayloadBytes: Int
+      private let error: (any Error)?
+      private var recordIndex = 0
+
+      fileprivate init(
+        reader: PermissionedRepoCARReader,
+        records: [RepoRecord],
+        recordValues: RecordValues,
+        maximumPayloadBytes: Int
+      ) {
+        self.reader = reader
+        self.records = records
+        self.recordValues = recordValues
+        self.maximumPayloadBytes = maximumPayloadBytes
+        self.error = nil
+      }
+
+      fileprivate init(throwing error: any Error) {
+        self.reader = nil
+        self.records = []
+        self.recordValues = .included
+        self.maximumPayloadBytes = 0
+        self.error = error
+      }
+
+      public mutating func next() async throws -> PermissionedRepoCARRecord? {
+        if let error { throw error }
+        guard let reader else { return nil }
+        do {
+          if recordValues == .excluded || recordIndex == records.count {
+            guard
+              try await reader.readBlock(maximumPayloadBytes: maximumPayloadBytes) == nil
+            else {
+              throw RepoVerificationError.unexpectedCARRecordBlock
+            }
+            return nil
+          }
+
+          guard
+            let block = try await reader.readBlock(
+              maximumPayloadBytes: maximumPayloadBytes)
+          else {
+            throw RepoVerificationError.missingCARRecordBlocks(
+              expected: records.count,
+              actual: recordIndex)
+          }
+          let record = records[recordIndex]
+          guard block.cid == record.cid else {
+            throw RepoVerificationError.unexpectedCARRecordCID(
+              collection: record.collection,
+              recordKey: record.recordKey,
+              expected: record.cid,
+              actual: block.cid)
+          }
+          recordIndex += 1
+          return PermissionedRepoCARRecord(
+            collection: record.collection,
+            recordKey: record.recordKey,
+            cid: record.cid,
+            bytes: block.bytes)
+        } catch {
+          reader.cancel()
+          throw error
+        }
+      }
+    }
+  }
+}
+
+private final class PermissionedRepoCARReader: @unchecked Sendable {
+  private static let cidLength = 36
+  private static let cidPrefix: [UInt8] = [0x01, 0x71, 0x12, 0x20]
+
+  private let body: XRPCBody
+  private var iterator: XRPCBody.Iterator
+  private var buffered: ArraySlice<UInt8> = []
+
+  init(body: XRPCBody) {
+    self.body = body
+    self.iterator = body.makeAsyncIterator()
+  }
+
+  func cancel() {
+    body.cancel()
+  }
+
+  func readRoots(limits: RepoVerificationLimits) async throws -> [LexLink] {
+    guard let encodedLength = try await readUnsignedVarint() else {
+      throw RepoVerificationError.malformedCARHeader
+    }
+    guard
+      limits.maximumCARHeaderBytes >= 0,
+      encodedLength <= UInt64(limits.maximumCARHeaderBytes)
+    else {
+      throw RepoVerificationError.inputTooLarge(
+        limit: limits.maximumCARHeaderBytes,
+        actual: Int(exactly: encodedLength) ?? Int.max)
+    }
+
+    let headerBytes = try await readExactly(Int(encodedLength))
+    let header: Header
+    do {
+      header = try drislDecoder(
+        maximumNestingDepth: 4,
+        maximumContainerElements: 4,
+        maximumStringBytes: limits.maximumCARHeaderBytes
+      ).decode(Header.self, from: headerBytes)
+    } catch {
+      throw RepoVerificationError.malformedCARHeader
+    }
+
+    guard header.version == 1 else {
+      throw RepoVerificationError.unsupportedCARVersion(header.version)
+    }
+    guard header.roots.count == 2 else {
+      throw RepoVerificationError.invalidCARRootCount(actual: header.roots.count)
+    }
+    guard header.roots.allSatisfy(Self.isPermissionedRepoCID) else {
+      throw RepoVerificationError.malformedCARCID
+    }
+    return header.roots
+  }
+
+  func requiredBlock(maximumPayloadBytes: Int) async throws -> PermissionedRepoCARBlock {
+    guard let block = try await readBlock(maximumPayloadBytes: maximumPayloadBytes) else {
+      throw RepoVerificationError.truncatedCAR
+    }
+    return block
+  }
+
+  func readBlock(maximumPayloadBytes: Int) async throws -> PermissionedRepoCARBlock? {
+    guard let encodedLength = try await readUnsignedVarint() else { return nil }
+    guard encodedLength >= Self.cidLength else {
+      throw RepoVerificationError.malformedCARCID
+    }
+
+    let payloadLength = encodedLength - UInt64(Self.cidLength)
+    guard maximumPayloadBytes >= 0, payloadLength <= UInt64(maximumPayloadBytes) else {
+      throw RepoVerificationError.inputTooLarge(
+        limit: maximumPayloadBytes,
+        actual: Int(exactly: payloadLength) ?? Int.max)
+    }
+
+    let cidBytes = try await readExactly(Self.cidLength)
+    guard cidBytes.starts(with: Self.cidPrefix), let cid = try? LexLink(cidBytes) else {
+      throw RepoVerificationError.malformedCARCID
+    }
+    let bytes = try await readExactly(Int(payloadLength))
+    let digest = Data(SHA256.hash(data: bytes))
+    guard digest.elementsEqual(cidBytes.suffix(32)) else {
+      throw RepoVerificationError.carBlockCIDMismatch(cid)
+    }
+    return PermissionedRepoCARBlock(cid: cid, bytes: bytes)
+  }
+
+  private func readUnsignedVarint() async throws -> UInt64? {
+    var value: UInt64 = 0
+    var byteCount = 0
+
+    while byteCount < 10 {
+      guard let byte = try await readByte() else {
+        if byteCount == 0 { return nil }
+        throw RepoVerificationError.truncatedCAR
+      }
+      let payload = UInt64(byte & 0x7f)
+      if byteCount == 9, payload > 1 {
+        throw RepoVerificationError.malformedCARVarint
+      }
+      value |= payload << UInt64(byteCount * 7)
+      byteCount += 1
+
+      if byte & 0x80 == 0 {
+        if byteCount > 1, payload == 0 {
+          throw RepoVerificationError.malformedCARVarint
+        }
+        return value
+      }
+    }
+    throw RepoVerificationError.malformedCARVarint
+  }
+
+  private func readByte() async throws -> UInt8? {
+    while buffered.isEmpty {
+      guard let chunk = try await iterator.next() else { return nil }
+      buffered = chunk
+    }
+    return buffered.removeFirst()
+  }
+
+  private func readExactly(_ count: Int) async throws -> Data {
+    var result = Data()
+    result.reserveCapacity(count)
+    while result.count < count {
+      while buffered.isEmpty {
+        guard let chunk = try await iterator.next() else {
+          throw RepoVerificationError.truncatedCAR
+        }
+        buffered = chunk
+      }
+      let consumed = min(count - result.count, buffered.count)
+      result.append(contentsOf: buffered.prefix(consumed))
+      buffered = buffered.dropFirst(consumed)
+    }
+    return result
+  }
+
+  private static func isPermissionedRepoCID(_ link: LexLink) -> Bool {
+    link.cid.rawBuffer.count == cidLength && link.cid.rawBuffer.starts(with: cidPrefix)
+  }
+
+  private struct Header: Decodable {
+    let roots: [LexLink]
+    let version: Int
+  }
+}
+
+private final class ConsumptionState: @unchecked Sendable {
+  private let lock = NSLock()
+  private var iterationStarted = false
+
+  func beginIteration() -> Bool {
+    lock.withLock {
+      guard !iterationStarted else { return false }
+      iterationStarted = true
+      return true
+    }
+  }
+}

--- a/Sources/ATProtoSync/PermissionedRepoIndex.swift
+++ b/Sources/ATProtoSync/PermissionedRepoIndex.swift
@@ -1,0 +1,42 @@
+import Foundation
+import SwiftAtproto
+
+struct PermissionedRepoIndex: Sendable {
+  let records: [RepoRecord]
+
+  init(
+    drisl data: Data,
+    limits: RepoVerificationLimits
+  ) throws {
+    guard data.count <= limits.maximumIndexBytes else {
+      throw RepoVerificationError.inputTooLarge(
+        limit: limits.maximumIndexBytes, actual: data.count)
+    }
+
+    let index: [String: LexLink]
+    do {
+      index = try drislDecoder(
+        maximumNestingDepth: limits.maximumNestingDepth,
+        maximumContainerElements: limits.maximumIndexEntries,
+        maximumStringBytes: 1024
+      ).decode([String: LexLink].self, from: data)
+    } catch {
+      throw RepoVerificationError.malformedRepositoryIndex
+    }
+
+    records = try index.sorted { lhs, rhs in
+      Self.canonicalKeyPrecedes(lhs.key, rhs.key)
+    }.map { path, cid in
+      try RepoRecord(path: path, cid: cid)
+    }
+  }
+
+  private static func canonicalKeyPrecedes(_ lhs: String, _ rhs: String) -> Bool {
+    let lhsBytes = Array(lhs.utf8)
+    let rhsBytes = Array(rhs.utf8)
+    if lhsBytes.count != rhsBytes.count {
+      return lhsBytes.count < rhsBytes.count
+    }
+    return lhsBytes.lexicographicallyPrecedes(rhsBytes)
+  }
+}

--- a/Sources/ATProtoSync/RepoCommit.swift
+++ b/Sources/ATProtoSync/RepoCommit.swift
@@ -87,26 +87,7 @@ public struct RepoCommit: Hashable, Sendable {
     drislIndex data: Data,
     limits: RepoVerificationLimits = .init()
   ) throws {
-    guard data.count <= limits.maximumIndexBytes else {
-      throw RepoVerificationError.inputTooLarge(
-        limit: limits.maximumIndexBytes, actual: data.count)
-    }
-
-    let index: [String: LexLink]
-    do {
-      index = try drislDecoder(
-        maximumNestingDepth: limits.maximumNestingDepth,
-        maximumContainerElements: limits.maximumIndexEntries,
-        maximumStringBytes: 1024
-      ).decode([String: LexLink].self, from: data)
-    } catch {
-      throw RepoVerificationError.malformedRepositoryIndex
-    }
-
-    self.init()
-    for (path, cid) in index {
-      add(try Self.record(path: path, cid: cid))
-    }
+    self.init(records: try PermissionedRepoIndex(drisl: data, limits: limits).records)
   }
 
   /// Adds a complete record reference to the state.
@@ -194,23 +175,25 @@ public struct RepoCommit: Hashable, Sendable {
     return link
   }
 
-  private static func record(path: String, cid: LexLink) throws -> RepoRecord {
+  private static func element(for record: RepoRecord) -> String {
+    "\(record.collection.rawValue)/\(record.recordKey.rawValue)/\(record.cid.toBaseEncodedString)"
+  }
+}
+
+extension RepoRecord {
+  init(path: String, cid: LexLink) throws {
     guard let separator = path.firstIndex(of: "/") else {
       throw RepoVerificationError.malformedRecordPath(path)
     }
     let collectionRaw = String(path[..<separator])
     let recordKeyRaw = String(path[path.index(after: separator)...])
     do {
-      return RepoRecord(
+      self = RepoRecord(
         collection: try NSID(string: collectionRaw),
         recordKey: try RecordKey(string: recordKeyRaw),
         cid: cid)
     } catch {
       throw RepoVerificationError.malformedRecordPath(path)
     }
-  }
-
-  private static func element(for record: RepoRecord) -> String {
-    "\(record.collection.rawValue)/\(record.recordKey.rawValue)/\(record.cid.toBaseEncodedString)"
   }
 }

--- a/Sources/ATProtoSync/RepoVerification.swift
+++ b/Sources/ATProtoSync/RepoVerification.swift
@@ -6,6 +6,12 @@ import SwiftCbor
 
 /// Resource limits applied while decoding and verifying Permissioned Data repositories.
 public struct RepoVerificationLimits: Hashable, Sendable {
+  /// The largest encoded CAR header accepted by the streaming reader.
+  public var maximumCARHeaderBytes: Int
+
+  /// The largest record block payload accepted by the streaming reader.
+  public var maximumCARBlockBytes: Int
+
   /// The largest encoded signed commit accepted by the DRISL decoder.
   public var maximumCommitBytes: Int
 
@@ -23,12 +29,16 @@ public struct RepoVerificationLimits: Hashable, Sendable {
 
   /// Creates verification limits suitable for client-side repository sync.
   public init(
+    maximumCARHeaderBytes: Int = 64 * 1024,
+    maximumCARBlockBytes: Int = 64 * 1024 * 1024,
     maximumCommitBytes: Int = 64 * 1024,
     maximumIndexBytes: Int = 64 * 1024 * 1024,
     maximumIndexEntries: Int = 100_000,
     maximumNestingDepth: Int = 16,
     maximumSignatureBytes: Int = 256
   ) {
+    self.maximumCARHeaderBytes = maximumCARHeaderBytes
+    self.maximumCARBlockBytes = maximumCARBlockBytes
     self.maximumCommitBytes = maximumCommitBytes
     self.maximumIndexBytes = maximumIndexBytes
     self.maximumIndexEntries = maximumIndexEntries
@@ -41,6 +51,47 @@ public struct RepoVerificationLimits: Hashable, Sendable {
 public enum RepoVerificationError: Error, Hashable, Sendable {
   /// An encoded input exceeded its configured byte limit.
   case inputTooLarge(limit: Int, actual: Int)
+
+  /// A CAR header could not be decoded.
+  case malformedCARHeader
+
+  /// A CAR header declared an unsupported version.
+  case unsupportedCARVersion(Int)
+
+  /// A Permissioned Data CAR did not declare signed-commit and index roots.
+  case invalidCARRootCount(actual: Int)
+
+  /// A CAR section length used an invalid unsigned varint encoding.
+  case malformedCARVarint
+
+  /// A CAR ended before the current header or block was complete.
+  case truncatedCAR
+
+  /// A CAR block did not contain a valid AT Protocol DAG-CBOR CID.
+  case malformedCARCID
+
+  /// A leading CAR block did not match its declared root.
+  case unexpectedCARRootBlock(expected: LexLink, actual: LexLink)
+
+  /// A CAR block's bytes did not match its CID digest.
+  case carBlockCIDMismatch(LexLink)
+
+  /// The record-block sequence was consumed more than once.
+  case carRecordBlocksAlreadyConsumed
+
+  /// A CAR contained more record blocks than its repository index declares.
+  case unexpectedCARRecordBlock
+
+  /// A value-bearing CAR ended before all indexed records were read.
+  case missingCARRecordBlocks(expected: Int, actual: Int)
+
+  /// A record block did not match the CID declared for its repository path.
+  case unexpectedCARRecordCID(
+    collection: NSID,
+    recordKey: RecordKey,
+    expected: LexLink,
+    actual: LexLink
+  )
 
   /// A persisted LtHash state had a size other than 2048 bytes.
   case invalidLtHashStateLength(actual: Int)

--- a/Tests/ATProtoSyncTests/PermissionedRepoCARTests.swift
+++ b/Tests/ATProtoSyncTests/PermissionedRepoCARTests.swift
@@ -1,0 +1,499 @@
+import Crypto
+import Foundation
+import SwiftAtproto
+import SwiftCbor
+import Testing
+
+@testable import ATProtoSync
+
+@Suite("Permissioned repository CAR")
+struct PermissionedRepoCARTests {
+  @Test("reads roots eagerly and record blocks on demand")
+  func readsWithBackpressure() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0xa1, 0x61, 0x61, 0x01])])
+    let source = PullDrivenState(chunks: fixture.parts.map(ArraySlice.init))
+    let body = XRPCBody(PullDrivenChunks(state: source), onCancel: { source.cancel() })
+
+    let car = try await PermissionedRepoCAR.read(from: body)
+
+    #expect(car.signedCommitBlock.bytes == fixture.commitPayload)
+    #expect(car.repositoryIndexBlock.bytes == fixture.indexPayload)
+    #expect(source.snapshot == .init(pullCount: 3, isCancelled: false))
+
+    var iterator = car.recordBlocks.makeAsyncIterator()
+    let record = try #require(try await iterator.next())
+    #expect(record.bytes == fixture.recordPayloads[0])
+    #expect(record.collection.rawValue == "com.example.record")
+    #expect(record.recordKey.rawValue == "first")
+    #expect(record.cid == (try Fixture.cid(for: fixture.recordPayloads[0])))
+    #expect(source.snapshot == .init(pullCount: 4, isCancelled: false))
+    #expect(try await iterator.next() == nil)
+  }
+
+  @Test("accepts a repository without record blocks")
+  func readsIndexOnlyCAR() async throws {
+    let fixture = try Fixture(recordPayloads: [])
+    let car = try await PermissionedRepoCAR.read(from: XRPCBody(fixture.data))
+    var iterator = car.recordBlocks.makeAsyncIterator()
+    #expect(try await iterator.next() == nil)
+  }
+
+  @Test("reads framing split at every byte boundary")
+  func readsBytewiseChunks() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0xa0])])
+    let chunks = fixture.data.map { ArraySlice([$0]) }
+    let body = XRPCBody(PullDrivenChunks(state: PullDrivenState(chunks: chunks)))
+
+    let car = try await PermissionedRepoCAR.read(from: body)
+    var iterator = car.recordBlocks.makeAsyncIterator()
+
+    #expect(try await iterator.next()?.bytes == fixture.recordPayloads[0])
+    #expect(try await iterator.next() == nil)
+  }
+
+  @Test("rejects a second record-block iterator")
+  func rejectsSecondConsumption() async throws {
+    let fixture = try Fixture(recordPayloads: [])
+    let car = try await PermissionedRepoCAR.read(from: XRPCBody(fixture.data))
+    var first = car.recordBlocks.makeAsyncIterator()
+    var second = car.recordBlocks.makeAsyncIterator()
+
+    #expect(try await first.next() == nil)
+    await #expect(throws: RepoVerificationError.carRecordBlocksAlreadyConsumed) {
+      try await second.next()
+    }
+  }
+
+  @Test("cancels an abandoned record stream")
+  func cancelsRecordStream() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0x01])])
+    let source = PullDrivenState(chunks: fixture.parts.map(ArraySlice.init))
+    let body = XRPCBody(PullDrivenChunks(state: source), onCancel: { source.cancel() })
+    let car = try await PermissionedRepoCAR.read(from: body)
+
+    car.recordBlocks.cancel()
+
+    #expect(source.snapshot.isCancelled)
+  }
+
+  @Test(
+    "rejects malformed headers",
+    arguments: [
+      HeaderFailure.version,
+      .rootCount,
+      .malformed,
+    ])
+  func rejectsMalformedHeaders(_ failure: HeaderFailure) async throws {
+    let fixture = try Fixture(recordPayloads: [])
+    let body: Data
+    let expected: RepoVerificationError
+    switch failure {
+    case .version:
+      body = try Fixture.header(roots: fixture.roots, version: 2)
+      expected = .unsupportedCARVersion(2)
+    case .rootCount:
+      body = try Fixture.header(roots: [fixture.roots[0]])
+      expected = .invalidCARRootCount(actual: 1)
+    case .malformed:
+      body = Data([0x01, 0xff])
+      expected = .malformedCARHeader
+    }
+
+    await #expect(throws: expected) {
+      try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    }
+  }
+
+  @Test("rejects leading blocks that do not match root order")
+  func rejectsRootOrderMismatch() async throws {
+    let fixture = try Fixture(recordPayloads: [])
+    let body = fixture.parts[0] + fixture.parts[2] + fixture.parts[1]
+
+    await #expect(
+      throws: RepoVerificationError.unexpectedCARRootBlock(
+        expected: fixture.roots[0], actual: fixture.roots[1])
+    ) {
+      try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    }
+  }
+
+  @Test("rejects bytes that do not match a block CID")
+  func rejectsCIDMismatch() async throws {
+    let fixture = try Fixture(recordPayloads: [])
+    let tamperedCommit = Fixture.block(
+      cid: fixture.roots[0], payload: fixture.commitPayload + Data([0x00]))
+    let body = fixture.parts[0] + tamperedCommit + fixture.parts[2]
+
+    await #expect(throws: RepoVerificationError.carBlockCIDMismatch(fixture.roots[0])) {
+      try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    }
+  }
+
+  @Test("rejects a record payload that does not match its CID")
+  func rejectsRecordCIDMismatchLazily() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0x01])])
+    let recordCID = try Fixture.cid(for: fixture.recordPayloads[0])
+    let tamperedRecord = Fixture.block(cid: recordCID, payload: Data([0x02]))
+    let body = fixture.parts.prefix(3).reduce(into: Data(), +=) + tamperedRecord
+    let car = try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    var iterator = car.recordBlocks.makeAsyncIterator()
+
+    await #expect(throws: RepoVerificationError.carBlockCIDMismatch(recordCID)) {
+      try await iterator.next()
+    }
+  }
+
+  @Test("rejects a record block not declared by an empty index")
+  func rejectsExtraRecordBlock() async throws {
+    let fixture = try Fixture(recordPayloads: [])
+    let payload = Data([0xa0])
+    let extraBlock = Fixture.block(cid: try Fixture.cid(for: payload), payload: payload)
+    let car = try await PermissionedRepoCAR.read(
+      from: XRPCBody(fixture.data + extraBlock))
+    var iterator = car.recordBlocks.makeAsyncIterator()
+
+    await #expect(throws: RepoVerificationError.unexpectedCARRecordBlock) {
+      try await iterator.next()
+    }
+  }
+
+  @Test("rejects a missing indexed record block")
+  func rejectsMissingRecordBlock() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0x01]), Data([0x02])])
+    let body = fixture.parts.dropLast().reduce(into: Data(), +=)
+    let car = try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    var iterator = car.recordBlocks.makeAsyncIterator()
+
+    #expect(try await iterator.next() != nil)
+    await #expect(
+      throws: RepoVerificationError.missingCARRecordBlocks(expected: 2, actual: 1)
+    ) {
+      try await iterator.next()
+    }
+  }
+
+  @Test("rejects record blocks outside canonical index order")
+  func rejectsRecordBlockOrderMismatch() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0x01]), Data([0x02])])
+    let body =
+      fixture.parts.prefix(3).reduce(into: Data(), +=)
+      + fixture.parts[4] + fixture.parts[3]
+    let car = try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    var iterator = car.recordBlocks.makeAsyncIterator()
+    let expected = try Fixture.cid(for: fixture.recordPayloads[0])
+    let actual = try Fixture.cid(for: fixture.recordPayloads[1])
+
+    await #expect(
+      throws: RepoVerificationError.unexpectedCARRecordCID(
+        collection: try NSID(string: "com.example.record"),
+        recordKey: try RecordKey(string: "first"),
+        expected: expected,
+        actual: actual)
+    ) {
+      try await iterator.next()
+    }
+  }
+
+  @Test("rejects a self-consistent block with a CID absent from the index")
+  func rejectsRecordCIDOutsideIndex() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0x01])])
+    let replacementPayload = Data([0x02])
+    let replacementCID = try Fixture.cid(for: replacementPayload)
+    let body =
+      fixture.parts.prefix(3).reduce(into: Data(), +=)
+      + Fixture.block(cid: replacementCID, payload: replacementPayload)
+    let car = try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    var iterator = car.recordBlocks.makeAsyncIterator()
+
+    await #expect(
+      throws: RepoVerificationError.unexpectedCARRecordCID(
+        collection: try NSID(string: "com.example.record"),
+        recordKey: try RecordKey(string: "first"),
+        expected: try Fixture.cid(for: fixture.recordPayloads[0]),
+        actual: replacementCID)
+    ) {
+      try await iterator.next()
+    }
+  }
+
+  @Test("accepts index-only CARs only when record values are excluded")
+  func distinguishesExcludedRecordValues() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0x01])])
+    let indexOnly = fixture.parts.prefix(3).reduce(into: Data(), +=)
+    let excluded = try await PermissionedRepoCAR.read(
+      from: XRPCBody(indexOnly),
+      recordValues: .excluded)
+    var excludedIterator = excluded.recordBlocks.makeAsyncIterator()
+    #expect(try await excludedIterator.next() == nil)
+
+    let included = try await PermissionedRepoCAR.read(from: XRPCBody(indexOnly))
+    var includedIterator = included.recordBlocks.makeAsyncIterator()
+    await #expect(
+      throws: RepoVerificationError.missingCARRecordBlocks(expected: 1, actual: 0)
+    ) {
+      try await includedIterator.next()
+    }
+
+    let valuesPresent = try await PermissionedRepoCAR.read(
+      from: XRPCBody(fixture.data),
+      recordValues: .excluded)
+    var valuesPresentIterator = valuesPresent.recordBlocks.makeAsyncIterator()
+    await #expect(throws: RepoVerificationError.unexpectedCARRecordBlock) {
+      try await valuesPresentIterator.next()
+    }
+  }
+
+  @Test(
+    "rejects malformed or truncated framing",
+    arguments: [
+      FramingFailure.nonCanonicalVarint,
+      .overflowingVarint,
+      .truncatedVarint,
+      .shortCID,
+      .invalidCID,
+      .truncatedPayload,
+    ])
+  func rejectsMalformedFraming(_ failure: FramingFailure) async throws {
+    let fixture = try Fixture(recordPayloads: [])
+    let body: Data
+    let expected: RepoVerificationError
+    switch failure {
+    case .nonCanonicalVarint:
+      body = Data([0x80, 0x00])
+      expected = .malformedCARVarint
+    case .overflowingVarint:
+      body = Data(repeating: 0xff, count: 10) + Data([0x00])
+      expected = .malformedCARVarint
+    case .truncatedVarint:
+      body = Data([0x80])
+      expected = .truncatedCAR
+    case .shortCID:
+      body = fixture.parts[0] + Data([0x01, 0x00])
+      expected = .malformedCARCID
+    case .invalidCID:
+      var invalidBlock = fixture.parts[1]
+      invalidBlock[invalidBlock.startIndex + 1] = 0x02
+      body = fixture.parts[0] + invalidBlock
+      expected = .malformedCARCID
+    case .truncatedPayload:
+      let section = fixture.parts[1]
+      body = fixture.parts[0] + section.dropLast()
+      expected = .truncatedCAR
+    }
+
+    await #expect(throws: expected) {
+      try await PermissionedRepoCAR.read(from: XRPCBody(body))
+    }
+  }
+
+  @Test("enforces header and block limits before allocation")
+  func enforcesLimits() async throws {
+    let fixture = try Fixture(recordPayloads: [Data([0x01, 0x02])])
+    let headerLength = fixture.parts[0].count - Fixture.varintLength(fixture.parts[0])
+    await #expect(
+      throws: RepoVerificationError.inputTooLarge(
+        limit: headerLength - 1, actual: headerLength)
+    ) {
+      try await PermissionedRepoCAR.read(
+        from: XRPCBody(fixture.data),
+        limits: RepoVerificationLimits(maximumCARHeaderBytes: headerLength - 1))
+    }
+
+    await #expect(
+      throws: RepoVerificationError.inputTooLarge(
+        limit: fixture.commitPayload.count - 1, actual: fixture.commitPayload.count)
+    ) {
+      try await PermissionedRepoCAR.read(
+        from: XRPCBody(fixture.data),
+        limits: RepoVerificationLimits(
+          maximumCommitBytes: fixture.commitPayload.count - 1))
+    }
+
+    await #expect(
+      throws: RepoVerificationError.inputTooLarge(
+        limit: fixture.indexPayload.count - 1, actual: fixture.indexPayload.count)
+    ) {
+      try await PermissionedRepoCAR.read(
+        from: XRPCBody(fixture.data),
+        limits: RepoVerificationLimits(
+          maximumIndexBytes: fixture.indexPayload.count - 1))
+    }
+
+    let car = try await PermissionedRepoCAR.read(
+      from: XRPCBody(fixture.data),
+      limits: RepoVerificationLimits(maximumCARBlockBytes: 1))
+    var iterator = car.recordBlocks.makeAsyncIterator()
+    await #expect(throws: RepoVerificationError.inputTooLarge(limit: 1, actual: 2)) {
+      try await iterator.next()
+    }
+  }
+}
+
+enum HeaderFailure: Sendable {
+  case version
+  case rootCount
+  case malformed
+}
+
+enum FramingFailure: Sendable {
+  case nonCanonicalVarint
+  case overflowingVarint
+  case truncatedVarint
+  case shortCID
+  case invalidCID
+  case truncatedPayload
+}
+
+private struct Fixture {
+  let commitPayload = Data([0xa1, 0x63, 0x76, 0x65, 0x72, 0x01])
+  let indexPayload: Data
+  let recordPayloads: [Data]
+  let roots: [LexLink]
+  let parts: [Data]
+
+  var data: Data { parts.reduce(into: Data(), +=) }
+
+  init(recordPayloads: [Data]) throws {
+    self.recordPayloads = recordPayloads
+    let recordEntries = try recordPayloads.enumerated().map { index, payload in
+      (
+        path: "com.example.record/\(Self.recordKey(at: index))",
+        cid: try Self.cid(for: payload),
+        payload: payload
+      )
+    }.sorted { lhs, rhs in
+      let lhsBytes = Array(lhs.path.utf8)
+      let rhsBytes = Array(rhs.path.utf8)
+      if lhsBytes.count != rhsBytes.count { return lhsBytes.count < rhsBytes.count }
+      return lhsBytes.lexicographicallyPrecedes(rhsBytes)
+    }
+    let index = Dictionary(uniqueKeysWithValues: recordEntries.map { ($0.path, $0.cid) })
+    self.indexPayload = try CborEncoder(
+      options: .lexicographicallySortedMapKeys,
+      allowedTags: [42]
+    ).encode(index)
+    let commitCID = try Self.cid(for: commitPayload)
+    let indexCID = try Self.cid(for: indexPayload)
+    self.roots = [commitCID, indexCID]
+    var parts = [
+      try Self.header(roots: [commitCID, indexCID]),
+      Self.block(cid: commitCID, payload: commitPayload),
+      Self.block(cid: indexCID, payload: indexPayload),
+    ]
+    for entry in recordEntries {
+      parts.append(Self.block(cid: entry.cid, payload: entry.payload))
+    }
+    self.parts = parts
+  }
+
+  private static func recordKey(at index: Int) -> String {
+    switch index {
+    case 0: "first"
+    case 1: "second"
+    case 2: "third"
+    default: "record-\(index)"
+    }
+  }
+
+  static func header(roots: [LexLink], version: Int = 1) throws -> Data {
+    let bytes = try CborEncoder(
+      options: .lexicographicallySortedMapKeys,
+      allowedTags: [42]
+    ).encode(Header(roots: roots, version: version))
+    return varint(UInt64(bytes.count)) + bytes
+  }
+
+  static func block(cid: LexLink, payload: Data) -> Data {
+    let cidBytes = Data(cid.cid.rawBuffer)
+    return varint(UInt64(cidBytes.count + payload.count)) + cidBytes + payload
+  }
+
+  static func cid(for payload: Data) throws -> LexLink {
+    try Data([0x01, 0x71, 0x12, 0x20])
+      .appending(Data(SHA256.hash(data: payload)))
+      .withUnsafeBytes { try LexLink(Data($0)) }
+  }
+
+  static func varint(_ value: UInt64) -> Data {
+    var value = value
+    var result = Data()
+    repeat {
+      var byte = UInt8(value & 0x7f)
+      value >>= 7
+      if value != 0 { byte |= 0x80 }
+      result.append(byte)
+    } while value != 0
+    return result
+  }
+
+  static func varintLength(_ data: Data) -> Int {
+    data.prefix { $0 & 0x80 != 0 }.count + 1
+  }
+
+  private struct Header: Encodable {
+    let roots: [LexLink]
+    let version: Int
+  }
+}
+
+private struct PullDrivenChunks: AsyncSequence, Sendable {
+  typealias Element = ArraySlice<UInt8>
+
+  let state: PullDrivenState
+
+  func makeAsyncIterator() -> Iterator {
+    Iterator(state: state)
+  }
+
+  struct Iterator: AsyncIteratorProtocol {
+    let state: PullDrivenState
+
+    mutating func next() async throws -> Element? {
+      state.next()
+    }
+  }
+}
+
+private final class PullDrivenState: @unchecked Sendable {
+  struct Snapshot: Equatable {
+    let pullCount: Int
+    let isCancelled: Bool
+  }
+
+  private let lock = NSLock()
+  private let chunks: [ArraySlice<UInt8>]
+  private var index = 0
+  private var pullCount = 0
+  private var isCancelled = false
+
+  init(chunks: [ArraySlice<UInt8>]) {
+    self.chunks = chunks
+  }
+
+  var snapshot: Snapshot {
+    lock.withLock { Snapshot(pullCount: pullCount, isCancelled: isCancelled) }
+  }
+
+  func next() -> ArraySlice<UInt8>? {
+    lock.withLock {
+      guard index < chunks.count else { return nil }
+      defer {
+        index += 1
+        pullCount += 1
+      }
+      return chunks[index]
+    }
+  }
+
+  func cancel() {
+    lock.withLock { isCancelled = true }
+  }
+}
+
+extension Data {
+  fileprivate func appending(_ other: Data) -> Data {
+    var copy = self
+    copy.append(other)
+    return copy
+  }
+}


### PR DESCRIPTION
Adds a bounded-memory Permissioned Data CAR reader that validates the signed commit and repository index roots while streaming and verifying each block against its CID. It also rejects malformed, truncated, and oversized archives.