### PR TITLE
feat: add permissioned repository recovery results

### DIFF
--- a/Sources/ATProtoSync/Documentation.docc/ATProtoSync.md
+++ b/Sources/ATProtoSync/Documentation.docc/ATProtoSync.md
@@ -16,17 +16,22 @@ needs, so a consumer can pass generated values directly to ``RepoCommit`` and
 ``SignedRepoCommitVerifier``.
 
 ```swift
-var repository = RepoCommit()
-for operation in response.ops {
-  try repository.apply(operation)
-}
+let checkpoint = try RepoSyncCheckpoint(revision: persistedRevision, state: persistedState)
+var update = RepoIncrementalSync(checkpoint: checkpoint)
+try update.apply(response.ops)
 
 if let commit = response.commit {
-  try repository.verify(
+  let result = try update.finish(
     commit,
     context: RepoCommitContext(space: space, author: author, revision: revision),
     publicKey: authorKey
   )
+  switch result {
+  case .synchronized(let replacement):
+    // Persist replacement.revision and replacement.state atomically.
+  case .fullStateRecoveryRequired:
+    // Discard the candidate and restart from getRepo.
+  }
 }
 ```
 
@@ -43,13 +48,12 @@ let commit = try SignedRepoCommitVerifier.decode(
   Com.Atproto.SpaceDefs_SignedCommit.self,
   fromDRISL: car.signedCommitBlock.bytes
 )
-let repository = try RepoCommit(drislIndex: car.repositoryIndexBlock.bytes)
 let context = RepoCommitContext(
   space: expectedSpace,
   author: repositoryAuthor,
   revision: try TID(string: commit.permissionedRepoCommitRevision.rawValue)
 )
