### PR TITLE
feat: stream non-JSON XRPC server responses

### DIFF
--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -39,7 +39,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
   var contentType: String {
     if let input {
       switch input.encoding {
-      case .json, .jsonl, .text, .mp4:
+      case .json, .jsonl, .text, .mp4, .other:
         return input.encoding.rawValue
       case .cbor, .any, .car:
         return "*/*"
@@ -89,7 +89,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
             rightParen: .rightParenToken()
           )
         )
-      case .cbor, .car, .any, .mp4:
+      case .cbor, .car, .any, .mp4, .other:
         return EnumCaseElementSyntax(
           name: .identifier("binary"),
           parameterClause: EnumCaseParameterClauseSyntax(
@@ -128,7 +128,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         return Lex.typeSyntax("Swift.String")
       case .any:
         return Lex.typeSyntax("SwiftAtproto.XRPCBlobUpload")
-      case .cbor, .car, .mp4:
+      case .cbor, .car, .mp4, .other:
         return Lex.typeSyntax("Foundation.Data")
       }
     }
@@ -154,7 +154,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         return Lex.typeSyntax(token)
       case .text:
         return Lex.typeSyntax("Swift.String")
-      case .cbor, .car, .any, .mp4:
+      case .cbor, .car, .any, .mp4, .other:
         return Lex.typeSyntax("Foundation.Data")
       }
     }
@@ -168,7 +168,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
     case .any:
       let tname = "SwiftAtproto.XRPCBlobUpload"
       arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
-    case .cbor, .car, .mp4:
+    case .cbor, .car, .mp4, .other:
       let tname = "Foundation.Data"
       arguments.append(.init(firstName: .identifier("input"), type: TypeSyntax(stringLiteral: tname)))
     case .text:

--- a/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/ProcedureTypeDefinition.swift
@@ -213,6 +213,10 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
   func generateDeclaration(leadingTrivia: SwiftSyntax.Trivia?, ts: TypeSchema, name: String, type: String, defMap: ExtDefMap, generate: GenerateOption) -> any DeclSyntaxProtocol {
     let prefix = Lex.structNameFor(prefix: ts.prefix)
     let responseBody = responseBody(fname: name, defMap: defMap, prefix: Lex.structNameFor(prefix: ts.prefix))
+    let usesRawServerBody = output?.usesRawServerBody == true
+    let requiresExplicitContentType = output?.requiresExplicitContentType == true
+    let outputBodyCaseName = usesRawServerBody ? "binary" : "json"
+    let serverResponseBody: TypeSyntax = usesRawServerBody ? Lex.typeSyntax("OpenAPIRuntime.HTTPBody") : responseBody
     return EnumDeclSyntax(
       modifiers: [
         declModifierSyntax
@@ -453,14 +457,20 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                         leadingTrivia: .newline,
                                         elements: EnumCaseElementListSyntax([
                                           EnumCaseElementSyntax(
-                                            name: .identifier("json"),
+                                            name: .identifier(outputBodyCaseName),
                                             parameterClause: EnumCaseParameterClauseSyntax(
                                               leftParen: .leftParenToken(),
-                                              parameters: EnumCaseParameterListSyntax([
+                                              parameters: EnumCaseParameterListSyntax {
                                                 EnumCaseParameterSyntax(
-                                                  type: TypeSyntax(responseBody)
+                                                  type: serverResponseBody
                                                 )
-                                              ]),
+                                                if requiresExplicitContentType {
+                                                  EnumCaseParameterSyntax(
+                                                    firstName: .identifier("contentType"),
+                                                    colon: .colonToken(),
+                                                    type: Lex.typeSyntax("Swift.String"))
+                                                }
+                                              },
                                               rightParen: .rightParenToken()
                                             )
                                           )
@@ -475,10 +485,10 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                         bindingSpecifier: .keyword(.var),
                                         bindings: PatternBindingListSyntax([
                                           PatternBindingSyntax(
-                                            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("json"))),
+                                            pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier(outputBodyCaseName))),
                                             typeAnnotation: TypeAnnotationSyntax(
                                               colon: .colonToken(),
-                                              type: TypeSyntax(responseBody)
+                                              type: serverResponseBody
                                             ),
                                             accessorBlock: AccessorBlockSyntax(
                                               leftBrace: .leftBraceToken(),
@@ -510,7 +520,7 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                                                                   FunctionCallExprSyntax(
                                                                                     callee: MemberAccessExprSyntax(
                                                                                       period: .periodToken(),
-                                                                                      declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                                                                      declName: DeclReferenceExprSyntax(baseName: .identifier(outputBodyCaseName))
                                                                                     )
                                                                                   ) {
                                                                                     LabeledExprSyntax(
@@ -519,6 +529,12 @@ struct ProcedureTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                                                                           bindingSpecifier: .keyword(.let),
                                                                                           pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("body")))
                                                                                         )))
+                                                                                    if requiresExplicitContentType {
+                                                                                      LabeledExprSyntax(
+                                                                                        label: .identifier("contentType"),
+                                                                                        colon: .colonToken(),
+                                                                                        expression: PatternExprSyntax(pattern: WildcardPatternSyntax()))
+                                                                                    }
                                                                                   }
                                                                                 ))))
                                                                         ]),

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -617,6 +617,10 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
 
   private func genQueryOutput(ts: TypeSchema, name: String, type: String, prefix: String, defMap: ExtDefMap) -> EnumDeclSyntax {
     let prefix = Lex.structNameFor(prefix: ts.prefix)
+    let usesRawServerBody = output?.usesRawServerBody == true
+    let requiresExplicitContentType = output?.requiresExplicitContentType == true
+    let bodyCaseName = usesRawServerBody ? "binary" : "json"
+    let bodyType = usesRawServerBody ? "OpenAPIRuntime.HTTPBody" : "ResponseBody"
     return EnumDeclSyntax(
       attributes: [
         AttributeListSyntax.Element(
@@ -654,10 +658,10 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
             bindingSpecifier: .keyword(.var),
             bindings: PatternBindingListSyntax([
               PatternBindingSyntax(
-                pattern: IdentifierPatternSyntax(identifier: .identifier("json")),
+                pattern: IdentifierPatternSyntax(identifier: .identifier(bodyCaseName)),
                 typeAnnotation: TypeAnnotationSyntax(
                   colon: .colonToken(),
-                  type: IdentifierTypeSyntax(name: .identifier("ResponseBody"))
+                  type: Lex.typeSyntax(bodyType)
                 ),
                 accessorBlock: AccessorBlockSyntax(
                   leftBrace: .leftBraceToken(),
@@ -681,10 +685,16 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
                                       expression: FunctionCallExprSyntax(
                                         callee: MemberAccessExprSyntax(
                                           period: .periodToken(),
-                                          declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                                          declName: DeclReferenceExprSyntax(baseName: .identifier(bodyCaseName))
                                         )
                                       ) {
                                         LabeledExprSyntax(expression: PatternExprSyntax(pattern: ValueBindingPatternSyntax(bindingSpecifier: .keyword(.let), pattern: IdentifierPatternSyntax(identifier: .identifier("body")))))
+                                        if requiresExplicitContentType {
+                                          LabeledExprSyntax(
+                                            label: .identifier("contentType"),
+                                            colon: .colonToken(),
+                                            expression: PatternExprSyntax(pattern: WildcardPatternSyntax()))
+                                        }
                                       }
                                     ))
                                 ]),
@@ -927,18 +937,24 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
   }
 
   private func genQueryOutputBody(ts: TypeSchema, name: String, type: String, prefix: String, defMap: ExtDefMap) -> EnumCaseDeclSyntax {
-    EnumCaseDeclSyntax(
+    let usesRawServerBody = output?.usesRawServerBody == true
+    let requiresExplicitContentType = output?.requiresExplicitContentType == true
+    return EnumCaseDeclSyntax(
       leadingTrivia: .newline,
       elements: EnumCaseElementListSyntax([
         EnumCaseElementSyntax(
-          name: .identifier("json"),
+          name: .identifier(usesRawServerBody ? "binary" : "json"),
           parameterClause: EnumCaseParameterClauseSyntax(
             leftParen: .leftParenToken(),
-            parameters: EnumCaseParameterListSyntax([
-              EnumCaseParameterSyntax(
-                type: IdentifierTypeSyntax(name: .identifier("ResponseBody"))
-              )
-            ]),
+            parameters: EnumCaseParameterListSyntax {
+              EnumCaseParameterSyntax(type: Lex.typeSyntax(usesRawServerBody ? "OpenAPIRuntime.HTTPBody" : "ResponseBody"))
+              if requiresExplicitContentType {
+                EnumCaseParameterSyntax(
+                  firstName: .identifier("contentType"),
+                  colon: .colonToken(),
+                  type: Lex.typeSyntax("Swift.String"))
+              }
+            },
             rightParen: .rightParenToken()
           )
         )

--- a/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
+++ b/Sources/SwiftAtprotoLex/Definitions/QueryTypeDefinition.swift
@@ -118,7 +118,7 @@ struct QueryTypeDefinition: HTTPAPITypeDefinition, SwiftCodeGeneratable {
         return Lex.typeSyntax("\(prefix).\(outname)")
       case .text:
         return Lex.typeSyntax("Swift.String")
-      case .cbor, .car, .any, .mp4:
+      case .cbor, .car, .any, .mp4, .other:
         return Lex.typeSyntax("Foundation.Data")
       }
     }

--- a/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
+++ b/Sources/SwiftAtprotoLex/SwiftAtprotoLex+Server.swift
@@ -538,7 +538,7 @@ extension Lex {
             LabeledExprSyntax(
               label: .identifier("serializer", leadingTrivia: .newline),
               colon: .colonToken(),
-              expression: makeSerializerExpr()
+              expression: makeSerializerExpr(output: def.output)
             )
           }
           .with(\.rightParen, .rightParenToken(leadingTrivia: .newline))
@@ -816,9 +816,92 @@ extension Lex {
       )
     }
   }
-  /// `serializer`
-  private static func makeSerializerExpr() -> ClosureExprSyntax {
-    ClosureExprSyntax(signaturesBuilder: {
+  /// Creates the response serializer for an operation.
+  private static func makeSerializerExpr(output: OutputType?) -> ClosureExprSyntax {
+    let usesRawServerBody = output?.usesRawServerBody == true
+    let requiresExplicitContentType = output?.requiresExplicitContentType == true
+    let contentType = output?.encoding.rawValue ?? "application/json"
+    let responseContentType: ExprSyntax =
+      requiresExplicitContentType
+      ? ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("contentType")))
+      : ExprSyntax(StringLiteralExprSyntax(content: contentType))
+    func binaryBodyPattern(requiresExplicitContentType: Bool) -> ExpressionPatternSyntax {
+      ExpressionPatternSyntax(
+        expression: FunctionCallExprSyntax(
+          callee: MemberAccessExprSyntax(
+            period: .periodToken(),
+            declName: DeclReferenceExprSyntax(baseName: .identifier("binary"))
+          )
+        ) {
+          LabeledExprSyntax(
+            expression: PatternExprSyntax(
+              pattern: ValueBindingPatternSyntax(
+                bindingSpecifier: .keyword(.let),
+                pattern: IdentifierPatternSyntax(identifier: .identifier("value"))
+              )))
+          if requiresExplicitContentType {
+            LabeledExprSyntax(
+              label: .identifier("contentType"),
+              colon: .colonToken(),
+              expression: PatternExprSyntax(
+                pattern: ValueBindingPatternSyntax(
+                  bindingSpecifier: .keyword(.let),
+                  pattern: IdentifierPatternSyntax(identifier: .identifier("contentType"))
+                )))
+          }
+        })
+    }
+    func unwrapBinaryBody(requiresExplicitContentType: Bool) -> GuardStmtSyntax {
+      GuardStmtSyntax(
+        leadingTrivia: .newline,
+        conditions: ConditionElementListSyntax {
+          MatchingPatternConditionSyntax(
+            pattern: binaryBodyPattern(requiresExplicitContentType: requiresExplicitContentType),
+            initializer: InitializerClauseSyntax(
+              equal: .equalToken(),
+              value: MemberAccessExprSyntax(parts: [.identifier("value"), .identifier("body")])
+            ))
+        }
+      ) {
+        FunctionCallExprSyntax(
+          callee: DeclReferenceExprSyntax(baseName: .identifier("preconditionFailure"))
+        ) {
+          LabeledExprSyntax(
+            expression: StringLiteralExprSyntax(
+              content: "Generated non-JSON response has an incompatible body case"))
+        }
+      }
+    }
+    func validateAccept(_ contentType: ExprSyntax) -> TryExprSyntax {
+      TryExprSyntax(
+        expression: FunctionCallExprSyntax(
+          callee: MemberAccessExprSyntax(parts: [
+            .identifier("converter"),
+            .identifier("validateAcceptIfPresent"),
+          ])
+        ) {
+          LabeledExprSyntax(expression: contentType)
+          LabeledExprSyntax(
+            label: .identifier("in"),
+            colon: .colonToken(),
+            expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")]))
+        })
+    }
+    func setResponseContentType(_ contentType: ExprSyntax) -> SequenceExprSyntax {
+      SequenceExprSyntax {
+        SubscriptCallExprSyntax(
+          calledExpression: MemberAccessExprSyntax(parts: [.identifier("response"), .identifier("headerFields")])
+        ) {
+          LabeledExprSyntax(
+            expression: MemberAccessExprSyntax(
+              period: .periodToken(),
+              declName: DeclReferenceExprSyntax(baseName: .identifier("contentType"))))
+        }
+        AssignmentExprSyntax(equal: .equalToken())
+        contentType
+      }
+    }
+    return ClosureExprSyntax(signaturesBuilder: {
       ClosureShorthandParameterSyntax(name: .identifier("output"))
       ClosureShorthandParameterSyntax(name: .identifier("request"))
     }) {
@@ -847,12 +930,14 @@ extension Lex {
             }
           )
         ) {
-          FunctionCallExprSyntax(
-            callee: DeclReferenceExprSyntax(baseName: .identifier("suppressUnusedWarning"))
-          ) {
-            LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("value"))))
+          if !usesRawServerBody {
+            FunctionCallExprSyntax(
+              callee: DeclReferenceExprSyntax(baseName: .identifier("suppressUnusedWarning"))
+            ) {
+              LabeledExprSyntax(expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("value"))))
+            }
+            .with(\.leadingTrivia, .newline)
           }
-          .with(\.leadingTrivia, .newline)
           VariableDeclSyntax(
             leadingTrivia: .newline,
             bindingSpecifier: .keyword(.var),
@@ -874,14 +959,16 @@ extension Lex {
               )
             ]
           )
-          FunctionCallExprSyntax(
-            callee: DeclReferenceExprSyntax(baseName: .identifier("suppressMutabilityWarning", leadingTrivia: .newline))
-          ) {
-            LabeledExprSyntax(
-              expression: InOutExprSyntax(
-                ampersand: .prefixAmpersandToken(),
-                expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("response")))
-              ))
+          if !usesRawServerBody {
+            FunctionCallExprSyntax(
+              callee: DeclReferenceExprSyntax(baseName: .identifier("suppressMutabilityWarning", leadingTrivia: .newline))
+            ) {
+              LabeledExprSyntax(
+                expression: InOutExprSyntax(
+                  ampersand: .prefixAmpersandToken(),
+                  expression: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("response")))
+                ))
+            }
           }
           VariableDeclSyntax(
             bindingSpecifier: .keyword(.let, leadingTrivia: .newline),
@@ -899,95 +986,109 @@ extension Lex {
               )
             ])
           )