-try repository.verify(
+try car.repository.verify(
   commit,
   context: context,
   publicKey: authorPublicKey
@@ -58,6 +62,12 @@ try repository.verify(
 for try await record in car.recordBlocks {
   // Map the index-verified path and CID-verified value into consumer-owned storage.
 }
+let replacement = try car.repository.verifiedCheckpoint(
+  commit,
+  context: context,
+  publicKey: authorPublicKey
+)
+// Replace records and persist replacement only after the record stream reaches its end.
 ```
 
 The internal BLAKE3 implementation is upstream BLAKE3 1.8.7, distributed
@@ -73,6 +83,10 @@ see `THIRD_PARTY_NOTICES.md` in the package repository.
 - ``RepoCommit``
 - ``RepoRecord``
 - ``RepoOperation``
+- ``RepoSyncCheckpoint``
+- ``RepoIncrementalSync``
+- ``RepoIncrementalSyncResult``
+- ``RepoFullStateRecoveryReason``
 
 ### Full-state recovery
 

--- a/Sources/ATProtoSync/PermissionedRepoCAR.swift
+++ b/Sources/ATProtoSync/PermissionedRepoCAR.swift
@@ -52,6 +52,12 @@ public struct PermissionedRepoCAR: Sendable {
   /// The block matching the CAR's second, repository-index root.
   public let repositoryIndexBlock: PermissionedRepoCARBlock
 
+  /// The complete repository state reconstructed from the index entries.
+  ///
+  /// Authenticate this state against the decoded signed commit before treating
+  /// its paths and CIDs as an author claim.
+  public let repository: RepoCommit
+
   /// The remaining CID-verified record blocks.
   public let recordBlocks: RecordBlocks
 
@@ -88,6 +94,7 @@ public struct PermissionedRepoCAR: Sendable {
       return Self(
         signedCommitBlock: signedCommit,
         repositoryIndexBlock: repositoryIndex,
+        repository: RepoCommit(records: index.records),
         recordBlocks: RecordBlocks(
           reader: reader,
           records: index.records,

--- a/Sources/ATProtoSync/RepoSync.swift
+++ b/Sources/ATProtoSync/RepoSync.swift
@@ -1,0 +1,120 @@
+import ATProtoCrypto
+import Foundation
+import SwiftAtproto
+
+/// A durable, verified position in a Permissioned Data repository.
+public struct RepoSyncCheckpoint: Hashable, Sendable {
+  /// The revision authenticated by the repository's signed commit.
+  public let revision: TID
+
+  /// The repository state at ``revision``.
+  public let repository: RepoCommit
+
+  /// The serialized LtHash state for consumer-owned persistence.
+  public var state: Data { repository.setHash.state }
+
+  /// Restores a previously persisted checkpoint.
+  ///
+  /// Only restore bytes that the consumer persisted after successful
+  /// verification. This initializer validates the state representation, but
+  /// cannot re-authenticate a historical checkpoint without its signed commit.
+  public init(revision: TID, state: Data) throws {
+    self.revision = revision
+    self.repository = try RepoCommit(state: state)
+  }
+
+  init(revision: TID, repository: RepoCommit) {
+    self.revision = revision
+    self.repository = repository
+  }
+}
+
+/// Why incremental synchronization must restart from a complete repository CAR.
+public enum RepoFullStateRecoveryReason: Hashable, Sendable {
+  /// The incrementally reconstructed state did not match the authenticated head.
+  ///
+  /// The current Permissioned Data Lexicon has no distinct history-compaction
+  /// signal, so this also represents a missing operation or unavailable history.
+  case incrementalStateMismatch
+}
+
+/// The terminal result of verifying an incremental repository update.
+public enum RepoIncrementalSyncResult: Hashable, Sendable {
+  /// The candidate state matched the authenticated repository head.
+  case synchronized(RepoSyncCheckpoint)
+
+  /// The candidate state must be discarded and replaced from `getRepo`.
+  case fullStateRecoveryRequired(RepoFullStateRecoveryReason)
+}
+
+/// An uncommitted candidate state accumulated from incremental repository operations.
+///
+/// Create a fresh value from the last durable checkpoint, apply every page of
+/// `listRepoOps`, and call ``finish(_:context:publicKey:limits:)`` only after a
+/// response includes the head signed commit. The base checkpoint remains
+/// unchanged unless the returned result supplies a replacement.
+public struct RepoIncrementalSync: Hashable, Sendable {
+  /// The last durable checkpoint from which this update started.
+  public let checkpoint: RepoSyncCheckpoint
+
+  private var candidate: RepoCommit
+
+  /// Starts an incremental update from a durable checkpoint.
+  public init(checkpoint: RepoSyncCheckpoint) {
+    self.checkpoint = checkpoint
+    self.candidate = checkpoint.repository
+  }
+
+  /// Validates and applies one generated operation page transactionally.
+  ///
+  /// If any operation is malformed, none of the operations in this call are
+  /// retained in the candidate state.
+  public mutating func apply<Operations: Sequence>(_ operations: Operations) throws
+  where Operations.Element: PermissionedRepoOperationDescribing {
+    var updated = candidate
+    try updated.apply(operations)
+    candidate = updated
+  }
+
+  /// Authenticates the head commit and decides whether the candidate can be persisted.
+  ///
+  /// Signature, context, and MAC failures are thrown because recovery from the
+  /// same unauthenticated source cannot make them trustworthy. Only a valid
+  /// commit whose set hash differs from the candidate requests full recovery.
+  public func finish(
+    _ commit: any PermissionedRepoSignedCommitDescribing,
+    context: RepoCommitContext,
+    publicKey: PublicKey,
+    limits: RepoVerificationLimits = .init()
+  ) throws -> RepoIncrementalSyncResult {
+    try SignedRepoCommitVerifier.verify(
+      commit, context: context, publicKey: publicKey, limits: limits)
+    guard context.revision.rawValue >= checkpoint.revision.rawValue else {
+      throw RepoVerificationError.staleCommitRevision(
+        checkpoint: checkpoint.revision,
+        commit: context.revision)
+    }
+    guard candidate.matches(commit) else {
+      return .fullStateRecoveryRequired(.incrementalStateMismatch)
+    }
+    return .synchronized(
+      RepoSyncCheckpoint(revision: context.revision, repository: candidate))
+  }
+}
+
+extension RepoCommit {
+  /// Authenticates this complete state and returns a durable replacement checkpoint.
+  ///
+  /// For a state built from ``PermissionedRepoCAR/repository``, consume
+  /// ``PermissionedRepoCAR/recordBlocks`` through its `nil` terminator before
+  /// persisting the returned checkpoint alongside mapped record values.
+  public func verifiedCheckpoint(
+    _ commit: any PermissionedRepoSignedCommitDescribing,
+    context: RepoCommitContext,
+    publicKey: PublicKey,
+    limits: RepoVerificationLimits = .init()
+  ) throws -> RepoSyncCheckpoint {
+    try verify(commit, context: context, publicKey: publicKey, limits: limits)
+    return RepoSyncCheckpoint(revision: context.revision, repository: self)
+  }
+}

--- a/Sources/ATProtoSync/RepoVerification.swift
+++ b/Sources/ATProtoSync/RepoVerification.swift
@@ -131,6 +131,9 @@ public enum RepoVerificationError: Error, Hashable, Sendable {
 
   /// The local LtHash digest did not match the authenticated commit hash.
   case setHashMismatch
+
+  /// An incremental response tried to replace a newer durable checkpoint.
+  case staleCommitRevision(checkpoint: TID, commit: TID)
 }
 
 /// The identity and revision bound into a Permissioned Data signed commit.

--- a/Tests/ATProtoSyncTests/PermissionedRepoCARTests.swift
+++ b/Tests/ATProtoSyncTests/PermissionedRepoCARTests.swift
@@ -18,6 +18,15 @@ struct PermissionedRepoCARTests {
 
     #expect(car.signedCommitBlock.bytes == fixture.commitPayload)
     #expect(car.repositoryIndexBlock.bytes == fixture.indexPayload)
+    #expect(
+      car.repository
+        == RepoCommit(
+          records: [
+            RepoRecord(
+              collection: try NSID(string: "com.example.record"),
+              recordKey: try RecordKey(string: "first"),
+              cid: try Fixture.cid(for: fixture.recordPayloads[0]))
+          ]))
     #expect(source.snapshot == .init(pullCount: 3, isCancelled: false))
 
     var iterator = car.recordBlocks.makeAsyncIterator()

--- a/Tests/ATProtoSyncTests/RepoSyncTests.swift
+++ b/Tests/ATProtoSyncTests/RepoSyncTests.swift
@@ -1,0 +1,294 @@
+import ATProtoCrypto
+import Crypto
+import Foundation
+import SwiftAtproto
+import SwiftCbor
+import Testing
+
+@testable import ATProtoSync
+
+@Suite("Permissioned repository recovery")
+struct RepoSyncTests {
+  private let space = try! SpaceRef(
+    string: "at://did:plc:spaceauthority/space/com.example.project/demo")
+  private let author = try! SwiftAtproto.DID(string: "did:plc:alice")
+  private let baseRevision = try! TID(string: "3kbgyjzqfeq2e")
+  private let headRevision = try! TID(string: "3kbgyjzqfeq2f")
+  private let key = try! PrivateKey(
+    type: .ed25519, rawValue: Data(repeating: 9, count: 32))
+  private let first = RepoRecord(
+    collection: try! NSID(string: "com.example.record"),
+    recordKey: try! RecordKey(string: "first"),
+    cid: try! LexLink("bafyreidefdycgbfy3oglcb6ism3eqhyp5llsrpzxjsuac2gsy4mtrtx244"))
+  private let second = RepoRecord(
+    collection: try! NSID(string: "com.example.record"),
+    recordKey: try! RecordKey(string: "second"),
+    cid: try! LexLink("bafyreidpw4cbv6gr4ukh33z23pvvrpr3wi4gnpmi4doamlsl3sa4rgri2a"))
+
+  @Test("advances a durable checkpoint after incremental verification")
+  func advancesCheckpoint() throws {
+    let checkpoint = try restoredCheckpoint(records: [first])
+    var update = RepoIncrementalSync(checkpoint: checkpoint)
+    try update.apply([SyncStubOperation(record: second, previousCID: nil)])
+    let repository = RepoCommit(records: [first, second])
+    let context = headContext()
+    let commit = try signedCommit(repository: repository, context: context)
+
+    let result = try update.finish(
+      commit, context: context, publicKey: key.publicKey)
+    let replacement: RepoSyncCheckpoint
+    switch result {
+    case .synchronized(let value):
+      replacement = value
+    case .fullStateRecoveryRequired:
+      Issue.record("matching incremental state requested full recovery")
+      return
+    }
+
+    #expect(replacement.revision == headRevision)
+    #expect(replacement.repository == repository)
+    #expect(try RepoSyncCheckpoint(revision: headRevision, state: replacement.state) == replacement)
+    #expect(checkpoint.repository == RepoCommit(records: [first]))
+  }
+
+  @Test("maps missing history to full-state recovery")
+  func requiresRecoveryForMissingHistory() throws {
+    let checkpoint = try restoredCheckpoint(records: [first])
+    let update = RepoIncrementalSync(checkpoint: checkpoint)
+    let context = headContext()
+    let commit = try signedCommit(
+      repository: RepoCommit(records: [first, second]), context: context)
+
+    #expect(
+      try update.finish(commit, context: context, publicKey: key.publicKey)
+        == .fullStateRecoveryRequired(.incrementalStateMismatch))
+  }
+
+  @Test("maps a divergent local state to the same recovery result")
+  func requiresRecoveryForDivergentState() throws {
+    let checkpoint = try restoredCheckpoint(records: [first])
+    var update = RepoIncrementalSync(checkpoint: checkpoint)
+    try update.apply([SyncStubOperation(record: second, previousCID: nil)])
+    let context = headContext()
+    let commit = try signedCommit(repository: RepoCommit(records: [first]), context: context)
+
+    #expect(
+      try update.finish(commit, context: context, publicKey: key.publicKey)
+        == .fullStateRecoveryRequired(.incrementalStateMismatch))
+  }
+
+  @Test("does not classify an unauthenticated commit as recoverable")
+  func rejectsUnauthenticatedCommit() throws {
+    let checkpoint = try restoredCheckpoint(records: [first])
+    let update = RepoIncrementalSync(checkpoint: checkpoint)
+    let context = headContext()
+    var commit = try signedCommit(repository: checkpoint.repository, context: context)
+    commit.mac[0] ^= 0xff
+
+    #expect(throws: RepoVerificationError.macMismatch) {
+      try update.finish(commit, context: context, publicKey: key.publicKey)
+    }
+  }
+
+  @Test("rejects a commit older than the durable checkpoint")
+  func rejectsStaleCommit() throws {
+    let checkpoint = try RepoSyncCheckpoint(
+      revision: headRevision,
+      state: RepoCommit(records: [first]).setHash.state)
+    let update = RepoIncrementalSync(checkpoint: checkpoint)
+    let context = RepoCommitContext(space: space, author: author, revision: baseRevision)
+    let commit = try signedCommit(repository: checkpoint.repository, context: context)
+
+    #expect(
+      throws: RepoVerificationError.staleCommitRevision(
+        checkpoint: headRevision, commit: baseRevision)
+    ) {
+      try update.finish(commit, context: context, publicKey: key.publicKey)
+    }
+  }
+
+  @Test("applies each operation page transactionally")
+  func rejectsAnEntireMalformedPage() throws {
+    let checkpoint = try restoredCheckpoint(records: [first])
+    var update = RepoIncrementalSync(checkpoint: checkpoint)
+    let malformed = SyncStubOperation(
+      collection: "not-an-nsid", recordKey: "bad", cid: nil, previousCID: nil)
+
+    #expect(throws: RepoVerificationError.malformedOperation) {
+      try update.apply([
+        SyncStubOperation(record: second, previousCID: nil),
+        malformed,
+      ])
+    }
+
+    let context = headContext()
+    let commit = try signedCommit(repository: checkpoint.repository, context: context)
+    #expect(
+      try update.finish(commit, context: context, publicKey: key.publicKey)
+        == .synchronized(
+          RepoSyncCheckpoint(revision: headRevision, repository: checkpoint.repository)))
+  }
+
+  @Test("creates a replacement checkpoint from a verified full state")
+  func createsFullStateCheckpoint() throws {
+    let repository = RepoCommit(records: [first, second])
+    let context = headContext()
+    let commit = try signedCommit(repository: repository, context: context)
+
+    let checkpoint = try repository.verifiedCheckpoint(
+      commit, context: context, publicKey: key.publicKey)
+
+    #expect(checkpoint.revision == headRevision)
+    #expect(checkpoint.repository == repository)
+    #expect(checkpoint.state == repository.setHash.state)
+  }
+
+  @Test("replaces a checkpoint after consuming a verified repository CAR")
+  func replacesCheckpointFromCAR() async throws {
+    let recordPayload = try CborEncoder(
+      options: .lexicographicallySortedMapKeys
+    ).encode(["text": "hello"])
+    let recordCID = try carCID(for: recordPayload)
+    let record = RepoRecord(
+      collection: try NSID(string: "com.example.record"),
+      recordKey: try RecordKey(string: "car"),
+      cid: recordCID)
+    let repository = RepoCommit(records: [record])
+    let context = headContext()
+    let commit = try signedCommit(repository: repository, context: context)
+    let commitPayload = try CborEncoder(
+      options: .lexicographicallySortedMapKeys
+    ).encode(commit)
+    let indexPayload = try CborEncoder(
+      options: .lexicographicallySortedMapKeys,
+      allowedTags: [42]
+    ).encode(["com.example.record/car": recordCID])
+    let commitCID = try carCID(for: commitPayload)
+    let indexCID = try carCID(for: indexPayload)
+    let carBytes =
+      try carHeader(roots: [commitCID, indexCID])
+      + carBlock(cid: commitCID, payload: commitPayload)
+      + carBlock(cid: indexCID, payload: indexPayload)
+      + carBlock(cid: recordCID, payload: recordPayload)
+
+    let car = try await PermissionedRepoCAR.read(from: XRPCBody(carBytes))
+    let decoded = try SignedRepoCommitVerifier.decode(
+      SyncTestSignedCommit.self,
+      fromDRISL: car.signedCommitBlock.bytes)
+    try car.repository.verify(decoded, context: context, publicKey: key.publicKey)
+
+    var records = car.recordBlocks.makeAsyncIterator()
+    #expect(try await records.next()?.bytes == recordPayload)
+    #expect(try await records.next() == nil)
+
+    let replacement = try car.repository.verifiedCheckpoint(
+      decoded, context: context, publicKey: key.publicKey)
+    #expect(replacement.revision == headRevision)
+    #expect(replacement.repository == repository)
+  }
+
+  private func restoredCheckpoint(records: [RepoRecord]) throws -> RepoSyncCheckpoint {
+    try RepoSyncCheckpoint(
+      revision: baseRevision,
+      state: RepoCommit(records: records).setHash.state)
+  }
+
+  private func headContext() -> RepoCommitContext {
+    RepoCommitContext(space: space, author: author, revision: headRevision)
+  }
+
+  private func signedCommit(
+    repository: RepoCommit,
+    context: RepoCommitContext
+  ) throws -> SyncTestSignedCommit {
+    let inputKeyMaterial = Data((0..<32).map(UInt8.init))
+    let contextBytes = try context.encoded(inputKeyMaterial: inputKeyMaterial)
+    let macKey = HKDF<SHA256>.expand(
+      pseudoRandomKey: SymmetricKey(data: inputKeyMaterial),
+      info: contextBytes,
+      outputByteCount: 32)
+    let hash = repository.setHash.digest
+    return SyncTestSignedCommit(
+      ver: 1,
+      hash: hash,
+      ikm: inputKeyMaterial,
+      sig: try key.sign(contextBytes),
+      mac: Data(HMAC<SHA256>.authenticationCode(for: hash, using: macKey)),
+      rev: .init(rawValue: context.revision.rawValue))
+  }
+
+  private func carCID(for payload: Data) throws -> LexLink {
+    try LexLink(
+      Data([0x01, 0x71, 0x12, 0x20])
+        + Data(SHA256.hash(data: payload)))
+  }
+
+  private func carHeader(roots: [LexLink]) throws -> Data {
+    let payload = try CborEncoder(
+      options: .lexicographicallySortedMapKeys,
+      allowedTags: [42]
+    ).encode(SyncCARHeader(roots: roots, version: 1))
+    return unsignedVarint(UInt64(payload.count)) + payload
+  }
+
+  private func carBlock(cid: LexLink, payload: Data) -> Data {
+    let cidBytes = Data(cid.cid.rawBuffer)
+    return unsignedVarint(UInt64(cidBytes.count + payload.count)) + cidBytes + payload
+  }
+
+  private func unsignedVarint(_ input: UInt64) -> Data {
+    var value = input
+    var result = Data()
+    repeat {
+      var byte = UInt8(value & 0x7f)
+      value >>= 7
+      if value != 0 { byte |= 0x80 }
+      result.append(byte)
+    } while value != 0
+    return result
+  }
+}
+
+private struct SyncTestSignedCommit: Codable, Hashable, PermissionedRepoSignedCommitDescribing {
+  var ver: Int
+  var hash: Data
+  var ikm: Data
+  var sig: Data
+  var mac: Data
+  var rev: FormatString<TID>
+
+  var permissionedRepoCommitVersion: Int { ver }
+  var permissionedRepoCommitHash: Data { hash }
+  var permissionedRepoCommitInputKeyMaterial: Data { ikm }
+  var permissionedRepoCommitSignature: Data { sig }
+  var permissionedRepoCommitMAC: Data { mac }
+  var permissionedRepoCommitRevision: FormatString<TID> { rev }
+}
+
+private struct SyncCARHeader: Encodable {
+  let roots: [LexLink]
+  let version: Int
+}
+
+private struct SyncStubOperation: PermissionedRepoOperationDescribing {
+  let permissionedRepoOperationCollection: FormatString<NSID>
+  let permissionedRepoOperationRecordKey: FormatString<RecordKey>
+  let permissionedRepoOperationCID: FormatString<LexLink>?
+  let permissionedRepoOperationPreviousCID: FormatString<LexLink>?
+
+  init(record: RepoRecord, previousCID: LexLink?) {
+    self.init(
+      collection: record.collection.rawValue,
+      recordKey: record.recordKey.rawValue,
+      cid: record.cid.toBaseEncodedString,
+      previousCID: previousCID?.toBaseEncodedString)
+  }
+
+  init(collection: String, recordKey: String, cid: String?, previousCID: String?) {
+    permissionedRepoOperationCollection = .init(rawValue: collection)
+    permissionedRepoOperationRecordKey = .init(rawValue: recordKey)
+    permissionedRepoOperationCID = cid.map(FormatString<LexLink>.init(rawValue:))
+    permissionedRepoOperationPreviousCID = previousCID.map(
+      FormatString<LexLink>.init(rawValue:))
+  }
+}


### PR DESCRIPTION
Add verified repository checkpoints and an incremental sync result that directs state mismatches to full-state recovery. Document and test safe checkpoint replacement from incremental operations and streamed repository CARs.