-          ExpressionStmtSyntax(
-            expression: SwitchExprSyntax(
-              leadingTrivia: .newline,
-              subject: MemberAccessExprSyntax(parts: [.identifier("value"), .identifier("body")])
-            ) {
-              SwitchCaseSyntax(
-                label: SwitchCaseSyntax.Label(
-                  SwitchCaseLabelSyntax(
-                    leadingTrivia: .newline
-                  ) {
-                    SwitchCaseItemSyntax(
-                      pattern: ExpressionPatternSyntax(
-                        expression: FunctionCallExprSyntax(
-                          callee: MemberAccessExprSyntax(
-                            period: .periodToken(),
-                            declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
-                          )
-                        ) {
-                          LabeledExprSyntax(
-                            expression: PatternExprSyntax(
-                              pattern: ValueBindingPatternSyntax(
-                                bindingSpecifier: .keyword(.let),
-                                pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("value")))
-                              )))
-                        }
-                      ))
-                  }
-                )
+          .with(\.trailingTrivia, .newline)
+          if usesRawServerBody {
+            unwrapBinaryBody(requiresExplicitContentType: requiresExplicitContentType)
+            validateAccept(responseContentType)
+              .with(\.leadingTrivia, .newline)
+            setResponseContentType(responseContentType)
+              .with(\.leadingTrivia, .newline)
+            SequenceExprSyntax {
+              DeclReferenceExprSyntax(leadingTrivia: .newline, baseName: .identifier("body"))
+              AssignmentExprSyntax(equal: .equalToken())
+              DeclReferenceExprSyntax(baseName: .identifier("value"))
+            }
+          } else {
+            ExpressionStmtSyntax(
+              expression: SwitchExprSyntax(
+                leadingTrivia: .newline,
+                subject: MemberAccessExprSyntax(parts: [.identifier("value"), .identifier("body")])
               ) {
-                TryExprSyntax(
-                  leadingTrivia: .newline,
-                  expression: FunctionCallExprSyntax(
-                    callee: MemberAccessExprSyntax(parts: [
-                      .identifier("converter"),
-                      .identifier("validateAcceptIfPresent"),
-                    ])
-                  ) {
-                    LabeledExprSyntax(
-                      leadingTrivia: .newline,
-                      expression: StringLiteralExprSyntax(content: "application/json")
-                    )
-                    LabeledExprSyntax(
-                      label: .identifier("in", leadingTrivia: .newline),
-                      colon: .colonToken(),
-                      expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")])
-                    )
-                  }
-                  .with(\.rightParen, .rightParenToken(leadingTrivia: .newline))
-                )
-                SequenceExprSyntax {
-                  DeclReferenceExprSyntax(
-                    leadingTrivia: .newline,
-                    baseName: .identifier("body"))
-                  AssignmentExprSyntax(equal: .equalToken())
+                SwitchCaseSyntax(
+                  label: SwitchCaseSyntax.Label(
+                    SwitchCaseLabelSyntax(
+                      leadingTrivia: .newline
+                    ) {
+                      SwitchCaseItemSyntax(
+                        pattern: ExpressionPatternSyntax(
+                          expression: FunctionCallExprSyntax(
+                            callee: MemberAccessExprSyntax(
+                              period: .periodToken(),
+                              declName: DeclReferenceExprSyntax(baseName: .identifier("json"))
+                            )
+                          ) {
+                            LabeledExprSyntax(
+                              expression: PatternExprSyntax(
+                                pattern: ValueBindingPatternSyntax(
+                                  bindingSpecifier: .keyword(.let),
+                                  pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("value")))
+                                )))
+                          }
+                        ))
+                    }
+                  )
+                ) {
                   TryExprSyntax(
+                    leadingTrivia: .newline,
                     expression: FunctionCallExprSyntax(
-                      callee: MemberAccessExprSyntax(
-                        base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("converter"))),
-                        period: .periodToken(),
-                        declName: DeclReferenceExprSyntax(baseName: .identifier("setResponseBodyAsJSON"))
-                      )
+                      callee: MemberAccessExprSyntax(parts: [
+                        .identifier("converter"),
+                        .identifier("validateAcceptIfPresent"),
+                      ])
                     ) {
                       LabeledExprSyntax(
                         leadingTrivia: .newline,
-                        expression: DeclReferenceExprSyntax(baseName: .identifier("value")),
+                        expression: StringLiteralExprSyntax(content: "application/json")
                       )
                       LabeledExprSyntax(
-                        leadingTrivia: .newline,
-                        label: .identifier("headerFields"),
+                        label: .identifier("in", leadingTrivia: .newline),
                         colon: .colonToken(),
-                        expression: InOutExprSyntax(
-                          ampersand: .prefixAmpersandToken(),
-                          expression: MemberAccessExprSyntax(parts: [.identifier("response"), .identifier("headerFields")])
-                        )
-                      )
-                      LabeledExprSyntax(
-                        leadingTrivia: .newline,
-                        label: .identifier("contentType"),
-                        colon: .colonToken(),
-                        expression: StringLiteralExprSyntax(content: "application/json; charset=utf-8")
+                        expression: MemberAccessExprSyntax(parts: [.identifier("request"), .identifier("headerFields")])
                       )
                     }
                     .with(\.rightParen, .rightParenToken(leadingTrivia: .newline))
                   )
+                  SequenceExprSyntax {
+                    DeclReferenceExprSyntax(
+                      leadingTrivia: .newline,
+                      baseName: .identifier("body"))
+                    AssignmentExprSyntax(equal: .equalToken())
+                    TryExprSyntax(
+                      expression: FunctionCallExprSyntax(
+                        callee: MemberAccessExprSyntax(
+                          base: ExprSyntax(DeclReferenceExprSyntax(baseName: .identifier("converter"))),
+                          period: .periodToken(),
+                          declName: DeclReferenceExprSyntax(baseName: .identifier("setResponseBodyAsJSON"))
+                        )
+                      ) {
+                        LabeledExprSyntax(
+                          leadingTrivia: .newline,
+                          expression: DeclReferenceExprSyntax(baseName: .identifier("value")),
+                        )
+                        LabeledExprSyntax(
+                          leadingTrivia: .newline,
+                          label: .identifier("headerFields"),
+                          colon: .colonToken(),
+                          expression: InOutExprSyntax(
+                            ampersand: .prefixAmpersandToken(),
+                            expression: MemberAccessExprSyntax(parts: [.identifier("response"), .identifier("headerFields")])
+                          )
+                        )
+                        LabeledExprSyntax(
+                          leadingTrivia: .newline,
+                          label: .identifier("contentType"),
+                          colon: .colonToken(),
+                          expression: StringLiteralExprSyntax(content: "application/json; charset=utf-8")
+                        )
+                      }
+                      .with(\.rightParen, .rightParenToken(leadingTrivia: .newline))
+                    )
+                  }
                 }
               }
-            }
-            .with(\.rightBrace, .rightBraceToken(leadingTrivia: .newline))
-          )
+              .with(\.rightBrace, .rightBraceToken(leadingTrivia: .newline))
+            )
+          }
           ReturnStmtSyntax(
             leadingTrivia: .newline,
             expression: ExprSyntax(

--- a/Sources/SwiftAtprotoLex/TypeSchema.swift
+++ b/Sources/SwiftAtprotoLex/TypeSchema.swift
@@ -728,22 +728,43 @@ struct RecordSchema {
   let nullable: [String]?
 }
 
-enum EncodingType: String, Codable {
-  case cbor = "application/cbor"
-  case json = "application/json"
-  case jsonl = "application/jsonl"
-  case car = "application/vnd.ipld.car"
-  case text = "text/plain"
-  case mp4 = "video/mp4"
-  case any = "*/*"
+enum EncodingType: Codable, Equatable {
+  case cbor
+  case json
+  case jsonl
+  case car
+  case text
+  case mp4
+  case any
+  case other(String)
+
+  var rawValue: String {
+    switch self {
+    case .cbor: "application/cbor"
+    case .json: "application/json"
+    case .jsonl: "application/jsonl"
+    case .car: "application/vnd.ipld.car"
+    case .text: "text/plain"
+    case .mp4: "video/mp4"
+    case .any: "*/*"
+    case .other(let rawValue): rawValue
+    }
+  }
 
   init(from decoder: Decoder) throws {
     let rawValue = try String(from: decoder)
 
-    guard let value = EncodingType(rawValue: rawValue) else {
-      throw DecodingError.dataCorrupted(.init(codingPath: decoder.codingPath, debugDescription: "unexpected mimetype: \(rawValue.debugDescription)"))
-    }
-    self = value
+    self =
+      switch rawValue {
+      case "application/cbor": .cbor
+      case "application/json": .json
+      case "application/jsonl": .jsonl
+      case "application/vnd.ipld.car": .car
+      case "text/plain": .text
+      case "video/mp4": .mp4
+      case "*/*": .any
+      default: .other(rawValue)
+      }
   }
 
   func encode(to encoder: Encoder) throws {
@@ -781,18 +802,26 @@ struct OutputType: Encodable, DecodableWithConfiguration {
       return token
     case .text:
       return "Swift.String"
-    case .cbor, .car, .any, .mp4:
+    case .cbor, .car, .any, .mp4, .other:
       return binaryTypeName
     }
   }
 
   var isBinary: Bool {
     switch encoding {
-    case .cbor, .car, .any, .mp4:
+    case .cbor, .car, .any, .mp4, .other:
       true
     default:
       false
     }
+  }
+
+  var usesRawServerBody: Bool {
+    encoding != .json
+  }
+
+  var requiresExplicitContentType: Bool {
+    encoding == .any
   }
 }
 

--- a/Tests/SwiftAtprotoLexTests/BinaryResponseStreamingGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/BinaryResponseStreamingGenerationTests.swift
@@ -6,6 +6,16 @@ import Testing
 
 @Suite("Binary response streaming generation")
 struct BinaryResponseStreamingGenerationTests {
+  @Test("preserves an unknown encoding as an opaque string")
+  func preservesUnknownEncoding() throws {
+    let rawValue = "application/x-example; profile=custom"
+    let data = try JSONEncoder().encode(rawValue)
+    let encoding = try JSONDecoder().decode(EncodingType.self, from: data)
+
+    #expect(encoding == .other(rawValue))
+    #expect(try JSONDecoder().decode(String.self, from: JSONEncoder().encode(encoding)) == rawValue)
+  }
+
   @Test("generates streaming overloads only for binary outputs")
   func generatesBinaryStreamingMethods() async throws {
     let source = try await generate([

--- a/Tests/SwiftAtprotoLexTests/BinaryResponseStreamingGenerationTests.swift
+++ b/Tests/SwiftAtprotoLexTests/BinaryResponseStreamingGenerationTests.swift
@@ -33,6 +33,66 @@ struct BinaryResponseStreamingGenerationTests {
     #expect(!source.contains("func GetMetadataStreaming("))
   }
 
+  @Test("preserves custom MIME types in clients and streaming server responses")
+  func generatesCustomBinaryServerResponse() async throws {
+    let source = try await generateServer(["getDiff.json": Self.getDiff])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains("typealias ResponseBody = Foundation.Data"))
+    #expect(source.contains("case binary(OpenAPIRuntime.HTTPBody)"))
+    #expect(source.contains("try converter.validateAcceptIfPresent(\"text/x-diff; charset=utf-8\", in: request.headerFields)"))
+    #expect(source.contains("response.headerFields[.contentType] = \"text/x-diff; charset=utf-8\""))
+    #expect(source.contains("guard case .binary(let value) = value.body"))
+    #expect(!source.contains("setResponseBodyAsJSON(value"))
+  }
+
+  @Test("uses the declared MIME type for unknown procedure inputs")
+  func generatesCustomBinaryInput() async throws {
+    let source = try await generateServer(["importDiff.json": Self.importDiff])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains("public static let contentType = \"text/x-diff\""))
+    #expect(source.contains("typealias RequestBody = Foundation.Data"))
+    #expect(source.contains("case binary(HTTPBody)"))
+    #expect(source.contains("options: [\"text/x-diff\"]"))
+  }
+
+  @Test("streams every non-JSON server response body")
+  func generatesNonJSONServerResponses() async throws {
+    let source = try await generateServer([
+      "exportLines.json": Self.exportLines,
+      "exportVideo.json": Self.exportVideo,
+      "getArchive.json": Self.getArchive,
+      "getText.json": Self.getText,
+    ])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.components(separatedBy: "case binary(OpenAPIRuntime.HTTPBody)").count - 1 == 4)
+    #expect(source.components(separatedBy: "guard case .binary(let value) = value.body").count - 1 == 4)
+  }
+
+  @Test("keeps application/json on the structured serializer")
+  func generatesJSONServerResponse() async throws {
+    let source = try await generateServer(["getMetadata.json": Self.getMetadata])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains("case json(ResponseBody)"))
+    #expect(source.contains("try converter.setResponseBodyAsJSON("))
+    #expect(!source.contains("case binary(OpenAPIRuntime.HTTPBody)"))
+  }
+
+  @Test("requires an actual response MIME type for wildcard outputs")
+  func generatesWildcardServerResponse() async throws {
+    let source = try await generateServer(["getBlob.json": Self.getBlob])
+
+    #expect(!Parser.parse(source: source).hasError)
+    #expect(source.contains("case binary(OpenAPIRuntime.HTTPBody, contentType: Swift.String)"))
+    #expect(source.contains("guard case .binary(let value, contentType: let contentType) = value.body"))
+    #expect(source.contains("try converter.validateAcceptIfPresent(contentType, in: request.headerFields)"))
+    #expect(source.contains("response.headerFields[.contentType] = contentType"))
+    #expect(!source.contains("response.headerFields[.contentType] = \"*/*\""))
+  }
+
   private func generate(_ fixtures: [String: String]) async throws -> String {
     let root = FileManager.default.temporaryDirectory
       .appending(path: "swift-atproto-streaming-generation-\(UUID().uuidString)")
@@ -47,6 +107,26 @@ struct BinaryResponseStreamingGenerationTests {
     try await SwiftAtprotoLex.main(
       outdir: output, path: input.path, generate: .client, pluginSource: .command)
     return try String(contentsOf: output.appending(path: "XRPCAPIClient.swift"), encoding: .utf8)
+  }
+
+  private func generateServer(_ fixtures: [String: String]) async throws -> String {
+    let root = FileManager.default.temporaryDirectory
+      .appending(path: "swift-atproto-binary-server-generation-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let input = root.appending(path: "input")
+    let output = root.appending(path: "output")
+    try FileManager.default.createDirectory(at: input, withIntermediateDirectories: true)
+    try FileManager.default.createDirectory(at: output, withIntermediateDirectories: true)
+    for (name, fixture) in fixtures {
+      try Data(fixture.utf8).write(to: input.appending(path: name))
+    }
+    try await SwiftAtprotoLex.main(
+      outdir: output, path: input.path, generate: [.client, .server], pluginSource: .command)
+    return try FileManager.default.contentsOfDirectory(at: output, includingPropertiesForKeys: nil)
+      .filter { $0.pathExtension == "swift" }
+      .sorted { $0.lastPathComponent < $1.lastPathComponent }
+      .map { try String(contentsOf: $0, encoding: .utf8) }
+      .joined(separator: "\n")
   }
 
   private static let getArchive = """
@@ -88,6 +168,79 @@ struct BinaryResponseStreamingGenerationTests {
             "encoding": "application/json",
             "schema": { "type": "object", "properties": {} }
           }
+        }
+      }
+    }
+    """
+
+  private static let getDiff = """
+    {
+      "lexicon": 1,
+      "id": "app.example.getDiff",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": { "type": "params", "properties": {} },
+          "output": { "encoding": "text/x-diff; charset=utf-8" }
+        }
+      }
+    }
+    """
+
+  private static let importDiff = """
+    {
+      "lexicon": 1,
+      "id": "app.example.importDiff",
+      "defs": {
+        "main": {
+          "type": "procedure",
+          "input": { "encoding": "text/x-diff" },
+          "output": {
+            "encoding": "application/json",
+            "schema": { "type": "object", "properties": {} }
+          }
+        }
+      }
+    }
+    """
+
+  private static let exportLines = """
+    {
+      "lexicon": 1,
+      "id": "app.example.exportLines",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": { "type": "params", "properties": {} },
+          "output": { "encoding": "application/jsonl" }
+        }
+      }
+    }
+    """
+
+  private static let getText = """
+    {
+      "lexicon": 1,
+      "id": "app.example.getText",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": { "type": "params", "properties": {} },
+          "output": { "encoding": "text/plain" }
+        }
+      }
+    }
+    """
+
+  private static let getBlob = """
+    {
+      "lexicon": 1,
+      "id": "app.example.getBlob",
+      "defs": {
+        "main": {
+          "type": "query",
+          "parameters": { "type": "params", "properties": {} },
+          "output": { "encoding": "*/*" }
         }
       }
     }


### PR DESCRIPTION
Preserve unrecognized Lexicon input and output encodings as their declared MIME types instead of rejecting them. Generate server responses for every non-JSON output as streaming `OpenAPIRuntime.HTTPBody` values, including explicit response content types for wildcard outputs, while keeping `application/json` on structured serialization.